### PR TITLE
v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,31 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Pytest
-        run: pytest -q
+        # Collect coverage on a single interpreter and upload it; the other
+        # matrix cells just run the suite. --cov-report=xml is what Codecov
+        # consumes.
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.12" ]; then
+            pytest -q --cov=airflow_pytest_operator --cov-report=xml --cov-report=term-missing
+          else
+            pytest -q
+          fi
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          flags: unit
+          # Public repo uses tokenless OIDC upload; no secret required.
+          fail_ci_if_error: false
 
   # ---------------------------------------------------------------------
   # Integration: install a REAL Airflow and confirm the compat shim and
   # operator import and work against the actual BaseOperator. Only valid
   # Python x Airflow pairings are listed (Airflow 3.2 dropped 3.9; we use
-  # widely-deployed pairings here).
+  # widely-deployed pairings here). 3.2.1 is pinned explicitly because it is
+  # where the 0.2.1 provider-discovery startup crash first appeared, so it
+  # guards against a regression of the lazy-import fix.
   # ---------------------------------------------------------------------
   integration:
     name: Integration (Airflow ${{ matrix.airflow }}, py${{ matrix.python-version }})
@@ -79,6 +97,9 @@ jobs:
             python-version: "3.11"
             constraint: "3.11"
           - airflow: "3.0.6"
+            python-version: "3.12"
+            constraint: "3.12"
+          - airflow: "3.2.1"
             python-version: "3.12"
             constraint: "3.12"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,15 @@ jobs:
           fi
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
           flags: unit
-          # Public repo uses tokenless OIDC upload; no secret required.
+          # Pushes to a protected branch (main) require an upload token.
+          # Add it as the CODECOV_TOKEN repository secret (Codecov gives it
+          # to you when you activate the repo on codecov.io). Fork PRs upload
+          # tokenlessly, so a missing secret there is harmless.
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   # ---------------------------------------------------------------------

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR commits
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           # Fetch the full PR range so we can inspect every commit, not just
           # the merge head.
@@ -39,7 +39,7 @@ jobs:
             author="$(git show -s --format='%an <%ae>' "$sha")"
             subject="$(git show -s --format='%s' "$sha")"
             if ! git show -s --format='%B' "$sha" \
-                 | grep -qiE "^Signed-off-by: .+ <.+@.+>"; then
+                 | grep -qiF "Signed-off-by: ${author}"; then
               echo "::error::Commit ${sha} (\"${subject}\") is missing a Signed-off-by line."
               echo "  Author: ${author}"
               missing=1

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,56 @@
+name: DCO
+
+# Verifies that every commit in a pull request carries a
+# `Signed-off-by:` trailer (the Developer Certificate of Origin sign-off).
+# This keeps contribution provenance explicit without requiring a CLA or a
+# third-party GitHub App. Contributors sign off with `git commit -s`; see
+# CONTRIBUTING.md for how to fix commits that are missing the trailer.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco-check:
+    name: Check Signed-off-by on all commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR commits
+        uses: actions/checkout@v4
+        with:
+          # Fetch the full PR range so we can inspect every commit, not just
+          # the merge head.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify sign-off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          # Walk each commit in base..head and require a Signed-off-by line
+          # whose author matches the commit author.
+          for sha in $(git rev-list "${BASE_SHA}..${HEAD_SHA}"); do
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            subject="$(git show -s --format='%s' "$sha")"
+            if ! git show -s --format='%B' "$sha" \
+                 | grep -qiE "^Signed-off-by: .+ <.+@.+>"; then
+              echo "::error::Commit ${sha} (\"${subject}\") is missing a Signed-off-by line."
+              echo "  Author: ${author}"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo ""
+            echo "One or more commits are not signed off. Fix with:"
+            echo "  git rebase --signoff ${BASE_SHA}"
+            echo "  git push --force-with-lease"
+            echo "See CONTRIBUTING.md (Developer Certificate of Origin)."
+            exit 1
+          fi
+          echo "All commits are signed off."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,14 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      # Third-party actions are pinned by commit SHA, not by floating tag.
+      # If an attacker compromises the upstream action and force-pushes its
+      # release branch, a tag-based reference would silently execute the new
+      # code with our PyPI OIDC permissions; a SHA reference cannot. Update
+      # by resolving the new SHA from the upstream release page; the trailing
+      # comment names the version so the diff is human-readable.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install build tooling
@@ -51,7 +57,7 @@ jobs:
             exit 1
           fi
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: dist
           path: dist/
@@ -71,10 +77,15 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # PEP 740 Sigstore attestations are produced by default since
+        # pypa/gh-action-pypi-publish v1.10 (opt-in) / v1.11 (default on)
+        # for any project using Trusted Publishing, so the artifacts on
+        # PyPI ship with a verifiable link back to this workflow, repo,
+        # and commit. See README for end-user verification instructions.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         # No `with:` block needed -- Trusted Publishing authenticates via OIDC.

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,74 @@
+name: Scorecard supply-chain security
+
+# Runs the OpenSSF Scorecard (https://securityscorecards.dev/) against this
+# repository to produce a numeric supply-chain security score and publish
+# SARIF findings to the Security tab.
+#
+# Triggers:
+#   - schedule: weekly, so the score and findings stay current even when
+#     development is quiet.
+#   - push to main: refreshes the score after every merge so a regression
+#     (e.g. an action getting unpinned) shows up immediately.
+#
+# Scope: read-only analysis. The publish_results step uses the GITHUB_TOKEN
+# via OIDC (id-token: write) to sign the result so consumers can verify it
+# came from this workflow, not a hand-edited upload.
+
+on:
+  schedule:
+    - cron: "30 5 * * 1"   # Monday 05:30 UTC -- before most maintainer days
+  push:
+    branches: [main]
+
+# `read-all` at the workflow level keeps the default token narrow; the job
+# below widens only the specific permissions it actually needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed for SARIF upload to the GitHub Code Scanning dashboard.
+      security-events: write
+      # Needed by publish_results to sign the result with the workflow's
+      # OIDC token (Sigstore-style attestation that the score is genuine).
+      id-token: write
+      # Needed so Scorecard can read repository metadata (branches, etc).
+      contents: read
+      actions: read
+
+    steps:
+      # SHA-pinned for the same reason as release.yml / testpypi.yml: a
+      # compromised upstream action could otherwise silently substitute new
+      # code into a workflow that holds an OIDC token.
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes the result to the OpenSSF Scorecard API so the badge
+          # on README and the public viewer at https://scorecard.dev show
+          # the live score. This requires id-token: write above.
+          publish_results: true
+
+      # Keep the raw SARIF for 5 days so it's easy to inspect a regression
+      # without scrolling through the Code Scanning dashboard.
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      # Push the findings into the repository's Security tab. Each Scorecard
+      # check becomes a Code Scanning alert that can be reviewed and dismissed.
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57  # v3.36.0
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/testpypi.yml
+++ b/.github/workflows/testpypi.yml
@@ -25,8 +25,12 @@ jobs:
     name: Build distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      # Third-party actions are SHA-pinned for the same reason as release.yml:
+      # the OIDC token issued here is valid against TestPyPI and a compromised
+      # action could publish under our identity. Keep this in sync with
+      # release.yml when bumping.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install build tooling
@@ -38,7 +42,7 @@ jobs:
       - name: Check distribution metadata
         run: twine check dist/*
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: dist-testpypi
           path: dist/
@@ -54,11 +58,11 @@ jobs:
       id-token: write
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: dist-testpypi
           path: dist/
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `# pragma: no cover`; they cannot execute on the Linux CI runners and are
   excluded from the coverage measurement rather than left as phantom gaps.
 
+### Security
+- Release and TestPyPI workflows now pin every third-party GitHub Action by
+  immutable commit SHA (with a trailing comment naming the version) rather
+  than by floating tag, so a compromise of an upstream action repository
+  cannot silently substitute new code into the workflow that holds our
+  PyPI OIDC token.
+- Release artifacts ship with [PEP 740](https://peps.python.org/pep-0740/)
+  Sigstore attestations, produced automatically by
+  `pypa/gh-action-pypi-publish` v1.10+ for any Trusted-Publishing release.
+  PyPI verifies them at upload and surfaces the source repository in the
+  release's *Verified details*. README documents how end users can verify
+  individual artifacts against this repository with `pypi-attestations`.
+
 ### Contributor experience
 - `CONTRIBUTING.md` now documents the license header to copy into new files,
   the project's GitHub Flow branching model (PRs target `main`; there is no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-26
+
+### Added
+- Coverage measurement wired into the project: `pytest-cov` is now a dev
+  dependency and `[tool.coverage]` configuration lives in `pyproject.toml`
+  (branch coverage on, `airflow_pytest_operator` as the source). Coverage is
+  opt-in via `pytest --cov=airflow_pytest_operator` so the integration CI
+  job, which installs a bare pytest, is unaffected.
+- Codecov integration in CI: the unit job uploads a coverage report
+  (`coverage.xml`) on Python 3.12 via `codecov/codecov-action`, and the
+  README now carries a coverage badge.
+- The CI integration matrix now also runs against Airflow 3.2.1 (py3.12),
+  the release where the 0.2.1 provider-discovery startup crash first
+  appeared, guarding the lazy-import fix against regression.
+- Substantial test additions bringing measured coverage to ~99.5% on the
+  test stub and on real Airflow 2.10.3, 3.0.6, and 3.2.1. The single
+  uncovered line is a `run()`/`cancel()` race-guard with no deterministic
+  test, left uncovered by design rather than chased with a flaky timing
+  test (a `fail_under = 85` gate guards against real regressions):
+  - `tests/test_models.py` — node-id reconstruction (with and without a
+    classname), `success`/`failed_node_ids` derivation, and the XCom
+    projection that drops per-case detail.
+  - `tests/test_base_interfaces.py` — the abstract `PytestRunner`/
+    `ResultParser` defaults (no-op `cancel`/`cleanup`, abstract-method
+    contracts), proving Liskov-substitutability of minimal implementations.
+  - `tests/test_compat.py` — every `BaseOperator` resolution branch of the
+    compatibility shim, driven deterministically by injecting fake modules
+    into `sys.modules`, plus `get_airflow_version` parsing and the
+    `apply_defaults` passthrough.
+  - Operator logging of child stdout/stderr and failed node ids, asserted
+    by spying on the logger's methods rather than `caplog` (robust across
+    Airflow versions, which route task logging differently).
+  - `SubprocessPytestRunner` edge paths: `_terminate` when the process is
+    already dead or disappears mid-signal (`ProcessLookupError` on SIGTERM
+    and SIGKILL) and the cleanup race-guard that prevents a double `rmtree`.
+  - A malformed `time` attribute in a JUnit report now has an explicit test
+    confirming it degrades to `0.0` rather than failing the parse.
+
+### Changed
+- OS-specific Windows-only branches in `SubprocessPytestRunner` are marked
+  `# pragma: no cover`; they cannot execute on the Linux CI runners and are
+  excluded from the coverage measurement rather than left as phantom gaps.
+
 ## [0.2.1] - 2026-05-24
 
 ### Fixed
@@ -88,7 +131,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/IKrysanov/airflow-pytest-operator/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     confirming it degrades to `0.0` rather than failing the parse.
 
 ### Changed
+- License headers on all source files now use a collective copyright
+  ("the airflow-pytest-operator contributors") instead of an individual
+  name, so contributors never have to edit copyright lines per file. A
+  `NOTICE` file records project-level authorship, and each contributor
+  retains copyright over their own contributions.
 - OS-specific Windows-only branches in `SubprocessPytestRunner` are marked
   `# pragma: no cover`; they cannot execute on the Linux CI runners and are
   excluded from the coverage measurement rather than left as phantom gaps.
+
+### Contributor experience
+- `CONTRIBUTING.md` now documents the license header to copy into new files,
+  the project's GitHub Flow branching model (PRs target `main`; there is no
+  `develop` branch), a Developer Certificate of Origin (DCO) sign-off
+  workflow, and a maintainer review/merge checklist.
+- Added a `DCO` GitHub Actions workflow that verifies every pull-request
+  commit carries a `Signed-off-by` trailer.
 
 ## [0.2.1] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-05-26
+## [0.3.0] - 2026-05-30
 
 ### Added
 - Coverage measurement wired into the project: `pytest-cov` is now a dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   excluded from the coverage measurement rather than left as phantom gaps.
 
 ### Security
+- A `SECURITY.md` security policy documents supported versions, the
+  preferred reporting channel (GitHub Private Vulnerability Reporting),
+  response-time expectations (acknowledgement within 72 hours, initial
+  assessment within 7 days, 90-day coordinated disclosure), out-of-scope
+  cases, and hardening recommendations for users (including the
+  `[secure-xml]` extra and how to verify release attestations). Closes the
+  Security-Policy criterion in supply-chain audits such as OpenSSF
+  Scorecard.
+- A weekly OpenSSF Scorecard analysis (`.github/workflows/scorecard.yml`)
+  scans the repository for supply-chain best practices and publishes its
+  result as a signed SARIF report to the GitHub Security tab and to the
+  public Scorecard API. The score badge is linked from the README so
+  consumers can see the project's supply-chain posture at a glance.
 - Release and TestPyPI workflows now pin every third-party GitHub Action by
   immutable commit SHA (with a trailing comment naming the version) rather
   than by floating tag, so a compromise of an upstream action repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,4 +161,4 @@ fixup commits. Either way, the resulting commit on `main` must keep a
 
 By contributing, you agree that your contributions are licensed under the
 Apache License 2.0, and that you hold copyright over your own contributions
-as one of the project's contributors (see `NOTICE`).
+as one of the project's contributors (see [NOTICE](NOTICE)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,67 @@ This project follows SOLID deliberately; please keep new code consistent with it
 - **Domain models stay framework-free.** `models.py` must not import Airflow, pytest, or subprocess.
 - **Teardown must never raise.** `on_kill`, `cancel`, and `cleanup` run during termination; swallow and log their errors.
 
+## License headers on new files
+
+Every source file carries the project's Apache-2.0 header. The copyright
+line is **deliberately impersonal** — it names the project's contributors
+collectively, not any individual. When you add a new file, copy this header
+verbatim; do **not** put your own name in it. Your authorship is recorded by
+your commit's `Signed-off-by` line and the Git history, which is exactly what
+makes per-file name-juggling unnecessary.
+
+```python
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+```
+
+In Python files this goes **below** the module docstring (so the docstring
+stays the first statement), as in the existing modules. You keep copyright
+over your own contributions — see `NOTICE`; the collective header simply
+spares everyone from editing names file by file.
+
 ## Tests
 
 - Add tests for any behaviour change; bug fixes should come with a regression test.
 - Prefer testing the operator with injected fakes (see `tests/test_operator.py`) over spinning up Airflow.
 - Runner tests use real child processes (see `tests/test_subprocess_runner.py`); keep them fast and deterministic.
 - New public exceptions should follow the `...Error` naming convention.
+
+## Branching and pull requests
+
+This project uses **GitHub Flow**: `main` is the only long-lived branch
+and is always in a releasable state. Releases are tags (`vX.Y.Z`) on
+specific `main` commits; there is no `develop` branch.
+
+Concretely, to contribute a change:
+
+1. **Fork** the repository on GitHub.
+2. **Create a topic branch from `main`** in your fork. Name it after the
+   change, e.g. `feat/docker-runner`, `fix/temp-dir-leak`, `docs/readme`.
+   Don't work on your fork's `main` directly — keep it clean so you can
+   rebase easily.
+3. **Open a pull request into `IKrysanov/airflow-pytest-operator:main`**.
+   Draft PRs are welcome for early feedback.
+4. **Rebase, don't merge `main`** if `main` moves while your PR is open:
+   `git fetch upstream && git rebase upstream/main`, then
+   `git push --force-with-lease`. This keeps history linear and CI clean.
+5. Keep the PR **focused on one concern** — smaller PRs review faster and
+   are easier to revert if needed.
+
+Direct pushes to `main` are reserved for maintainers and for release tags.
+Unreleased work accumulates under the `[Unreleased]` section of
+`CHANGELOG.md` until a release is cut.
 
 ## Commit messages and PRs
 
@@ -51,14 +106,59 @@ This project follows SOLID deliberately; please keep new code consistent with it
 
 ## Developer Certificate of Origin (DCO)
 
-By contributing, you certify that you wrote the code or otherwise have the right to submit it under the project's Apache-2.0 license (see the [DCO](https://developercertificate.org/)). Sign off your commits:
+This project tracks contribution provenance with the
+[DCO](https://developercertificate.org/) rather than a CLA. By signing off a
+commit you certify that you wrote the code, or otherwise have the right to
+submit it under the project's Apache-2.0 license. Sign off every commit:
 
 ```bash
 git commit -s -m "Your message"
 ```
 
-This adds a `Signed-off-by` line and is required for any future inclusion in the Apache Airflow ecosystem.
+This appends a `Signed-off-by: Your Name <you@example.com>` line using your
+configured `git` identity. If you forgot to sign off, fix it before pushing:
+
+```bash
+git commit --amend -s --no-edit          # last commit
+git rebase --signoff main                # a whole branch of commits
+```
+
+The sign-off is checked automatically on every pull request by the project's
+`DCO` workflow (`.github/workflows/dco.yml`), which blocks merge until all
+commits are signed. This keeps a clear, lightweight record that each
+contribution was submitted deliberately and lawfully — which protects both
+you and the project.
+
+## Reviewing and merging (for maintainers)
+
+A pull request is ready to approve when:
+
+1. **Targets `main`** — this project uses GitHub Flow; PRs to any other base
+   branch should be retargeted before review.
+2. **CI is green** — lint, type-check, the unit matrix, and all three
+   integration jobs (Airflow 2.10.3, 3.0.6, 3.2.1) pass.
+3. **DCO check passes** — every commit is signed off. If not, ask the
+   contributor to amend/rebase with `--signoff`; do not merge unsigned
+   commits.
+4. **Coverage holds** — the `fail_under` gate is satisfied and Codecov does
+   not report a meaningful drop. New behaviour comes with new tests.
+5. **License header present** on any new file, using the collective header
+   above (no individual names).
+6. **Design principles respected** — especially: the operator stays thin,
+   new behaviour arrives as new `PytestRunner`/`ResultParser` subclasses
+   rather than branches in existing classes, and only `compat/airflow.py`
+   imports Airflow.
+7. **Docs updated** — `README.md` and `CHANGELOG.md` reflect any
+   behaviour or public-API change.
+
+Use **rebase-merge** when the PR is already a clean series of well-scoped
+commits (each signed off, each green if you imagine CI on it); use
+**squash-merge** when the PR is a single concern spread across many small
+fixup commits. Either way, the resulting commit on `main` must keep a
+`Signed-off-by` trailer. Tag a release only from a green `main`.
 
 ## License
 
-By contributing, you agree that your contributions are licensed under the Apache License 2.0.
+By contributing, you agree that your contributions are licensed under the
+Apache License 2.0, and that you hold copyright over your own contributions
+as one of the project's contributors (see `NOTICE`).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,16 @@
+airflow-pytest-operator
+Copyright 2026 the airflow-pytest-operator contributors
+
+This product was created and is maintained by Ilya Krysanov
+and the project's contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Each contributor holds copyright over their contributions. The project
+as a whole is licensed under the terms above; see the LICENSE file for
+the full text. The list of contributors is recorded in the project's
+Git history and in the Signed-off-by lines of its commits.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,43 @@ RUN pip install --no-cache-dir "airflow-pytest-operator" \
 
 The package itself pins nothing (`dependencies = []`), so any resolution conflict comes from your wider environment; the constraint file is the standard way to keep it reproducible.
 
+## Verifying the release
+
+Each PyPI release is published from GitHub Actions via PyPI's
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) and ships
+with a [PEP 740](https://peps.python.org/pep-0740/) **Sigstore attestation**
+that cryptographically binds every wheel and sdist to a specific commit and
+workflow in this repository. PyPI verifies the attestation at upload time
+and shows the source repository in the release's *Verified details*. You can
+also verify it yourself before installing, which protects against tampering
+between PyPI and your machine.
+
+PyPI itself verifies the attestation at upload time and surfaces the link
+back to this repository in the release's *Verified details*, so the common
+case (`pip install airflow-pytest-operator`) already gives you that
+assurance through PyPI. To verify a specific artifact yourself before
+installing, use the [`pypi-attestations`](https://pypi.org/project/pypi-attestations/) CLI:
+
+```bash
+pip install pypi-attestations
+# Replace the filename with the wheel or sdist you want to verify; the
+# `pypi:` prefix tells the tool to fetch the artifact + provenance from PyPI.
+pypi-attestations verify pypi \
+    --repository https://github.com/IKrysanov/airflow-pytest-operator \
+    pypi:airflow_pytest_operator-0.3.0-py3-none-any.whl
+```
+
+A successful exit confirms three things at once: the file came from this
+GitHub repository, it was produced by `release.yml` (the only configured
+Trusted Publisher), and it has not been modified since publication. A
+failure means **do not install** — either the file is tampered with, or it
+was published through a path that bypasses our release workflow.
+
+> The `pypi-attestations` CLI is explicitly an experimentation interface
+> per its own documentation; PyPI considers the upload-time check the
+> primary trust path and expects future tooling (including `pip` itself) to
+> stabilise verification ergonomics.
+
 ## Usage
 
 ```python

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 [![PyPI version](https://img.shields.io/pypi/v/airflow-pytest-operator.svg)](https://pypi.org/project/airflow-pytest-operator/)
 [![Python versions](https://img.shields.io/pypi/pyversions/airflow-pytest-operator.svg)](https://pypi.org/project/airflow-pytest-operator/)
 [![CI](https://github.com/IKrysanov/airflow-pytest-operator/actions/workflows/ci.yml/badge.svg)](https://github.com/IKrysanov/airflow-pytest-operator/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/IKrysanov/airflow-pytest-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/IKrysanov/airflow-pytest-operator)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Why a child process

--- a/README.md
+++ b/README.md
@@ -5,10 +5,18 @@ Run a `pytest` suite as an Airflow task. The operator executes your tests in a c
 Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated in a single compatibility module, so one wheel supports both.
 
 [![PyPI version](https://img.shields.io/pypi/v/airflow-pytest-operator.svg)](https://pypi.org/project/airflow-pytest-operator/)
+[![Airflow](https://img.shields.io/badge/Airflow-2.10%20%7C%203.0%20%7C%203.2-017CEE.svg?logo=apacheairflow)](https://airflow.apache.org/)
 [![Python versions](https://img.shields.io/pypi/pyversions/airflow-pytest-operator.svg)](https://pypi.org/project/airflow-pytest-operator/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+<details open>
+<summary>Quality &amp; build status</summary>
+
 [![CI](https://github.com/IKrysanov/airflow-pytest-operator/actions/workflows/ci.yml/badge.svg)](https://github.com/IKrysanov/airflow-pytest-operator/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/IKrysanov/airflow-pytest-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/IKrysanov/airflow-pytest-operator)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+</details>
 
 ## Why a child process
 
@@ -106,6 +114,15 @@ The summary pushed to XCom (standard `return_value` key) looks like:
 ```
 
 ## Constructor options
+
+`PytestOperator` accepts the parameters below **plus every parameter that
+[`BaseOperator`](https://airflow.apache.org/docs/apache-airflow/2.3.4/_api/airflow/models/baseoperator/index.html)
+accepts** — `task_id`, `retries`, `execution_timeout`, `on_failure_callback`,
+`trigger_rule`, `pool`, and so on. Airflow 3 users: `BaseOperator` moved to
+`airflow.sdk`; the canonical reference is the
+[Task SDK API docs](https://airflow.apache.org/docs/task-sdk/stable/api.html).
+
+The parameters specific to `PytestOperator` are:
 
 | Option | Default | Description |
 |---|---|---|
@@ -206,7 +223,7 @@ The library's own tests run **without Airflow** by stubbing `BaseOperator` — i
 pip install -e ".[dev]"
 ruff check src tests
 mypy
-pytest
+pytest --cov
 ```
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,109 @@
+# Security Policy
+
+We take the security of `airflow-pytest-operator` seriously. This document
+describes how to report vulnerabilities, which versions receive security
+fixes, and the timelines you can expect.
+
+## Supported versions
+
+Security fixes are released only for the **current minor version**.
+The project is pre-1.0; users on older minors are expected to upgrade to
+the latest release to receive security fixes.
+
+| Version | Status |
+|---------|--------|
+| 0.3.x   | ✅ Supported |
+| < 0.3   | ❌ Not supported — please upgrade |
+
+Once 1.0 is released this policy will be reviewed and tightened. For now,
+treat any pre-1.0 release older than the latest minor as end-of-life from a
+security standpoint.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub
+issues, discussions, or pull requests.** Public reports give attackers a
+window between disclosure and a fix landing in users' deployments.
+
+Use **GitHub's Private Vulnerability Reporting** instead. From the
+[Security tab of this repository](https://github.com/IKrysanov/airflow-pytest-operator/security)
+click **"Report a vulnerability"**. This opens a private advisory visible
+only to you and the maintainer; GitHub handles the notifications and
+provides a workspace for coordinating the fix.
+
+If for some reason you cannot use Private Vulnerability Reporting (for
+example, you do not have a GitHub account and creating one is not an
+option), you may open a regular GitHub issue containing **only** the words
+*"please contact me about a security matter"* and your preferred contact
+method — no technical details. The maintainer will reach out privately to
+continue the conversation off-issue.
+
+### What to include in a report
+
+A good report contains, where applicable:
+
+- A short summary of the issue and the impact you believe it has.
+- Affected version(s) of `airflow-pytest-operator`.
+- Affected Airflow version(s) and Python version(s), if relevant.
+- Steps to reproduce, or a minimal proof of concept.
+- Any suggested mitigation or fix, if you have one.
+
+You do not need a CVE assigned to file a report — the maintainer will
+request one if the issue warrants it.
+
+## What to expect after reporting
+
+- **Acknowledgement: within 72 hours** of receiving the report.
+- **Initial assessment: within 7 days**, including whether the issue is
+  confirmed, its preliminary severity, and rough remediation timeline.
+- **Coordinated disclosure: 90 days** from initial report, extendable by
+  mutual agreement if a fix requires more time. After 90 days, or after a
+  fix is released (whichever is sooner), the advisory may be made public.
+- **Credit:** reporters are credited in the GitHub Security Advisory and
+  in `CHANGELOG.md` unless they prefer to remain anonymous.
+
+These timelines reflect a single-maintainer project and are honest rather
+than aspirational. If a report sits unacknowledged past 72 hours, treat
+that as an outage — feel free to re-ping via the same channel.
+
+## Out of scope
+
+The following are **not** considered security issues by this project:
+
+- Behaviour of pytest, test code, or third-party plugins invoked by the
+  operator. Running arbitrary pytest code is the operator's purpose; the
+  security boundary is whoever can write DAGs and place tests on a worker.
+- Misconfiguration of the surrounding Airflow deployment (permissive
+  Connections, weak worker isolation, lack of network segmentation).
+- Vulnerabilities that require write access to the DAGs folder or the
+  worker filesystem — those imply a compromised Airflow environment, which
+  has its own security model.
+
+If you are unsure whether something is in scope, **file a report anyway** —
+we would rather review and close than miss a real issue.
+
+## Hardening recommendations for users
+
+A few things you can do today, in your own environment, to reduce risk:
+
+- **Install with the hardened XML extra** when parsing JUnit reports from
+  sources you do not fully trust:
+  ```bash
+  pip install "airflow-pytest-operator[secure-xml]"
+  ```
+  This pulls in `defusedxml` and routes the report parser through it,
+  closing the standard XML attack classes (entity expansion, external
+  entities, recursive expansion).
+- **Verify release artifacts** before installing in sensitive environments;
+  every release ships with [PEP 740](https://peps.python.org/pep-0740/)
+  Sigstore attestations bound to this repository and workflow. See the
+  *Verifying the release* section of the README for the exact commands.
+- **Restrict who can write DAGs and tests** in your Airflow deployment to
+  the same trust level as who can deploy production code — the operator
+  executes whatever pytest is pointed at, so the trust boundary is the DAG
+  author, not the operator itself.
+
+## Acknowledgements
+
+Reporters who have responsibly disclosed security issues will be listed
+here. None to date.

--- a/examples/example_dag.py
+++ b/examples/example_dag.py
@@ -1,6 +1,6 @@
 """Example DAG: run a smoke suite, then a fuller suite that only reports."""
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/example_dag.py
+++ b/examples/example_dag.py
@@ -17,16 +17,21 @@
 from __future__ import annotations
 
 import pendulum
+from datetime import timedelta
 
 from airflow import DAG
 from airflow_pytest_operator import PytestOperator
 
+# Use additional features like custom runners and parsers by importing them directly.
+from airflow_pytest_operator.runners import SubprocessPytestRunner
+from airflow_pytest_operator.reporters import JUnitResultParser
+
 with DAG(
     dag_id="pytest_example",
     start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
-    schedule=None,
+    schedule="30 9 * * *",
     catchup=False,
-    tags=["testing"],
+    tags=["testing", "demo"],
 ) as dag:
     # Hard gate: fail the pipeline if smoke tests fail.
     smoke = PytestOperator(
@@ -34,14 +39,21 @@ with DAG(
         test_path="/opt/airflow/tests",
         pytest_args=["-k", "smoke", "-x", "-q"],
         fail_on_test_failure=True,
+        do_xcom_push=False,
     )
 
     # Soft run: never fails the task, just records results in XCom.
     full = PytestOperator(
         task_id="full_report_only",
         test_path="/opt/airflow/tests",
-        pytest_args=["-q"],
+        pytest_args=["-v", "-s", "--cache-clear"],
         fail_on_test_failure=False,
+        env={"EXAMPLE_ENV_VAR": "example_value"},
+        # You can use any runner that implements the expected interface; the default is SubprocessPytestRunner.
+        runner=SubprocessPytestRunner(timeout=1800, cleanup="on_success"),
+        # You can use any parser that implements the expected interface; the default is JUnitResultParser.
+        parser=JUnitResultParser(),
+        do_xcom_push=True,  # This is the default, but being explicit for clarity.
     )
 
     smoke >> full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.2.1"
+version = "0.3.0"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -48,6 +48,7 @@ secure-xml = ["defusedxml>=0.7"]
 # Everything needed to develop and run the test/lint/type-check suite.
 dev = [
     "pytest>=7.0",
+    "pytest-cov>=4.0",
     "defusedxml>=0.7",
     "mypy>=1.8",
     "ruff>=0.4",
@@ -75,6 +76,32 @@ include = ["src", "tests", "examples", "README.md", "LICENSE", "CHANGELOG.md", "
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+# ---------------------------------------------------------------------------
+# Coverage. Not wired into pytest addopts by default: the integration CI job
+# installs a bare pytest (no pytest-cov), so coverage is opted into explicitly
+# with `pytest --cov=airflow_pytest_operator` where the plugin is present.
+# ---------------------------------------------------------------------------
+[tool.coverage.run]
+branch = true
+source = ["airflow_pytest_operator"]
+
+[tool.coverage.report]
+# Fail the measurement if it regresses below this. The suite sits at ~99.5%
+# on the stub; the single remaining uncovered line is a run()/cancel()
+# race-guard with no deterministic test (see subprocess_runner.run), left
+# uncovered by design. The threshold catches a real regression without
+# forcing a flaky timing test to chase the last line.
+fail_under = 85
+precision = 1
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    # Abstract method bodies are contracts, never executed directly.
+    "raise NotImplementedError",
+    # Defensive re-raises and type-checking-only blocks.
+    "if TYPE_CHECKING:",
+]
 
 # ---------------------------------------------------------------------------
 # Ruff: linter + formatter. Fast, single-tool replacement for flake8/isort.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Run pytest suites as Airflow tasks, with structured results in XC
 readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"
-license-files = ["LICENSE"]
+license-files = ["LICENSE", "NOTICE"]
 authors = [{ name = "Ilya Krysanov" }]
 keywords = ["airflow", "pytest", "operator", "testing", "ci", "provider"]
 
@@ -71,7 +71,7 @@ packages = ["src/airflow_pytest_operator"]
 
 [tool.hatch.build.targets.sdist]
 # Ship tests and examples in the source distribution for downstream auditing.
-include = ["src", "tests", "examples", "README.md", "LICENSE", "CHANGELOG.md", "CONTRIBUTING.md"]
+include = ["src", "tests", "examples", "README.md", "LICENSE", "NOTICE", "CHANGELOG.md", "CONTRIBUTING.md"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -9,7 +9,7 @@ Public API:
     TestRunResult          — structured result model
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/compat/__init__.py
+++ b/src/airflow_pytest_operator/compat/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/compat/airflow.py
+++ b/src/airflow_pytest_operator/compat/airflow.py
@@ -9,7 +9,7 @@ Airflow 2.x and 3.x differ in the import path of ``BaseOperator`` and a
 few helpers. We resolve them once, lazily, and expose a stable surface.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/compat/airflow.py
+++ b/src/airflow_pytest_operator/compat/airflow.py
@@ -25,6 +25,7 @@ few helpers. We resolve them once, lazily, and expose a stable surface.
 
 from __future__ import annotations
 
+import re
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -48,8 +49,8 @@ def get_airflow_version() -> tuple[int, ...]:
         return (0,)
     parts: list[int] = []
     for chunk in _v.split(".")[:3]:
-        num = "".join(ch for ch in chunk if ch.isdigit())
-        parts.append(int(num) if num else 0)
+        m = re.match(r"\d+", chunk)
+        parts.append(int(m.group(0)) if m else 0)
     return tuple(parts)
 
 

--- a/src/airflow_pytest_operator/exceptions.py
+++ b/src/airflow_pytest_operator/exceptions.py
@@ -6,7 +6,7 @@ distinction matters: a failing test usually shouldn't be retried,
 but a missing pytest binary or unreadable report might be.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/models.py
+++ b/src/airflow_pytest_operator/models.py
@@ -5,7 +5,7 @@ Airflow, pytest, or subprocess — keeping the domain layer dependency-free
 makes it trivial to unit-test parsers and the operator in isolation (DIP).
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/operators/__init__.py
+++ b/src/airflow_pytest_operator/operators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -10,7 +10,7 @@ use in DAGs, but tests can pass fakes, and advanced users can swap in a
 Docker/K8s runner or a JSON parser without subclassing.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/provider_info.py
+++ b/src/airflow_pytest_operator/provider_info.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/reporters/__init__.py
+++ b/src/airflow_pytest_operator/reporters/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/reporters/base.py
+++ b/src/airflow_pytest_operator/reporters/base.py
@@ -6,7 +6,7 @@ the runner means we can support other report formats (e.g. a JSON
 report plugin) by adding a parser, not by editing existing code (OCP).
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -17,7 +17,7 @@ JUnit structure recap (pytest dialect)::
     </testsuites>
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/runners/__init__.py
+++ b/src/airflow_pytest_operator/runners/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/runners/base.py
+++ b/src/airflow_pytest_operator/runners/base.py
@@ -8,7 +8,7 @@ That single responsibility is what makes runners interchangeable
 in later without changing the operator.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import signal
@@ -29,6 +30,7 @@ from ..models import RunArtifacts
 from .base import PytestRunner
 
 _IS_WINDOWS = os.name == "nt"
+_log = logging.getLogger(__name__)
 
 
 class SubprocessPytestRunner(PytestRunner):
@@ -280,7 +282,12 @@ class SubprocessPytestRunner(PytestRunner):
             # Timeout is an execution failure, but we still must not leave
             # the tree running -- reuse the same group-kill path.
             self._terminate(proc)
-            proc.communicate()
+
+            tail_stdout, tail_stderr = proc.communicate()
+            if tail_stdout:
+                _log.warning("pytest stdout captured before timeout:\n%s", tail_stdout)
+            if tail_stderr:
+                _log.warning("pytest stderr captured before timeout:\n%s", tail_stderr)
             raise TestExecutionError(
                 f"pytest run timed out after {self._timeout}s"
             ) from exc

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -232,7 +232,7 @@ class SubprocessPytestRunner(PytestRunner):
         # Detach into a new process group/session so cancel() can reach
         # the whole tree. On POSIX, start_new_session=True calls setsid().
         popen_kwargs: dict[str, Any] = {}
-        if _IS_WINDOWS:
+        if _IS_WINDOWS:  # pragma: no cover - Windows-only; CI runs on Linux
             popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
         else:
             popen_kwargs["start_new_session"] = True
@@ -262,6 +262,12 @@ class SubprocessPytestRunner(PytestRunner):
         with self._lock:
             # If cancel() landed before the process was registered, honour
             # it immediately rather than letting an orphan run to completion.
+            # This only triggers when cancel() runs from another thread in the
+            # tiny window between run()'s stale-flag reset and this check, so
+            # it is a genuine race-guard with no deterministic unit test; it is
+            # left uncovered by design rather than asserted via a flaky timing
+            # test. (Pre-`run()` cancel is intentionally treated as stale and
+            # reset -- see test_stale_cancel_does_not_abort_next_run.)
             self._proc = proc
             cancelled_early = self._cancelled
         if cancelled_early:
@@ -369,7 +375,7 @@ class SubprocessPytestRunner(PytestRunner):
     @staticmethod
     def _signal_group(proc: subprocess.Popen[str], sig: int) -> None:
         """Send a signal to the child's entire process group."""
-        if _IS_WINDOWS:
+        if _IS_WINDOWS:  # pragma: no cover - Windows-only; CI runs on Linux
             # No POSIX process groups; CREATE_NEW_PROCESS_GROUP lets us
             # send CTRL_BREAK, and as a fallback we kill the child.
             if sig == signal.SIGKILL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ suite fast and dependency-light while remaining faithful to the real
 operator contract (it only relies on ``self.log`` and ``task_id``).
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_base_interfaces.py
+++ b/tests/test_base_interfaces.py
@@ -1,0 +1,85 @@
+"""Tests for the abstract Runner/Parser interface defaults.
+
+The base classes provide default no-op ``cancel``/``cleanup`` so that
+simple runners stay Liskov-substitutable without reimplementing them,
+and the abstract ``run``/``parse`` bodies raise ``NotImplementedError``
+as an explicit contract marker. We exercise those defaults directly
+through a minimal concrete subclass.
+"""
+
+# Copyright 2026 Ilya Krysanov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from airflow_pytest_operator.models import RunArtifacts, TestRunResult
+from airflow_pytest_operator.reporters.base import ResultParser
+from airflow_pytest_operator.runners.base import PytestRunner
+
+
+class _MinimalRunner(PytestRunner):
+    """Implements only the abstract ``run``; inherits default cancel/cleanup."""
+
+    def run(self, test_path, *, pytest_args=None, env=None):
+        return RunArtifacts(exit_code=0, junit_xml_path=None)
+
+
+class _MinimalParser(ResultParser):
+    def parse(self, report_path, *, exit_code=0):
+        return TestRunResult(
+            total=0,
+            passed=0,
+            failed=0,
+            skipped=0,
+            errors=0,
+            duration=0.0,
+            exit_code=exit_code,
+        )
+
+
+def test_default_cancel_is_noop_and_safe():
+    runner = _MinimalRunner()
+    # Default cancel() returns None and never raises (substitutability).
+    assert runner.cancel() is None
+
+
+def test_default_cleanup_is_noop_and_safe():
+    runner = _MinimalRunner()
+    assert runner.cleanup(success=True) is None
+    assert runner.cleanup(success=False) is None
+
+
+def test_minimal_runner_run_works():
+    runner = _MinimalRunner()
+    artifacts = runner.run("tests/")
+    assert artifacts.exit_code == 0
+    assert artifacts.junit_xml_path is None
+
+
+def test_minimal_parser_parse_works():
+    parser = _MinimalParser()
+    result = parser.parse("/some/report.xml", exit_code=0)
+    assert result.total == 0
+    assert result.success is True
+
+
+def test_abstract_classes_cannot_be_instantiated_directly():
+    # Both interfaces declare abstract methods, so direct instantiation must
+    # fail -- proving they are genuine ABCs, not accidentally concrete.
+    with pytest.raises(TypeError):
+        PytestRunner()  # type: ignore[abstract]
+    with pytest.raises(TypeError):
+        ResultParser()  # type: ignore[abstract]

--- a/tests/test_base_interfaces.py
+++ b/tests/test_base_interfaces.py
@@ -7,7 +7,7 @@ as an explicit contract marker. We exercise those defaults directly
 through a minimal concrete subclass.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,157 @@
+"""Tests for the Airflow compatibility shim.
+
+The shim resolves ``BaseOperator`` across Airflow 2.x/3.x import locations
+and provides ``get_airflow_version`` and an ``apply_defaults`` passthrough.
+We drive each resolution branch by injecting fake modules into
+``sys.modules`` so the tests are deterministic regardless of which Airflow
+(if any) is installed in the environment. Helper functions are exercised
+directly rather than relying on the module's import-time resolution.
+"""
+
+# Copyright 2026 Ilya Krysanov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from airflow_pytest_operator.compat import airflow as compat
+
+
+def _fake_module(name: str, **attrs: object) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def test_get_airflow_version_parses_version(monkeypatch):
+    # Inject a fake airflow.version and confirm we parse the numeric
+    # (major, minor, patch) tuple. The parser keeps *all* digits within a
+    # dotted chunk, so a clean "3.0.6" yields (3, 0, 6).
+    compat.get_airflow_version.cache_clear()
+    ver_mod = _fake_module("airflow.version", version="3.0.6")
+    monkeypatch.setitem(sys.modules, "airflow.version", ver_mod)
+    try:
+        assert compat.get_airflow_version() == (3, 0, 6)
+    finally:
+        compat.get_airflow_version.cache_clear()
+
+
+def test_get_airflow_version_strips_nonnumeric_suffix(monkeypatch):
+    # A pre-release like "2.10.3.dev0" is truncated to three dotted chunks
+    # and digits are extracted from each, so we still get a clean tuple.
+    compat.get_airflow_version.cache_clear()
+    ver_mod = _fake_module("airflow.version", version="2.10.3.dev0")
+    monkeypatch.setitem(sys.modules, "airflow.version", ver_mod)
+    try:
+        assert compat.get_airflow_version() == (2, 10, 3)
+    finally:
+        compat.get_airflow_version.cache_clear()
+
+
+def test_get_airflow_version_handles_nonnumeric_chunks(monkeypatch):
+    compat.get_airflow_version.cache_clear()
+    ver_mod = _fake_module("airflow.version", version="2.x.0")
+    monkeypatch.setitem(sys.modules, "airflow.version", ver_mod)
+    try:
+        # Non-numeric chunk -> 0 in that slot, rest parsed normally.
+        assert compat.get_airflow_version() == (2, 0, 0)
+    finally:
+        compat.get_airflow_version.cache_clear()
+
+
+def test_get_airflow_version_returns_zero_when_unavailable(monkeypatch):
+    # If airflow.version cannot be imported, fall back to (0,).
+    compat.get_airflow_version.cache_clear()
+    monkeypatch.setitem(sys.modules, "airflow.version", None)
+    try:
+        assert compat.get_airflow_version() == (0,)
+    finally:
+        compat.get_airflow_version.cache_clear()
+
+
+def test_import_base_operator_prefers_sdk_bases_operator(monkeypatch):
+    # Step 1: canonical Airflow 3 location wins when present.
+    class _Base:
+        pass
+
+    bases_op = _fake_module("airflow.sdk.bases.operator", BaseOperator=_Base)
+    monkeypatch.setitem(sys.modules, "airflow.sdk.bases.operator", bases_op)
+    assert compat._import_base_operator() is _Base
+
+
+def test_import_base_operator_falls_back_to_sdk_top_level(monkeypatch):
+    # Step 2: when the canonical path is unimportable, the top-level
+    # airflow.sdk re-export is used.
+    class _Base:
+        pass
+
+    # Make step 1 fail explicitly.
+    monkeypatch.setitem(sys.modules, "airflow.sdk.bases.operator", None)
+    sdk = _fake_module("airflow.sdk", BaseOperator=_Base)
+    monkeypatch.setitem(sys.modules, "airflow.sdk", sdk)
+    assert compat._import_base_operator() is _Base
+
+
+def test_import_base_operator_falls_back_to_models_baseoperator(monkeypatch):
+    # Step 3: Airflow 2.x location, used only when both SDK paths fail.
+    class _Base:
+        pass
+
+    monkeypatch.setitem(sys.modules, "airflow.sdk.bases.operator", None)
+    monkeypatch.setitem(sys.modules, "airflow.sdk", None)
+    models_mod = _fake_module("airflow.models.baseoperator", BaseOperator=_Base)
+    monkeypatch.setitem(sys.modules, "airflow.models.baseoperator", models_mod)
+    assert compat._import_base_operator() is _Base
+
+
+def test_import_base_operator_raises_diagnostic_when_all_fail(monkeypatch):
+    # When every known path is unimportable, a single diagnostic ImportError
+    # is raised that lists each attempted path -- not a confusing internal
+    # traceback from Airflow's deprecation shim.
+    monkeypatch.setitem(sys.modules, "airflow.sdk.bases.operator", None)
+    monkeypatch.setitem(sys.modules, "airflow.sdk", None)
+    monkeypatch.setitem(sys.modules, "airflow.models.baseoperator", None)
+    with pytest.raises(ImportError) as excinfo:
+        compat._import_base_operator()
+    msg = str(excinfo.value)
+    assert "Attempted paths" in msg
+    assert "airflow.sdk.bases.operator" in msg
+    assert "airflow.models.baseoperator" in msg
+
+
+def test_apply_defaults_uses_airflow_decorator_when_present(monkeypatch):
+    # Step where airflow.utils.decorators.apply_defaults exists: we return it.
+    sentinel = object()
+    decorators = _fake_module("airflow.utils.decorators", apply_defaults=sentinel)
+    monkeypatch.setitem(sys.modules, "airflow.utils.decorators", decorators)
+    assert compat._import_apply_defaults() is sentinel
+
+
+def test_apply_defaults_passthrough_when_absent(monkeypatch):
+    # When apply_defaults is unavailable (Airflow 3.x), we return a
+    # passthrough decorator that leaves the function unchanged.
+    monkeypatch.setitem(sys.modules, "airflow.utils.decorators", None)
+    passthrough = compat._import_apply_defaults()
+
+    def my_func():
+        return 42
+
+    wrapped = passthrough(my_func)
+    assert wrapped is my_func
+    assert wrapped() == 42

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -8,7 +8,7 @@ We drive each resolution branch by injecting fake modules into
 directly rather than relying on the module's import-time resolution.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -40,9 +40,6 @@ def _fake_module(name: str, **attrs: object) -> types.ModuleType:
 
 
 def test_get_airflow_version_parses_version(monkeypatch):
-    # Inject a fake airflow.version and confirm we parse the numeric
-    # (major, minor, patch) tuple. The parser keeps *all* digits within a
-    # dotted chunk, so a clean "3.0.6" yields (3, 0, 6).
     compat.get_airflow_version.cache_clear()
     ver_mod = _fake_module("airflow.version", version="3.0.6")
     monkeypatch.setitem(sys.modules, "airflow.version", ver_mod)
@@ -62,6 +59,23 @@ def test_get_airflow_version_strips_nonnumeric_suffix(monkeypatch):
         assert compat.get_airflow_version() == (2, 10, 3)
     finally:
         compat.get_airflow_version.cache_clear()
+
+
+def test_get_airflow_version_parses_inline_prerelease(monkeypatch):
+    compat.get_airflow_version.cache_clear()
+    for version_str, expected in [
+        ("3.0.6rc1", (3, 0, 6)),
+        ("2.10.0a2", (2, 10, 0)),
+        ("1.0.0b3", (1, 0, 0)),
+        ("3.0.6.post1", (3, 0, 6)),
+    ]:
+        compat.get_airflow_version.cache_clear()
+        ver_mod = _fake_module("airflow.version", version=version_str)
+        monkeypatch.setitem(sys.modules, "airflow.version", ver_mod)
+        assert compat.get_airflow_version() == expected, (
+            f"version {version_str!r} parsed incorrectly"
+        )
+    compat.get_airflow_version.cache_clear()
 
 
 def test_get_airflow_version_handles_nonnumeric_chunks(monkeypatch):

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -5,7 +5,7 @@ then assert the parser interprets them correctly. This catches drift in
 pytest's XML dialect far better than hand-written fixtures.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -133,3 +133,21 @@ def test_to_xcom_is_serializable(tmp_path):
     json.dumps(payload)
     assert "cases" not in payload
     assert payload["success"] is True
+
+
+def test_malformed_time_attribute_defaults_to_zero(tmp_path):
+    # pytest never emits a non-numeric `time`, but a hand-rolled or
+    # third-party report might. The parser must not crash: a bad `time`
+    # falls back to 0.0 (junit_parser ValueError branch) rather than
+    # raising, so one malformed attribute can't sink the whole report.
+    junit = tmp_path / "junit.xml"
+    junit.write_text(
+        '<testsuite name="pytest" tests="1" failures="0" errors="0" skipped="0">'
+        '<testcase classname="m" name="test_a" time="not-a-number"></testcase>'
+        "</testsuite>"
+    )
+    result = JUnitResultParser().parse(str(junit), exit_code=0)
+    assert result.total == 1
+    assert result.passed == 1
+    # The unparseable time degraded to 0.0, so total duration is 0.0.
+    assert result.duration == 0.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,94 @@
+"""Tests for the framework-agnostic domain models.
+
+These cover small but real branches: node-id reconstruction with and
+without a classname, the success property, and the XCom projection that
+drops per-case detail. They need no Airflow, no subprocess, no XML.
+"""
+
+# Copyright 2026 Ilya Krysanov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from airflow_pytest_operator.models import CaseResult, TestRunResult
+
+
+def test_node_id_with_classname():
+    case = CaseResult(
+        name="test_a", classname="tests.test_mod", time=0.0, outcome="passed"
+    )
+    assert case.node_id == "tests.test_mod::test_a"
+
+
+def test_node_id_without_classname_falls_back_to_name():
+    # Covers the branch where classname is empty: the node id is just the
+    # bare test name (models.py node_id fallback).
+    case = CaseResult(name="test_a", classname="", time=0.0, outcome="passed")
+    assert case.node_id == "test_a"
+
+
+def test_success_true_when_no_failures_or_errors():
+    result = TestRunResult(
+        total=2, passed=2, failed=0, skipped=0, errors=0, duration=0.2, exit_code=0
+    )
+    assert result.success is True
+    assert result.failed_node_ids == []
+
+
+def test_success_false_with_failures():
+    result = TestRunResult(
+        total=1, passed=0, failed=1, skipped=0, errors=0, duration=0.1, exit_code=1
+    )
+    assert result.success is False
+
+
+def test_failed_node_ids_include_errors_and_failures_only():
+    cases = [
+        CaseResult(name="t_ok", classname="m", time=0.0, outcome="passed"),
+        CaseResult(name="t_fail", classname="m", time=0.0, outcome="failed"),
+        CaseResult(name="t_err", classname="m", time=0.0, outcome="error"),
+        CaseResult(name="t_skip", classname="m", time=0.0, outcome="skipped"),
+    ]
+    result = TestRunResult(
+        total=4,
+        passed=1,
+        failed=1,
+        skipped=1,
+        errors=1,
+        duration=0.4,
+        exit_code=1,
+        cases=cases,
+    )
+    assert result.failed_node_ids == ["m::t_fail", "m::t_err"]
+
+
+def test_to_xcom_drops_cases_and_adds_derived_fields():
+    cases = [CaseResult(name="t", classname="m", time=0.0, outcome="failed")]
+    result = TestRunResult(
+        total=1,
+        passed=0,
+        failed=1,
+        skipped=0,
+        errors=0,
+        duration=0.1,
+        exit_code=1,
+        cases=cases,
+    )
+    payload = result.to_xcom()
+    # Per-case blobs are dropped from the compact XCom summary...
+    assert "cases" not in payload
+    # ...and derived fields are present.
+    assert payload["success"] is False
+    assert payload["failed_node_ids"] == ["m::t"]
+    assert payload["total"] == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ without a classname, the success property, and the XCom projection that
 drops per-case detail. They need no Airflow, no subprocess, no XML.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -6,7 +6,7 @@ without a real subprocess, without parsing XML, and — via a stubbed
 BaseOperator in conftest — without Airflow installed.
 """
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -289,3 +289,84 @@ def test_default_collaborators_are_wired():
     op = PytestOperator(task_id="t", test_path="tests/")
     assert isinstance(op._runner, SubprocessPytestRunner)
     assert isinstance(op._parser, JUnitResultParser)
+
+
+def test_stdout_and_stderr_are_logged():
+    # The operator must surface child stdout/stderr in the task log. We assert
+    # on the operator's own logging contract by spying on the logger's methods
+    # rather than using `caplog`: on Airflow 3 the operator logger is
+    # `airflow.task...`, whose records Airflow routes through its own
+    # task-logging, so a root-handler `caplog` wouldn't see them. Patching the
+    # logger methods proves the contract ("we called self.log.info/warning
+    # with this content") independent of how any Airflow version wires
+    # handlers. `BaseOperator.log` is a read-only property on real Airflow, so
+    # we patch its methods in place rather than reassigning `op.log`.
+    from unittest import mock
+
+    runner = FakeRunner(
+        RunArtifacts(
+            exit_code=0,
+            junit_xml_path="/x.xml",
+            stdout="some-stdout-line",
+            stderr="some-stderr-line",
+        )
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with (
+        mock.patch.object(op.log, "info") as info,
+        mock.patch.object(op.log, "warning") as warning,
+    ):
+        op.execute(_ctx())
+
+    logged = " ".join(str(c) for c in info.call_args_list + warning.call_args_list)
+    assert "some-stdout-line" in logged
+    assert "some-stderr-line" in logged
+
+
+def test_failed_node_ids_are_logged():
+    # When the parsed result has failed cases, the operator logs their node
+    # ids at error level. Same logger-spy rationale as above.
+    from unittest import mock
+
+    def _result_with_failed_cases():
+        # A result whose cases yield non-empty failed_node_ids, exercising the
+        # operator's "Failed tests:" logging branch (pytest_operator.py:127).
+        from airflow_pytest_operator.models import CaseResult
+
+        cases = [
+            CaseResult(
+                name="test_bad",
+                classname="tests.test_api",
+                time=0.1,
+                outcome="failed",
+            ),
+        ]
+        return TestRunResult(
+            total=1,
+            passed=0,
+            failed=1,
+            skipped=0,
+            errors=0,
+            duration=0.1,
+            exit_code=1,
+            cases=cases,
+        )
+
+    runner = FakeRunner(RunArtifacts(exit_code=1, junit_xml_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=FakeParser(_result_with_failed_cases()),
+        fail_on_test_failure=False,  # don't raise; we only check logging
+    )
+    with mock.patch.object(op.log, "error") as error:
+        op.execute(_ctx())
+
+    logged = " ".join(str(c) for c in error.call_args_list)
+    assert "tests.test_api::test_bad" in logged

--- a/tests/test_provider_discovery.py
+++ b/tests/test_provider_discovery.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -566,3 +566,49 @@ def test_concurrent_cleanup_only_one_rmtree(tmp_path):
     import shutil as _shutil
 
     _shutil.rmtree(auto_dir, ignore_errors=True)
+
+
+def test_timeout_logs_drained_stdout_and_stderr(tmp_path, monkeypatch, caplog):
+    # When the child times out we kill it and drain the pipes one final time.
+    # That tail output should land in the worker log at WARNING level (it is
+    # genuinely useful for diagnosing a hang) but must NOT be embedded into
+    # the TestExecutionError message -- because it can be megabytes and the
+    # message propagates into XCom and the UI.
+    import logging as _logging
+    import subprocess as _sp
+
+    runner = SubprocessPytestRunner(
+        report_dir=str(tmp_path / "rep"), timeout=0.01, grace_period=0.1
+    )
+
+    class _HangThenLeak:
+        """First communicate() times out; second one returns the tail data."""
+
+        returncode = -9
+        _calls = 0
+
+        def poll(self):
+            return None
+
+        def communicate(self, timeout=None):
+            type(self)._calls += 1
+            if type(self)._calls == 1:
+                raise _sp.TimeoutExpired(cmd="pytest", timeout=timeout)
+            return ("tail-stdout-data\n", "tail-stderr-data\n")
+
+        def wait(self, timeout=None):
+            return -9
+
+    # Force the runner to use our fake process and skip real kill machinery.
+    monkeypatch.setattr(_sp, "Popen", lambda *_a, **_k: _HangThenLeak())
+    monkeypatch.setattr(runner, "_terminate", lambda proc: None)
+
+    path = _suite(tmp_path, "def test_a(): assert True")
+    with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
+        with pytest.raises(TestExecutionError, match="timed out"):
+            runner.run(path)
+
+    # Both tail channels were logged...
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "tail-stdout-data" in joined
+    assert "tail-stderr-data" in joined

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1,6 +1,6 @@
 """Tests for SubprocessPytestRunner using real child processes."""
 
-# Copyright 2026 Ilya Krysanov
+# Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import textwrap
 from pathlib import Path
 
@@ -454,3 +455,114 @@ def test_separate_instances_run_in_parallel_safely(tmp_path):
     assert len(set(dirs)) == 3, "temp dirs collided across instances"
     for d in dirs:
         assert not os.path.exists(d), "each instance must clean its own dir"
+
+
+def test_terminate_returns_early_when_process_already_dead(tmp_path):
+    # _terminate must no-op when the process has already exited (poll()
+    # returns a code), exercising its early-return guard (subprocess_runner
+    # _terminate poll() branch). We use a real, already-finished process.
+    import subprocess as _sp
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    dead = _sp.Popen([sys.executable, "-c", "pass"])
+    dead.wait()  # ensure it has fully exited
+    assert dead.poll() is not None
+    # Must return cleanly without trying to signal a dead process.
+    runner._terminate(dead)
+
+
+def test_terminate_handles_process_lookup_on_sigterm(tmp_path, monkeypatch):
+    # If the process dies between the poll() check and the SIGTERM, killpg
+    # raises ProcessLookupError; _terminate must swallow it and return
+    # (the "race: gone before SIGTERM" branch).
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+
+    class _FakeProc:
+        # poll() returns None (looks alive) so we get past the early guard,
+        # then _signal_group raises ProcessLookupError as if it just died.
+        returncode = None
+
+        def poll(self):
+            return None
+
+    def _raise_lookup(proc, sig):
+        raise ProcessLookupError
+
+    monkeypatch.setattr(runner, "_signal_group", _raise_lookup)
+    # Must not raise.
+    runner._terminate(_FakeProc())  # type: ignore[arg-type]
+
+
+def test_terminate_handles_process_lookup_on_sigkill(tmp_path, monkeypatch):
+    # The process survives SIGTERM and the grace wait, then disappears right
+    # before SIGKILL: the second _signal_group raises ProcessLookupError,
+    # which _terminate must also swallow (the SIGKILL-race branch).
+    import signal as _signal_module
+    import subprocess as _sp
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"), grace_period=0.1)
+
+    class _FakeProc:
+        returncode = None
+
+        def poll(self):
+            return None
+
+        def wait(self, timeout=None):
+            # Never exits during grace -> forces escalation to SIGKILL.
+            raise _sp.TimeoutExpired(cmd="pytest", timeout=timeout)
+
+    calls = {"n": 0}
+
+    def _signal(proc, sig):
+        calls["n"] += 1
+        if sig == _signal_module.SIGKILL:
+            raise ProcessLookupError
+        # SIGTERM path returns normally.
+
+    monkeypatch.setattr(runner, "_signal_group", _signal)
+    runner._terminate(_FakeProc())  # type: ignore[arg-type]
+    # Both SIGTERM and SIGKILL were attempted.
+    assert calls["n"] == 2
+
+
+def test_concurrent_cleanup_only_one_rmtree(tmp_path):
+    # Two cleanup() calls racing (e.g. operator post-run + on_kill) must not
+    # both rmtree: the loser sees _created_report_dir already claimed as None
+    # under the lock and bails (the cleanup race-guard branch).
+    #
+    # The race is between the unlocked first read (sees a path) and the
+    # locked re-read (sees None because the winner cleared it). We make it
+    # deterministic by wrapping the runner's lock so that the instant this
+    # cleanup() acquires it, the path has already been claimed -- exactly the
+    # state the loser would observe.
+    path = _suite(tmp_path, "def test_a(): assert True")
+    runner = SubprocessPytestRunner()  # auto temp dir, cleanup="always"
+    artifacts = runner.run(path)
+    auto_dir = artifacts.working_dir
+    assert auto_dir is not None and os.path.isdir(auto_dir)
+
+    real_lock = runner._lock
+
+    class _ClaimingLock:
+        # On acquire, simulate the winner having already taken the path.
+        def __enter__(self):
+            runner._created_report_dir = None
+            return real_lock.__enter__()
+
+        def __exit__(self, *exc):
+            return real_lock.__exit__(*exc)
+
+    runner._lock = _ClaimingLock()  # type: ignore[assignment]
+    # First (unlocked) read sees the real path; locked re-read sees None ->
+    # the guard returns without rmtree and without raising.
+    runner.cleanup(success=True)
+    runner._lock = real_lock  # type: ignore[assignment]
+
+    # Because the loser bailed, the directory is NOT removed here -- proving
+    # the guard prevented a double-rmtree rather than racing into one.
+    assert os.path.isdir(auto_dir)
+    # Clean up the leftover dir ourselves so the test leaves no trace.
+    import shutil as _shutil
+
+    _shutil.rmtree(auto_dir, ignore_errors=True)


### PR DESCRIPTION
### Added
- Coverage measurement wired into the project: `pytest-cov` is now a dev
  dependency and `[tool.coverage]` configuration lives in `pyproject.toml`
  (branch coverage on, `airflow_pytest_operator` as the source). Coverage is
  opt-in via `pytest --cov=airflow_pytest_operator` so the integration CI
  job, which installs a bare pytest, is unaffected.
- Codecov integration in CI: the unit job uploads a coverage report
  (`coverage.xml`) on Python 3.12 via `codecov/codecov-action`, and the
  README now carries a coverage badge.
- The CI integration matrix now also runs against Airflow 3.2.1 (py3.12),
  the release where the 0.2.1 provider-discovery startup crash first
  appeared, guarding the lazy-import fix against regression.
- Substantial test additions bringing measured coverage to ~99.5% on the
  test stub and on real Airflow 2.10.3, 3.0.6, and 3.2.1. The single
  uncovered line is a `run()`/`cancel()` race-guard with no deterministic
  test, left uncovered by design rather than chased with a flaky timing
  test (a `fail_under = 85` gate guards against real regressions):
  - `tests/test_models.py` — node-id reconstruction (with and without a
    classname), `success`/`failed_node_ids` derivation, and the XCom
    projection that drops per-case detail.
  - `tests/test_base_interfaces.py` — the abstract `PytestRunner`/
    `ResultParser` defaults (no-op `cancel`/`cleanup`, abstract-method
    contracts), proving Liskov-substitutability of minimal implementations.
  - `tests/test_compat.py` — every `BaseOperator` resolution branch of the
    compatibility shim, driven deterministically by injecting fake modules
    into `sys.modules`, plus `get_airflow_version` parsing and the
    `apply_defaults` passthrough.
  - Operator logging of child stdout/stderr and failed node ids, asserted
    by spying on the logger's methods rather than `caplog` (robust across
    Airflow versions, which route task logging differently).
  - `SubprocessPytestRunner` edge paths: `_terminate` when the process is
    already dead or disappears mid-signal (`ProcessLookupError` on SIGTERM
    and SIGKILL) and the cleanup race-guard that prevents a double `rmtree`.
  - A malformed `time` attribute in a JUnit report now has an explicit test
    confirming it degrades to `0.0` rather than failing the parse.

### Changed
- License headers on all source files now use a collective copyright
  ("the airflow-pytest-operator contributors") instead of an individual
  name, so contributors never have to edit copyright lines per file. A
  `NOTICE` file records project-level authorship, and each contributor
  retains copyright over their own contributions.
- OS-specific Windows-only branches in `SubprocessPytestRunner` are marked
  `# pragma: no cover`; they cannot execute on the Linux CI runners and are
  excluded from the coverage measurement rather than left as phantom gaps.

### Security
- A `SECURITY.md` security policy documents supported versions, the
  preferred reporting channel (GitHub Private Vulnerability Reporting),
  response-time expectations (acknowledgement within 72 hours, initial
  assessment within 7 days, 90-day coordinated disclosure), out-of-scope
  cases, and hardening recommendations for users (including the
  `[secure-xml]` extra and how to verify release attestations). Closes the
  Security-Policy criterion in supply-chain audits such as OpenSSF
  Scorecard.
- A weekly OpenSSF Scorecard analysis (`.github/workflows/scorecard.yml`)
  scans the repository for supply-chain best practices and publishes its
  result as a signed SARIF report to the GitHub Security tab and to the
  public Scorecard API. The score badge is linked from the README so
  consumers can see the project's supply-chain posture at a glance.
- Release and TestPyPI workflows now pin every third-party GitHub Action by
  immutable commit SHA (with a trailing comment naming the version) rather
  than by floating tag, so a compromise of an upstream action repository
  cannot silently substitute new code into the workflow that holds our
  PyPI OIDC token.
- Release artifacts ship with [PEP 740](https://peps.python.org/pep-0740/)
  Sigstore attestations, produced automatically by
  `pypa/gh-action-pypi-publish` v1.10+ for any Trusted-Publishing release.
  PyPI verifies them at upload and surfaces the source repository in the
  release's *Verified details*. README documents how end users can verify
  individual artifacts against this repository with `pypi-attestations`.

### Contributor experience
- `CONTRIBUTING.md` now documents the license header to copy into new files,
  the project's GitHub Flow branching model (PRs target `main`; there is no
  `develop` branch), a Developer Certificate of Origin (DCO) sign-off
  workflow, and a maintainer review/merge checklist.
- Added a `DCO` GitHub Actions workflow that verifies every pull-request
  commit carries a `Signed-off-by` trailer.