### PR TITLE
Potential fix for code scanning alert no. 30: Module is imported with 'import' and 'import from'

### DIFF
--- a/tests/test_provider_discovery.py
+++ b/tests/test_provider_discovery.py
@@ -93,13 +93,13 @@ def test_version_fallback_when_not_installed(monkeypatch):
     # resolver must not raise -- it returns a sentinel instead.
     import importlib.metadata as md
 
-    from airflow_pytest_operator import provider_info
+    import airflow_pytest_operator
 
     def _raise(_name):
         raise md.PackageNotFoundError
 
-    monkeypatch.setattr(provider_info, "version", _raise)
-    assert provider_info._resolve_version() == "0.0.0+unknown"
+    monkeypatch.setattr(airflow_pytest_operator.provider_info, "version", _raise)
+    assert airflow_pytest_operator.provider_info._resolve_version() == "0.0.0+unknown"
 
 
 def test_lazy_operator_attribute_resolves():


### PR DESCRIPTION
Potential fix for [https://github.com/IKrysanov/airflow-pytest-operator/security/code-scanning/30](https://github.com/IKrysanov/airflow-pytest-operator/security/code-scanning/30)

To fix this without changing behavior, keep only one import style for `airflow_pytest_operator` in this file: plain `import airflow_pytest_operator`.  
Specifically in `tests/test_provider_discovery.py`, update `test_version_fallback_when_not_installed`:

- Replace `from airflow_pytest_operator import provider_info` with `import airflow_pytest_operator`.
- Update references from `provider_info` to `airflow_pytest_operator.provider_info`.

This preserves test semantics while removing the mixed `import` + `from ... import ...` usage for the same module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
