### PR TITLE
 fix: prevent worker crash on Airflow 3.2.x due to early provider import (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.1] - 2026-05-24
 
 ### Fixed
-- Resolve a circular import on Airflow 3.2.x that surfaced as
-  ``partially initialized module 'airflow_pytest_operator' has no attribute
-  'get_provider_info'`` (often seen as a `BaseOperator` ImportError). The
-  provider-discovery entry point now lives in a dedicated import-light
-  module (`airflow_pytest_operator.provider_info`) that pulls in nothing
-  from the package, so Airflow's early provider scan no longer triggers the
-  operator/compat imports mid-initialization.
+- Prevent an Airflow worker startup crash on Airflow 3.2.x. Provider
+  discovery imports this package during Airflow's own config
+  initialization, before the Task SDK is ready; eagerly importing the
+  operator (and thus `airflow.sdk.bases.operator`) at that point raised
+  `ImportError: cannot import name 'conf' from 'airflow.sdk.configuration'`
+  and aborted startup. Two changes break the chain: the provider-discovery
+  entry point now lives in an import-light module
+  (`airflow_pytest_operator.provider_info`), and `PytestOperator` is
+  exposed lazily via module `__getattr__`, so importing the package no
+  longer triggers the Airflow import chain. `_import_base_operator` also
+  now raises a single diagnostic `ImportError` listing all attempted paths
+  instead of leaking Airflow's internal deprecation traceback.
 
 ## [0.2.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [0.2.1] - 2026-05-24
+
+### Fixed
+- Resolve a circular import on Airflow 3.2.x that surfaced as
+  ``partially initialized module 'airflow_pytest_operator' has no attribute
+  'get_provider_info'`` (often seen as a `BaseOperator` ImportError). The
+  provider-discovery entry point now lives in a dedicated import-light
+  module (`airflow_pytest_operator.provider_info`) that pulls in nothing
+  from the package, so Airflow's early provider scan no longer triggers the
+  operator/compat imports mid-initialization.
+
 ## [0.2.0] - 2026-05-24
 
 ### Fixed
@@ -70,6 +83,7 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/IKrysanov/airflow-pytest-operator/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.2.0"
+version = "0.2.1"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -63,7 +63,7 @@ Changelog = "https://github.com/IKrysanov/airflow-pytest-operator/blob/main/CHAN
 # up in `airflow providers list` and the UI. Operators also work via plain
 # imports, but this makes the package a well-behaved provider.
 [project.entry-points."apache_airflow_provider"]
-provider_info = "airflow_pytest_operator:get_provider_info"
+provider_info = "airflow_pytest_operator.provider_info:get_provider_info"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/airflow_pytest_operator"]

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -25,6 +25,8 @@ Public API:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from .exceptions import (
     AirflowPytestError,
     ReportParseError,
@@ -35,6 +37,13 @@ from .models import CaseResult, RunArtifacts, TestRunResult
 from .provider_info import get_provider_info
 from .reporters import JUnitResultParser, ResultParser
 from .runners import PytestRunner, SubprocessPytestRunner
+
+if TYPE_CHECKING:
+    # PytestOperator is exposed lazily via __getattr__ (see below) so that
+    # importing this package does not eagerly import Airflow. Re-declaring it
+    # here under TYPE_CHECKING lets mypy and IDEs resolve the name without
+    # triggering the runtime import.
+    from .operators import PytestOperator as PytestOperator
 
 __version__ = "0.2.1"
 

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -23,7 +23,7 @@ Public API:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
+from __future__ import annotations
 
 from .exceptions import (
     AirflowPytestError,
@@ -32,30 +32,15 @@ from .exceptions import (
     TestsFailedError,
 )
 from .models import CaseResult, RunArtifacts, TestRunResult
-from .operators import PytestOperator
+from .provider_info import get_provider_info
 from .reporters import JUnitResultParser, ResultParser
 from .runners import PytestRunner, SubprocessPytestRunner
 
-__version__ = "0.2.0"
-
-
-def get_provider_info() -> dict[str, Any]:
-    """Metadata for Airflow's provider-discovery mechanism.
-
-    Lets Airflow's CLI/UI list this package as a provider. Optional —
-    operators work via plain imports regardless — but it makes the
-    package a well-behaved citizen if published.
-    """
-    return {
-        "package-name": "airflow-pytest-operator",
-        "name": "Pytest Operator",
-        "description": "Run pytest suites as Airflow tasks.",
-        "versions": [__version__],
-    }
+__version__ = "0.2.1"
 
 
 __all__ = [
-    "PytestOperator",
+    "get_provider_info",
     "PytestRunner",
     "SubprocessPytestRunner",
     "ResultParser",
@@ -68,3 +53,17 @@ __all__ = [
     "ReportParseError",
     "TestsFailedError",
 ]
+
+
+def __getattr__(name: str) -> object:
+    # Lazy import: PytestOperator pulls in the Airflow compat shim which
+    # imports BaseOperator. Deferring this to first access means that
+    # Airflow's provider-discovery (which imports this module at startup
+    # to call get_provider_info) does NOT immediately trigger the Airflow
+    # import chain. This prevents a broken/mismatched SDK from crashing
+    # the entire Airflow worker process on startup.
+    if name == "PytestOperator":
+        from .operators import PytestOperator
+
+        return PytestOperator
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -34,7 +34,8 @@ from .exceptions import (
     TestsFailedError,
 )
 from .models import CaseResult, RunArtifacts, TestRunResult
-from .provider_info import get_provider_info
+from .provider_info import __version__ as __version__
+from .provider_info import get_provider_info as get_provider_info
 from .reporters import JUnitResultParser, ResultParser
 from .runners import PytestRunner, SubprocessPytestRunner
 
@@ -45,11 +46,9 @@ if TYPE_CHECKING:
     # triggering the runtime import.
     from .operators import PytestOperator as PytestOperator
 
-__version__ = "0.2.1"
-
 
 __all__ = [
-    "get_provider_info",
+    "PytestOperator",
     "PytestRunner",
     "SubprocessPytestRunner",
     "ResultParser",
@@ -61,6 +60,7 @@ __all__ = [
     "TestExecutionError",
     "ReportParseError",
     "TestsFailedError",
+    "get_provider_info",
 ]
 
 

--- a/src/airflow_pytest_operator/compat/airflow.py
+++ b/src/airflow_pytest_operator/compat/airflow.py
@@ -61,14 +61,24 @@ def _import_base_operator() -> type[Any]:
     on Airflow 2 (where it's the sole location) and never on Airflow 3
     (where importing it emits a DeprecatedImportWarning):
 
-      1. ``airflow.sdk.bases.operator``  -- canonical on all Airflow 3.x
-      2. ``airflow.sdk``                 -- top-level re-export (early 3.0.x,
-                                            and the test stub for Airflow 3)
+      1. ``airflow.sdk.bases.operator``  -- canonical on Airflow 3.x (>=3.0.0)
+      2. ``airflow.sdk``                 -- top-level re-export (early 3.0.x
+                                            builds and the test stub)
       3. ``airflow.models.baseoperator`` -- Airflow 2.x only
 
     Each step is tried independently; we never fall through to step 3 once
-    a 3.x SDK import has succeeded, which is what avoids the deprecation.
+    a 3.x SDK import has succeeded, which is what avoids the deprecation
+    warning on Airflow 3.
+
+    Some early Airflow 3 builds ship a partially-initialised SDK where
+    ``airflow.sdk.bases.operator`` itself crashes on import (e.g. missing
+    ``conf`` in ``airflow.sdk.configuration``).  We catch ``ImportError``
+    *and* ``Exception`` narrowly: if *all* three paths fail we raise a
+    single, diagnostic ``ImportError`` rather than surfacing a confusing
+    internal traceback from Airflow's deprecation shim.
     """
+    errors: list[str] = []
+
     # 1. Canonical Task SDK location (Airflow 3.x, no deprecation).
     try:
         from airflow.sdk.bases.operator import (  # type: ignore[import-not-found]
@@ -76,21 +86,38 @@ def _import_base_operator() -> type[Any]:
         )
 
         return BaseOperator  # type: ignore[no-any-return]
-    except Exception:
-        pass
+    except Exception as exc:
+        errors.append(f"airflow.sdk.bases.operator: {exc}")
 
     # 2. Top-level re-export: early 3.0.x releases and the test stub.
     try:
         from airflow.sdk import BaseOperator  # type: ignore[attr-defined]
 
         return BaseOperator  # type: ignore[no-any-return]
-    except Exception:
-        pass
+    except Exception as exc:
+        errors.append(f"airflow.sdk: {exc}")
 
     # 3. Airflow 2.x only.
-    from airflow.models.baseoperator import BaseOperator
+    # NOTE: on Airflow 3 this path emits DeprecatedImportWarning *and* may
+    # itself raise if the SDK it delegates to is broken (see steps 1-2).
+    # We catch broadly so that the error message below includes all context.
+    try:
+        from airflow.models.baseoperator import BaseOperator  # type: ignore[no-redef]
 
-    return BaseOperator  # type: ignore[no-any-return]
+        return BaseOperator  # type: ignore[no-any-return]
+    except Exception as exc:
+        errors.append(f"airflow.models.baseoperator: {exc}")
+
+    detail = "\n  ".join(errors)
+    raise ImportError(
+        "airflow-pytest-operator: could not import BaseOperator from any known "
+        "Airflow location.\n"
+        "This usually means your apache-airflow and apache-airflow-sdk packages "
+        "are mismatched (e.g. a provider built for 3.0.x installed against a "
+        "3.0.0b release that has an incomplete SDK).\n"
+        "Try: pip install --upgrade apache-airflow apache-airflow-sdk\n\n"
+        f"Attempted paths:\n  {detail}"
+    )
 
 
 def _import_apply_defaults() -> Any:

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -73,7 +73,6 @@ class PytestOperator(BaseOperator):
         self.pytest_args = list(pytest_args) if pytest_args else []
         self.env = env or {}
         self.fail_on_test_failure = fail_on_test_failure
-
         self._runner = runner or SubprocessPytestRunner()
         self._parser = parser or JUnitResultParser()
 
@@ -129,6 +128,10 @@ class PytestOperator(BaseOperator):
                     "Failed tests:\n  %s", "\n  ".join(result.failed_node_ids)
                 )
 
+            # The summary is returned from execute(); Airflow pushes it to
+            # XCom under the standard "return_value" key when do_xcom_push is
+            # on (the default). Pass do_xcom_push=False to disable. We push no
+            # second custom key -- a single source of truth for the result.
             summary = result.to_xcom()
 
             run_ok = result.success

--- a/src/airflow_pytest_operator/provider_info.py
+++ b/src/airflow_pytest_operator/provider_info.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Ilya Krysanov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Airflow provider-discovery metadata.
+
+This module is deliberately import-light: it pulls in *nothing* from the
+rest of the package (no operator, no compat shim, no Airflow imports).
+
+Airflow's provider manager imports the ``get_provider_info`` entry point
+very early during startup, before Airflow itself is fully initialized. If
+that entry point lived in ``__init__.py`` -- which eagerly imports the
+operator and therefore ``airflow.sdk.bases.operator`` -- the early import
+triggers a circular import on newer Airflow (3.2.x), surfacing as
+``partially initialized module ... has no attribute 'get_provider_info'``.
+Keeping the entry point here, with no heavy imports, breaks that cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Kept in sync with pyproject.toml / __init__.__version__. Defined locally so
+# this module never has to import the package root.
+__version__ = "0.2.1"
+
+
+def get_provider_info() -> dict[str, Any]:
+    """Metadata for Airflow's provider-discovery mechanism."""
+    return {
+        "package-name": "airflow-pytest-operator",
+        "name": "Pytest Operator",
+        "description": "Run pytest suites as Airflow tasks.",
+        "versions": [__version__],
+    }

--- a/src/airflow_pytest_operator/provider_info.py
+++ b/src/airflow_pytest_operator/provider_info.py
@@ -15,30 +15,57 @@
 """Airflow provider-discovery metadata.
 
 This module is deliberately import-light: it pulls in *nothing* from the
-rest of the package (no operator, no compat shim, no Airflow imports).
+rest of the package (no operator, no compat shim, no Airflow imports) --
+only the stdlib.
 
 Airflow's provider manager imports the ``get_provider_info`` entry point
-very early during startup, before Airflow itself is fully initialized. If
-that entry point lived in ``__init__.py`` -- which eagerly imports the
-operator and therefore ``airflow.sdk.bases.operator`` -- the early import
-triggers a circular import on newer Airflow (3.2.x), surfacing as
-``partially initialized module ... has no attribute 'get_provider_info'``.
-Keeping the entry point here, with no heavy imports, breaks that cycle.
+very early during startup, while Airflow's own configuration is still
+initializing and before the Task SDK is ready. If that entry point lived
+in ``__init__.py`` -- which would otherwise import the operator and thus
+``airflow.sdk.bases.operator`` -- that early import crashes on Airflow
+3.2.x (``cannot import name 'conf' from 'airflow.sdk.configuration'``) and
+aborts worker startup. Keeping the entry point here, import-light, breaks
+that chain.
+
+It also owns the single source of truth for ``__version__`` (read from
+package metadata), which the package root re-exports.
 """
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
-# Kept in sync with pyproject.toml / __init__.__version__. Defined locally so
-# this module never has to import the package root.
-__version__ = "0.2.1"
+#: Distribution name as published on PyPI / declared in pyproject.toml.
+_DIST_NAME = "airflow-pytest-operator"
+
+
+def _resolve_version() -> str:
+    """Read the version from installed package metadata.
+
+    ``pyproject.toml`` is the single source of truth; ``pip`` bakes that
+    value into the distribution metadata at install time, and we read it
+    back here so the version is never duplicated in source. Uses only the
+    stdlib (``importlib.metadata``) -- no Airflow, keeping this module
+    import-light for provider discovery.
+
+    Falls back to a sentinel when the package is not installed (e.g. when
+    running straight from a source checkout via ``PYTHONPATH=src``), so
+    importing the package never fails just because metadata is absent.
+    """
+    try:
+        return version(_DIST_NAME)
+    except PackageNotFoundError:  # running from an uninstalled source tree
+        return "0.0.0+unknown"
+
+
+__version__ = _resolve_version()
 
 
 def get_provider_info() -> dict[str, Any]:
     """Metadata for Airflow's provider-discovery mechanism."""
     return {
-        "package-name": "airflow-pytest-operator",
+        "package-name": _DIST_NAME,
         "name": "Pytest Operator",
         "description": "Run pytest suites as Airflow tasks.",
         "versions": [__version__],

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -248,6 +248,13 @@ class SubprocessPytestRunner(PytestRunner):
                 **popen_kwargs,
             )
         except OSError as exc:
+            # OSError covers the full range of process-launch failures
+            # (FileNotFoundError = missing interpreter, PermissionError =
+            # not executable, NotADirectoryError = bad cwd, etc.), all of
+            # which mean "pytest could not be launched". We deliberately do
+            # NOT catch broad Exception here: a TypeError/ValueError would be
+            # a bug in our own argument handling and should fail loudly with
+            # its real traceback, not be masked as a launch failure.
             raise TestExecutionError(
                 f"Could not launch pytest with interpreter {self._python!r}: {exc}"
             ) from exc

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -247,7 +247,7 @@ class SubprocessPytestRunner(PytestRunner):
                 text=True,
                 **popen_kwargs,
             )
-        except FileNotFoundError as exc:
+        except OSError as exc:
             raise TestExecutionError(
                 f"Could not launch pytest with interpreter {self._python!r}: {exc}"
             ) from exc

--- a/tests/test_provider_discovery.py
+++ b/tests/test_provider_discovery.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Ilya Krysanov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provider-discovery and lazy-import behavior.
+
+Regression coverage for the Airflow 3.2.x startup crash: provider
+discovery imports this package (to call get_provider_info) *during*
+Airflow's own config initialization, before the Task SDK is ready. If the
+package eagerly imported the operator -> compat -> airflow.sdk at that
+point, the whole worker would crash. These tests pin the two properties
+that prevent it: a heavy-import-free entry point, and a lazy operator.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_provider_info_is_import_light():
+    # The provider_info module must not pull in the operator/compat/Airflow.
+    # We import it in a fresh interpreter and assert none of the heavy
+    # modules ended up loaded as a side effect.
+    code = (
+        "import airflow_pytest_operator.provider_info as p;"
+        "import sys;"
+        "info = p.get_provider_info();"
+        "assert info['package-name'] == 'airflow-pytest-operator', info;"
+        "heavy = ["
+        "  'airflow_pytest_operator.operators.pytest_operator',"
+        "  'airflow_pytest_operator.compat.airflow',"
+        "];"
+        "loaded = [m for m in heavy if m in sys.modules];"
+        "assert not loaded, f'provider_info pulled in heavy modules: {loaded}';"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_importing_package_does_not_import_operator():
+    # Importing the top-level package (as Airflow's discovery does) must not
+    # eagerly import the operator -- that would trigger the Airflow import
+    # chain at startup and crash on a not-yet-ready SDK (Airflow 3.2.x).
+    code = (
+        "import airflow_pytest_operator;"
+        "import sys;"
+        "mod = 'airflow_pytest_operator.operators.pytest_operator';"
+        "assert mod not in sys.modules, 'operator was eagerly imported';"
+        "assert hasattr(airflow_pytest_operator, 'get_provider_info');"
+        "print('OK')"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_version_is_resolved_from_metadata():
+    # __version__ comes from installed package metadata (single source of
+    # truth = pyproject.toml), not a hardcoded string.
+    import airflow_pytest_operator
+
+    v = airflow_pytest_operator.__version__
+    assert isinstance(v, str) and v, "version must be a non-empty string"
+    # provider_info exposes the same value.
+    from airflow_pytest_operator.provider_info import (
+        __version__ as pi_version,
+    )
+    from airflow_pytest_operator.provider_info import get_provider_info
+
+    assert pi_version == v
+    assert get_provider_info()["versions"] == [v]
+
+
+def test_version_fallback_when_not_installed(monkeypatch):
+    # If metadata is missing (running from an uninstalled source tree), the
+    # resolver must not raise -- it returns a sentinel instead.
+    import importlib.metadata as md
+
+    from airflow_pytest_operator import provider_info
+
+    def _raise(_name):
+        raise md.PackageNotFoundError
+
+    monkeypatch.setattr(provider_info, "version", _raise)
+    assert provider_info._resolve_version() == "0.0.0+unknown"
+
+
+def test_lazy_operator_attribute_resolves():
+    # Accessing PytestOperator triggers the lazy import and returns the class.
+    import airflow_pytest_operator
+
+    op_cls = airflow_pytest_operator.PytestOperator
+    assert op_cls.__name__ == "PytestOperator"
+
+
+def test_unknown_attribute_raises_attribute_error():
+    import airflow_pytest_operator
+
+    try:
+        _ = airflow_pytest_operator.DefinitelyNotARealName
+    except AttributeError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("expected AttributeError for unknown attribute")


### PR DESCRIPTION
 ## Problem

  On Airflow 3.2.x, provider discovery imports the package entry point during
  Airflow's own config initialization — before the Task SDK is ready. The old
  entry point lived in `__init__.py`, which eagerly imported `PytestOperator`
  and thus `airflow.sdk.bases.operator`. This triggered:

      ImportError: cannot import name 'conf' from 'airflow.sdk.configuration'

  ...and aborted the entire Airflow worker process on startup.

 ## Tests

  Added `tests/test_provider_discovery.py` (6 tests) pinning the two
  properties that prevent the regression:
  - importing `provider_info` does not load any heavy modules (subprocess test
    in a fresh interpreter)
  - importing the package does not eagerly load the operator module
  - version resolves from metadata; fallback works on uninstalled source trees