### PR TITLE
Feature/json result parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-06-...
+## [0.4.0] - 2026-06-04
  
 ### Breaking changes
 This release removes the runner's hardcoded knowledge of the JUnit format.
@@ -17,7 +17,7 @@ declared path. No deprecation aliases are provided -- breakage is intentional
 and loud, because the silent-fallback alternative (a `JSONResultParser` that
 secretly gets a JUnit XML file) is much harder to diagnose than a `TypeError`
 at startup.
- 
+
 Migration matrix (was -> is):
  
 - `RunArtifacts.junit_xml_path` -> `RunArtifacts.report_path`.
@@ -34,15 +34,15 @@ Migration matrix (was -> is):
   `JUnitResultParser.report_request` now.
 - `TestExecutionError` raised on a missing report previously read
   `"pytest produced no JUnit report"`; it now names the configured parser
-  class (`"pytest produced no JUnitResultParser report"`,
-  `"... no JSONResultParser report"`, ...). Tests asserting against the old
-  wording must update the match string.
+  class (`"pytest produced no report for JUnitResultParser (exit code N)"`,
+  `"pytest produced no report for JSONResultParser ..."`, ...). Tests
+  asserting against the old wording must update the match string.
 ### Added
 - `ReportRequest` dataclass in `airflow_pytest_operator.models` (also
   re-exported from the package root). Frozen, with `pytest_args:
-  tuple[str, ...]` and `report_path: str | None`. `report_path=None` is
-  the documented signal for parsers that read stdout instead of a file
-  (no built-in implementation in this release; the type permits it).
+  tuple[str, ...]` and `report_path: str | None`. `report_path=None`
+  documents "no report file expected"; the type is kept permissive so a
+  future format that produces no file needs no model change.
 - `JSONResultParser` in `airflow_pytest_operator.reporters.json_parser`,
   parsing output produced by the `pytest-json-report` plugin. Same
   contract as `JUnitResultParser`: counts, durations, per-case results,
@@ -55,11 +55,21 @@ Migration matrix (was -> is):
   on the side where pytest runs.
 - The `[dev]` extra now also pulls in `pytest-json-report`, so
   `tests/test_json_parser.py` runs as part of the normal test suite.
-- The error message produced when pytest fails to write a report now
-  names the configured parser class (so logs say "no JUnitResultParser
-  report" / "no JSONResultParser report" rather than the parser-agnostic
-  "no report"), and truncates very long captured stderr at 4096 chars to
-  keep Airflow task logs and XCom payloads bounded.
+- The `TestExecutionError` raised when pytest writes no report truncates
+  very long captured stderr at 4096 chars, keeping Airflow task logs and
+  XCom payloads bounded. (The parser-class naming in that same message is
+  covered under Breaking changes above.)
+- `SubprocessPytestRunner` gained a `max_output_bytes` constructor
+  parameter (default 10 MiB) that caps captured `stdout`/`stderr` per
+  stream. A pytest run that writes unbounded output to a pipe (e.g.
+  `-s` with a chatty or looping test) could otherwise grow the in-memory
+  capture without limit and bloat the Airflow task log / XCom payload.
+  Once a stream reaches the cap, further chunks from it are dropped and
+  the captured text is suffixed with a one-line marker
+  (`...(stdout truncated at N bytes; ...)`); the underlying pipe keeps
+  being drained so the child never blocks on a full OS buffer. Pass
+  `None` to restore unbounded capture; a non-positive value raises
+  `ValueError`.
 - Two new worker-oriented extras: `[pytest]` (`pytest>=7.0`) and
   `[pytest-allure]` (`pytest>=7.0, allure-pytest>=2.13`). These let workers
   pull in pytest (and optionally the Allure plugin) as part of a single
@@ -111,14 +121,6 @@ Migration matrix (was -> is):
     and that reusing the same `report_dir` overwrites prior reports --
     callers needing history retention must give the runner a fresh dir
     per run (the default temp-dir behavior already does this).
-- `ReportRequest.report_path=None` no longer claims to be the channel for
-  "stdout-reading parsers" -- no such parser ships in 0.4.0. Documented
-  as "no report file expected", with the type kept permissive so a
-  future format that doesn't produce a file wouldn't need a model
-  change.
-- The package's public surface (`from airflow_pytest_operator import ...`)
-  gained `ReportRequest` and `JSONResultParser`. `__all__` updated in
-  step.
 - DCO check now skips automated bot commits (Dependabot, github-actions,
   etc.), identified by their `…[bot]@users.noreply.github.com` author
   email. Bots cannot run `git commit -s`, and their provenance comes from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-...
+ 
+### Breaking changes
+This release removes the runner's hardcoded knowledge of the JUnit format.
+Parsers now declare which pytest CLI flags they need and where their report
+will land; the runner just splices those args verbatim and reports back the
+declared path. No deprecation aliases are provided -- breakage is intentional
+and loud, because the silent-fallback alternative (a `JSONResultParser` that
+secretly gets a JUnit XML file) is much harder to diagnose than a `TypeError`
+at startup.
+ 
+Migration matrix (was -> is):
+ 
+- `RunArtifacts.junit_xml_path` -> `RunArtifacts.report_path`.
+- `ResultParser` -- subclasses now MUST implement `report_request(report_dir)`
+  in addition to `parse(...)`. A class that overrides only `parse` will raise
+  `TypeError` at instantiation. The new method returns a `ReportRequest` with
+  the CLI flags and the report path the parser wants pytest to produce.
+- `PytestRunner.run(...)` -- new required keyword-only argument
+  `report_request: Callable[[str], ReportRequest]`. Operators pass
+  `parser.report_request`; custom runners receive the callback and must call
+  it on the prepared report directory before launching pytest.
+- `SubprocessPytestRunner` no longer adds `--junitxml=...` or
+  `-o junit_logging=all` of its own accord. Those flags live in
+  `JUnitResultParser.report_request` now.
+- `TestExecutionError` raised on a missing report previously read
+  `"pytest produced no JUnit report"`; it now names the configured parser
+  class (`"pytest produced no JUnitResultParser report"`,
+  `"... no JSONResultParser report"`, ...). Tests asserting against the old
+  wording must update the match string.
 ### Added
+- `ReportRequest` dataclass in `airflow_pytest_operator.models` (also
+  re-exported from the package root). Frozen, with `pytest_args:
+  tuple[str, ...]` and `report_path: str | None`. `report_path=None` is
+  the documented signal for parsers that read stdout instead of a file
+  (no built-in implementation in this release; the type permits it).
+- `JSONResultParser` in `airflow_pytest_operator.reporters.json_parser`,
+  parsing output produced by the `pytest-json-report` plugin. Same
+  contract as `JUnitResultParser`: counts, durations, per-case results,
+  and `failed_node_ids`. Available from the package root.
+- `[json-report]` extra wiring `pytest-json-report>=1.5`. Install on
+  workers configured to use the JSON parser:
+      `pip install airflow-pytest-operator[json-report]`
+  The parser itself has no runtime dependency on the plugin -- it just
+  parses whatever JSON it is handed -- so this extra only needs to be
+  on the side where pytest runs.
+- The `[dev]` extra now also pulls in `pytest-json-report`, so
+  `tests/test_json_parser.py` runs as part of the normal test suite.
+- The error message produced when pytest fails to write a report now
+  names the configured parser class (so logs say "no JUnitResultParser
+  report" / "no JSONResultParser report" rather than the parser-agnostic
+  "no report"), and truncates very long captured stderr at 4096 chars to
+  keep Airflow task logs and XCom payloads bounded.
 - Two new worker-oriented extras: `[pytest]` (`pytest>=7.0`) and
   `[pytest-allure]` (`pytest>=7.0, allure-pytest>=2.13`). These let workers
   pull in pytest (and optionally the Allure plugin) as part of a single
   `pip install airflow-pytest-operator[pytest]` command without manually
   tracking a separate requirement. The `[dev]` extra is unchanged and
   continues to include `pytest` alongside the development toolchain.
-
 ### Changed
+- `SubprocessPytestRunner` is now format-agnostic. It receives a
+  `report_request` callback from the operator, invokes it on the prepared
+  report directory, splices the returned CLI args into the pytest command,
+  and returns the declared report path in `RunArtifacts`. Adding a new
+  report format is now strictly a matter of writing a new parser; the
+  runner needs no changes. (This closes the gap between the OCP claim in
+  the README and what the code actually allowed.)
+- The package's public surface (`from airflow_pytest_operator import ...`)
+  gained `ReportRequest` and `JSONResultParser`. `__all__` updated in
+  step.
 - DCO check now skips automated bot commits (Dependabot, github-actions,
   etc.), identified by their `…[bot]@users.noreply.github.com` author
   email. Bots cannot run `git commit -s`, and their provenance comes from
@@ -28,7 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and roughly doubled CI usage per change. Added `concurrency` groups with
   `cancel-in-progress` to CI, CodeQL, and DCO so superseded runs on the
   same ref are cancelled rather than left to finish.
-
 
 ## [0.3.1] - 2026-05-31
 
@@ -225,7 +285,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,48 @@ Migration matrix (was -> is):
   report format is now strictly a matter of writing a new parser; the
   runner needs no changes. (This closes the gap between the OCP claim in
   the README and what the code actually allowed.)
+- `SubprocessPytestRunner` no longer collects stdout/stderr via
+  `communicate()`. Two background threads drain each pipe from the moment
+  Popen returns, accumulating chunks until EOF. The main thread waits via
+  `proc.wait(timeout=...)` and then joins the drainers with a bounded
+  timeout. This removes a documented race: previously, the post-timeout
+  tail was collected by a second `communicate()` call, which CPython
+  documents as best-effort and which races SIGKILL against the kernel's
+  pipe-flush -- on a saturated pipe the tail could come back empty even
+  when bytes were waiting in the buffer. The new design captures every
+  byte the child wrote before the kill, plus also covers the cancel()
+  path that previously dropped the tail entirely.
+- `JSONResultParser` now treats unknown `outcome` values as `"skipped"`
+  instead of `"error"`. The previous default would flip a clean run to
+  failed if a future pytest-json-report version introduced a new state
+  (e.g. `"deselected"`, `"warned"`) and raise `TestsFailedError` on a
+  suite that actually passed. `"skipped"` is non-fatal and honest: we did
+  not classify the case as a real pass or failure. To prevent silent
+  drift, the parser logs a single `WARNING` per report listing every
+  unknown outcome it encountered, so schema changes still show up in
+  worker logs rather than being papered over forever.
+- `JSONResultParser` hardening pass:
+  * Non-list `tests` field now raises `ReportParseError` instead of
+    crashing with `TypeError` from a `for`-loop. Callers can catch a
+    single exception type for "report is malformed".
+  * Non-numeric values in `summary` counters are still coerced to 0 (to
+    keep the parse going), but trigger a single `WARNING` per report
+    listing every offending key. Silent structural errors no longer
+    produce misleading zero counts.
+  * Skipped-case message extraction now returns just the reason string
+    instead of the repr of the `(filename, lineno, 'Skipped: reason')`
+    tuple pytest-json-report stores in `longrepr`. Falls back to the raw
+    text on schema drift. Uses `ast.literal_eval` so report content is
+    never executed.
+  * Per-parser docstrings now document that the report filename is fixed
+    and that reusing the same `report_dir` overwrites prior reports --
+    callers needing history retention must give the runner a fresh dir
+    per run (the default temp-dir behavior already does this).
+- `ReportRequest.report_path=None` no longer claims to be the channel for
+  "stdout-reading parsers" -- no such parser ships in 0.4.0. Documented
+  as "no report file expected", with the type kept permissive so a
+  future format that doesn't produce a file wouldn't need a model
+  change.
 - The package's public surface (`from airflow_pytest_operator import ...`)
   gained `ReportRequest` and `JSONResultParser`. `__all__` updated in
   step.

--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ pip install "airflow-pytest-operator[pytest]"
 # Note: to *view* Allure reports you also need the Allure CLI (Java); see README below.
 pip install "airflow-pytest-operator[pytest-allure]"
  
+# pytest + pytest-json-report (for the built-in JSONResultParser)
+pip install "airflow-pytest-operator[json-report]"
+ 
 # hardened XML parsing for untrusted JUnit reports (recommended for production)
 pip install "airflow-pytest-operator[secure-xml]"
  
 # combine extras as needed
-pip install "airflow-pytest-operator[pytest,secure-xml]"
+pip install "airflow-pytest-operator[pytest,secure-xml,json-report]"
 ```
 
 Airflow itself is **not** a hard dependency — the package installs into your existing Airflow environment. Pin a compatible Airflow via an extra if you want resolution help: `airflow-pytest-operator[airflow2]` or `[airflow3]`.
@@ -313,9 +316,57 @@ When Airflow kills the task (execution timeout, manual clear/mark-failed, worker
 
 The operator runs whatever path exists **on the worker** at execute time, so it works with any executor (Local, Celery, Kubernetes, custom) — the runner spawns pytest wherever the task already runs. The practical constraint is *availability*: with `LocalExecutor` the tests sit next to `dags/`; with Celery/Kubernetes, make sure the test folder is synced to workers the same way DAGs are (git-sync, baked image, shared volume), or point `test_path` at wherever they land. If the path is missing, the task fails with a clear `TestExecutionError`.
 
+## Built-in parsers
+
+| Parser | Report format | Install requirement on the worker |
+|---|---|---|
+| `JUnitResultParser` (default) | JUnit XML (`--junitxml`) | nothing extra; pytest ships with it |
+| `JSONResultParser` | pytest-json-report JSON | `pip install airflow-pytest-operator[json-report]` |
+
+Both implement the same `ResultParser` interface and produce the same `TestRunResult`, so callers downstream of XCom don't care which one ran. Swap them via the `parser=` argument:
+
+```python
+from airflow_pytest_operator import JSONResultParser, PytestOperator
+
+PytestOperator(
+    task_id="t",
+    test_path="tests/",
+    parser=JSONResultParser(),
+)
+```
+
 ## Extending it
 
 The operator depends on two narrow abstractions and accepts them via constructor injection — no operator subclassing required. Provide your own to change *how* tests run or *how* results are parsed.
+
+The runner is **format-agnostic**: it does not know whether the report is JUnit XML, JSON, or anything else. Parsers declare the pytest CLI flags they need (and the path the report will land at) via `report_request(report_dir)`; the operator hands that callback to the runner before launching pytest. Adding a new format means writing a new parser, not editing the runner.
+
+### Custom parser
+
+A parser implements two methods: `report_request` declares what pytest must produce, `parse` interprets the resulting file.
+
+```python
+from airflow_pytest_operator import (
+    PytestOperator, ReportRequest, ResultParser, TestRunResult,
+)
+
+class TAPResultParser(ResultParser):
+    """Example: read TAP (Test Anything Protocol) output via pytest-tap."""
+
+    REPORT_FILENAME = "results.tap"
+
+    def report_request(self, report_dir: str) -> ReportRequest:
+        path = f"{report_dir}/{self.REPORT_FILENAME}"
+        return ReportRequest(
+            pytest_args=("--tap-files", f"--tap-outdir={report_dir}"),
+            report_path=path,
+        )
+
+    def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
+        ...  # read TAP, return a TestRunResult
+
+PytestOperator(task_id="t", test_path="tests/", parser=TAPResultParser())
+```
 
 ### Custom runner
 
@@ -323,9 +374,19 @@ The operator depends on two narrow abstractions and accepts them via constructor
 from airflow_pytest_operator import PytestOperator, PytestRunner, RunArtifacts
 
 class DockerPytestRunner(PytestRunner):
-    def run(self, test_path, *, pytest_args=None, env=None) -> RunArtifacts:
-        # run pytest inside a container, write a JUnit xml, then:
-        return RunArtifacts(exit_code=..., junit_xml_path="/path/junit.xml")
+    def run(
+        self,
+        test_path,
+        *,
+        pytest_args=None,
+        env=None,
+        report_request,            # required: parser-supplied callback
+    ) -> RunArtifacts:
+        report_dir = "/some/prepared/dir/in/the/container"
+        spec = report_request(report_dir)
+        # spawn pytest in a container with: [..., *spec.pytest_args, ...]
+        # then collect the file from spec.report_path
+        return RunArtifacts(exit_code=..., report_path=spec.report_path)
 
     # optional: override cancel() / cleanup() if you own resources
     # (the base class provides safe no-op defaults)
@@ -333,25 +394,14 @@ class DockerPytestRunner(PytestRunner):
 PytestOperator(task_id="t", test_path="tests/", runner=DockerPytestRunner())
 ```
 
-### Custom parser
-
-```python
-from airflow_pytest_operator import PytestOperator, ResultParser, TestRunResult
-
-class JSONResultParser(ResultParser):
-    def parse(self, report_path, *, exit_code=0) -> TestRunResult:
-        ...  # read pytest-json-report output, return a TestRunResult
-
-PytestOperator(task_id="t", test_path="tests/", parser=JSONResultParser())
-```
-
 ## Architecture
 
 | Concern | Type | Responsibility |
 |---|---|---|
 | `PytestOperator` | operator | orchestrate runner→parser, Airflow integration, fail/cleanup policy |
-| `PytestRunner` / `SubprocessPytestRunner` | runner | execute pytest, produce `RunArtifacts`, own cancel/cleanup |
-| `ResultParser` / `JUnitResultParser` | parser | turn a report file into `TestRunResult` |
+| `PytestRunner` / `SubprocessPytestRunner` | runner | execute pytest (format-agnostic), produce `RunArtifacts`, own cancel/cleanup |
+| `ResultParser` / `JUnitResultParser` / `JSONResultParser` | parser | declare pytest's report args via `report_request`, then `parse` the resulting file into `TestRunResult` |
+| `ReportRequest` | domain | what a parser asks pytest to produce (CLI flags + output path) |
 | `compat.airflow` | shim | the only place that imports Airflow |
 | `models` | domain | framework-free dataclasses |
 

--- a/examples/example_dag.py
+++ b/examples/example_dag.py
@@ -23,7 +23,7 @@ from airflow_pytest_operator import PytestOperator
 
 # Use additional features like custom runners and parsers by importing them directly.
 from airflow_pytest_operator.runners import SubprocessPytestRunner
-from airflow_pytest_operator.reporters import JUnitResultParser
+from airflow_pytest_operator.reporters import JSONResultParser
 
 with DAG(
     dag_id="pytest_example",
@@ -51,7 +51,7 @@ with DAG(
         # You can use any runner that implements the expected interface; the default is SubprocessPytestRunner.
         runner=SubprocessPytestRunner(timeout=1800, cleanup="on_success"),
         # You can use any parser that implements the expected interface; the default is JUnitResultParser.
-        parser=JUnitResultParser(),
+        parser=JSONResultParser(),
         do_xcom_push=True,  # This is the default, but being explicit for clarity.
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,9 @@ include = ["src", "tests", "examples", "README.md", "LICENSE", "NOTICE", "CHANGE
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+filterwarnings = [
+    "ignore:cannot collect test class 'TestRunResult':pytest.PytestCollectionWarning",
+]
 
 # ---------------------------------------------------------------------------
 # Coverage. Not wired into pytest addopts by default: the integration CI job

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ ignore = [
 # mypy: static type checking of the package source.
 # ---------------------------------------------------------------------------
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 files = ["src"]
 strict = true
 # Airflow has no complete type stubs and is an optional, unresolved import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.3.1"
+version = "0.4.0"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -55,10 +55,22 @@ pytest = ["pytest>=7.0"]
 # Note: to *view* Allure reports you also need the Allure CLI (Java),
 # which cannot be declared as a Python dependency; see README for details.
 pytest-allure = ["pytest>=7.0", "allure-pytest>=2.13"]
+# Adds pytest-json-report so the worker can emit reports consumable by
+# JSONResultParser. Install on workers configured to use the JSON parser:
+#     pip install airflow-pytest-operator[json-report]
+# The parser itself has no runtime dependency on the plugin -- it just
+# parses whatever JSON it is handed -- so this extra only needs to be on
+# the side where pytest runs (which may differ from the operator's side
+# in container/k8s deployments).
+json-report = ["pytest-json-report>=1.5"]
 # Everything needed to develop and run the test/lint/type-check suite.
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
+    # Required by tests/test_json_parser.py: the suite skips cleanly when
+    # the plugin is absent, but dev workflows expect it available so the
+    # JSON-parser coverage shows up.
+    "pytest-json-report>=1.5",
     "defusedxml>=0.7",
     "mypy>=1.8",
     "ruff>=0.4",

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -5,7 +5,9 @@ Public API:
     PytestRunner           — runner interface (extend for docker/k8s)
     SubprocessPytestRunner — default runner
     ResultParser           — parser interface
-    JUnitResultParser      — default parser
+    JUnitResultParser      — default parser (JUnit XML)
+    JSONResultParser       — parser for pytest-json-report output
+    ReportRequest          — parser-declared pytest invocation spec
     TestRunResult          — structured result model
 """
 
@@ -33,10 +35,10 @@ from .exceptions import (
     TestExecutionError,
     TestsFailedError,
 )
-from .models import CaseResult, RunArtifacts, TestRunResult
+from .models import CaseResult, ReportRequest, RunArtifacts, TestRunResult
 from .provider_info import __version__ as __version__
 from .provider_info import get_provider_info as get_provider_info
-from .reporters import JUnitResultParser, ResultParser
+from .reporters import JSONResultParser, JUnitResultParser, ResultParser
 from .runners import PytestRunner, SubprocessPytestRunner
 
 if TYPE_CHECKING:
@@ -53,6 +55,8 @@ __all__ = [
     "SubprocessPytestRunner",
     "ResultParser",
     "JUnitResultParser",
+    "JSONResultParser",
+    "ReportRequest",
     "TestRunResult",
     "RunArtifacts",
     "CaseResult",

--- a/src/airflow_pytest_operator/models.py
+++ b/src/airflow_pytest_operator/models.py
@@ -44,16 +44,43 @@ class CaseResult:
 
 
 @dataclass(frozen=True)
+class ReportRequest:
+    """What a parser needs pytest to produce.
+
+    A parser declares two things:
+      * ``pytest_args``  -- CLI tokens to splice into the pytest invocation
+        so it emits a report the parser can consume (e.g. ``--junitxml=...``
+        for JUnit, ``--json-report --json-report-file=...`` for JSON);
+      * ``report_path``  -- the path on disk where that report will land,
+        or ``None`` if the parser reads stdout instead of a file.
+
+    The runner is handed this request by the operator before launching
+    pytest. It splices the args verbatim and, on completion, returns the
+    declared ``report_path`` in :class:`RunArtifacts` (or ``None`` if the
+    file is missing). The runner never interprets the args -- this is what
+    keeps it format-agnostic and what makes "add a new format by adding a
+    parser, not by editing the runner" actually true.
+    """
+
+    pytest_args: tuple[str, ...]
+    report_path: str | None
+
+
+@dataclass(frozen=True)
 class RunArtifacts:
     """Everything a Runner produces: where to find outputs + the exit code.
 
     A Runner's job ends at producing files; interpreting them is the
     Parser's job. This separation is what lets us swap runners
     (subprocess, docker, k8s-pod) without touching parsing logic.
+
+    ``report_path`` is whatever path the parser declared via its
+    :class:`ReportRequest` -- the runner only checks the file exists and
+    passes it through; it does not assume a format.
     """
 
     exit_code: int
-    junit_xml_path: str | None
+    report_path: str | None
     stdout: str = ""
     stderr: str = ""
     working_dir: str | None = None

--- a/src/airflow_pytest_operator/models.py
+++ b/src/airflow_pytest_operator/models.py
@@ -1,10 +1,3 @@
-"""Domain models for test runs.
-
-These are plain, framework-agnostic dataclasses. Nothing here imports
-Airflow, pytest, or subprocess — keeping the domain layer dependency-free
-makes it trivial to unit-test parsers and the operator in isolation (DIP).
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,8 +44,9 @@ class ReportRequest:
       * ``pytest_args``  -- CLI tokens to splice into the pytest invocation
         so it emits a report the parser can consume (e.g. ``--junitxml=...``
         for JUnit, ``--json-report --json-report-file=...`` for JSON);
-      * ``report_path``  -- the path on disk where that report will land,
-        or ``None`` if the parser reads stdout instead of a file.
+      * ``report_path``  -- the path on disk where that report will land.
+        ``None`` means no report file is expected (the runner will return
+        ``RunArtifacts.report_path=None`` accordingly).
 
     The runner is handed this request by the operator before launching
     pytest. It splices the args verbatim and, on completion, returns the
@@ -88,9 +82,7 @@ class RunArtifacts:
 
 @dataclass(frozen=True)
 class TestRunResult:
-    """Structured, serializable result of a pytest run."""
-
-    __test__ = False  # not a pytest test class despite the name
+    """Aggregated result of one pytest run, mapped from a parsed report."""
 
     total: int
     passed: int
@@ -103,18 +95,14 @@ class TestRunResult:
 
     @property
     def success(self) -> bool:
-        return self.failed == 0 and self.errors == 0
+        return self.failed == 0 and self.errors == 0 and self.exit_code == 0
 
     @property
     def failed_node_ids(self) -> list[str]:
         return [c.node_id for c in self.cases if c.outcome in ("failed", "error")]
 
     def to_xcom(self) -> dict[str, Any]:
-        """A compact, JSON-serializable dict suitable for XCom.
-
-        We deliberately drop per-case ``message`` blobs from the summary
-        pushed to XCom (they can be huge); full detail stays in logs.
-        """
+        """A compact, JSON-serializable dict suitable for XCom."""
         data = asdict(self)
         data.pop("cases", None)
         data["success"] = self.success

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -107,7 +107,7 @@ class PytestOperator(BaseOperator):
             if artifacts.report_path is None:
                 stderr_text = artifacts.stderr or "<empty>"
                 if len(stderr_text) > self._MAX_STDERR_LEN:
-                    stderr_text = stderr_text[:self._MAX_STDERR_LEN] + "...(truncated)"
+                    stderr_text = stderr_text[: self._MAX_STDERR_LEN] + "...(truncated)"
 
                 raise TestExecutionError(
                     f"pytest produced no report for {type(self._parser).__name__} "

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -57,6 +57,8 @@ class PytestOperator(BaseOperator):
     template_fields: Sequence[str] = ("test_path", "pytest_args", "env")
     ui_color = "#4caf50"
 
+    _MAX_STDERR_LEN = 4096
+
     def __init__(
         self,
         *,
@@ -83,6 +85,10 @@ class PytestOperator(BaseOperator):
             self.test_path,
             pytest_args=self.pytest_args,
             env=self.env,
+            # The parser decides which pytest flags to add and where the
+            # report will land; the runner just splices and reports back.
+            # This is what keeps the runner format-agnostic.
+            report_request=self._parser.report_request,
         )
 
         # Surface child output in the task log regardless of outcome.
@@ -98,20 +104,25 @@ class PytestOperator(BaseOperator):
         run_ok = False
         try:
             # No report means pytest never got far enough to write one
-            # (collection error, internal crash, OOM kill, wrong path).
+            # (collection error, internal crash, OOM kill, wrong path,
+            # missing report-plugin for the configured parser).
             # This is an *execution* failure, not a test failure -- surface
             # it clearly with the captured stderr, not a cryptic parse error.
-            if artifacts.junit_xml_path is None:
+            if artifacts.report_path is None:
+                stderr_text = artifacts.stderr or "<empty>"
+                if len(stderr_text) > self._MAX_STDERR_LEN:
+                    stderr_text = stderr_text[:self._MAX_STDERR_LEN] + "...(truncated)"
+
                 raise TestExecutionError(
-                    "pytest produced no JUnit report "
+                    f"pytest produced no report for {type(self._parser).__name__} "
                     f"(exit code {artifacts.exit_code}). "
                     "This usually means a collection error or crash before "
                     "any test ran. Captured stderr:\n"
-                    f"{artifacts.stderr or '<empty>'}"
+                    f"{stderr_text}"
                 )
 
             result = self._parser.parse(
-                artifacts.junit_xml_path, exit_code=artifacts.exit_code
+                artifacts.report_path, exit_code=artifacts.exit_code
             )
 
             self.log.info(

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -81,28 +81,24 @@ class PytestOperator(BaseOperator):
     def execute(self, context: Any) -> dict[str, Any]:
         self.log.info("Running pytest on %s", self.test_path)
 
-        artifacts = self._runner.run(
-            self.test_path,
-            pytest_args=self.pytest_args,
-            env=self.env,
-            # The parser decides which pytest flags to add and where the
-            # report will land; the runner just splices and reports back.
-            # This is what keeps the runner format-agnostic.
-            report_request=self._parser.report_request,
-        )
-
-        # Surface child output in the task log regardless of outcome.
-        if artifacts.stdout:
-            self.log.info("pytest stdout:\n%s", artifacts.stdout)
-        if artifacts.stderr:
-            self.log.warning("pytest stderr:\n%s", artifacts.stderr)
-
-        # ``run_ok`` drives the runner's cleanup policy ("on_success").
-        # It stays False until we've parsed a report whose tests all passed,
-        # so any early exit (missing report, failing tests) is treated as a
-        # failure and artifacts can be retained for post-mortem.
         run_ok = False
         try:
+            artifacts = self._runner.run(
+                self.test_path,
+                pytest_args=self.pytest_args,
+                env=self.env,
+                # The parser decides which pytest flags to add and where the
+                # report will land; the runner just splices and reports back.
+                # This is what keeps the runner format-agnostic.
+                report_request=self._parser.report_request,
+            )
+
+            # Surface child output in the task log regardless of outcome.
+            if artifacts.stdout:
+                self.log.info("pytest stdout:\n%s", artifacts.stdout)
+            if artifacts.stderr:
+                self.log.warning("pytest stderr:\n%s", artifacts.stderr)
+
             # No report means pytest never got far enough to write one
             # (collection error, internal crash, OOM kill, wrong path,
             # missing report-plugin for the configured parser).

--- a/src/airflow_pytest_operator/reporters/__init__.py
+++ b/src/airflow_pytest_operator/reporters/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .base import ResultParser
+from .json_parser import JSONResultParser
 from .junit_parser import JUnitResultParser
 
-__all__ = ["ResultParser", "JUnitResultParser"]
+__all__ = ["ResultParser", "JUnitResultParser", "JSONResultParser"]

--- a/src/airflow_pytest_operator/reporters/base.py
+++ b/src/airflow_pytest_operator/reporters/base.py
@@ -24,11 +24,41 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from ..models import TestRunResult
+from ..models import ReportRequest, TestRunResult
 
 
 class ResultParser(ABC):
-    """Parses a report file into a structured result."""
+    """Parses a report file into a structured result.
+
+    A parser owns two responsibilities:
+
+    * declare *what it needs* pytest to produce -- the CLI flags and the
+      path where the report will land -- via :meth:`report_request`;
+    * *interpret* that report into a :class:`TestRunResult` via
+      :meth:`parse`.
+
+    Together these let the operator stay format-agnostic: it asks the
+    parser for a :class:`ReportRequest`, hands it to the runner, and
+    feeds the resulting path back to the parser. Adding a new format
+    (JSON, TAP, ...) is a new parser, not an edit of the runner.
+    """
+
+    @abstractmethod
+    def report_request(self, report_dir: str) -> ReportRequest:
+        """Declare the pytest args and report path for this parser.
+
+        ``report_dir`` is a directory the runner has prepared and into
+        which the parser may place its report file. The implementation
+        composes a path inside that directory (or returns ``None`` for
+        ``report_path`` if it reads stdout) and the pytest CLI args that
+        make pytest emit a report at that path.
+
+        The returned :class:`ReportRequest` is opaque to the runner --
+        it splices ``pytest_args`` verbatim and reports back whatever
+        ``report_path`` was declared (or ``None`` if the file is missing
+        after the run, e.g. on a collection error).
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
@@ -36,7 +66,7 @@ class ResultParser(ABC):
 
         ``exit_code`` is threaded through so the result records how the
         process actually terminated (a parser can't always infer e.g.
-        an internal pytest error from the XML alone).
+        an internal pytest error from the report alone).
 
         Raises :class:`ReportParseError` if the file is missing or malformed.
         """

--- a/src/airflow_pytest_operator/reporters/json_parser.py
+++ b/src/airflow_pytest_operator/reporters/json_parser.py
@@ -35,12 +35,15 @@ negatives.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any
 
 from ..exceptions import ReportParseError
 from ..models import CaseResult, ReportRequest, TestRunResult
 from .base import ResultParser
+
+_log = logging.getLogger(__name__)
 
 # pytest-json-report outcomes map onto our four canonical states. xfail
 # (expected failure, did fail) and xpass without strict (expected failure,
@@ -55,9 +58,28 @@ _OUTCOME_MAP = {
     "xpassed": "passed",
 }
 
+# Default for outcomes we don't recognize. Deliberately "skipped", not
+# "error": if a future pytest-json-report adds a new state (e.g. "deselected",
+# "warned"), classifying it as an error would flip a clean run to failed and
+# raise TestsFailedError on previously-green suites. "skipped" is the only
+# bucket that's both honest ("we didn't count this as a real pass or fail")
+# and non-fatal. Drift doesn't go silent though -- we log a WARNING the
+# first time each unknown outcome appears, so a real schema change still
+# shows up in worker logs rather than being papered over forever.
+_UNKNOWN_OUTCOME_FALLBACK = "skipped"
+
 
 class JSONResultParser(ResultParser):
-    """Parse pytest-json-report output into a :class:`TestRunResult`."""
+    """Parse pytest-json-report output into a :class:`TestRunResult`.
+
+    The output filename is fixed (``REPORT_FILENAME``) inside whatever
+    directory the runner provides. If the same ``report_dir`` is reused
+    across runs, each new pytest invocation overwrites the previous
+    report -- there is no per-run uniquification at the parser level.
+    Callers that need to retain historical reports should give the
+    runner a fresh ``report_dir`` per run (the default temp-dir behavior
+    does this automatically).
+    """
 
     REPORT_FILENAME = "report.json"
 
@@ -69,6 +91,26 @@ class JSONResultParser(ResultParser):
         )
 
     def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
+        """Parse a pytest-json-report document into a :class:`TestRunResult`.
+
+        Counter sourcing: when the document has a ``summary`` block (the
+        common case), ``total``/``passed``/``failed``/``skipped``/``errors``
+        come from there. Otherwise we count the entries we parsed out of
+        ``tests[]``. The ``cases`` list always reflects only the entries
+        in ``tests[]``.
+
+        These two can disagree -- typically when the run was interrupted
+        (early exit, ``--collect-only``, internal crash): the summary
+        records the collected total while ``tests[]`` only lists the cases
+        that actually ran. The summary stays authoritative for counts
+        because it reflects intent; ``cases`` stays authoritative for
+        per-case detail because that's all we have. The upshot is that
+        ``len(result.cases) == result.total`` is **not** an invariant
+        callers may rely on -- compare against ``result.passed +
+        result.failed + result.skipped + result.errors`` instead, or use
+        ``failed_node_ids`` (which is always derived from ``cases``).
+        """
+
         if not report_path or not os.path.exists(report_path):
             raise ReportParseError(f"JSON report not found: {report_path!r}")
 
@@ -85,32 +127,76 @@ class JSONResultParser(ResultParser):
                 f"JSON report {report_path!r} is not an object at the root"
             )
 
+        # Track unknown outcomes seen in this report so we can WARN once per
+        # distinct value instead of spamming the log for every test in a big
+        # suite that drifted.
+        unknown_outcomes_seen: set[str] = set()
+
+        raw_tests = doc.get("tests", [])
+        if not isinstance(raw_tests, list):
+            raise ReportParseError(
+                f"JSON report {report_path!r} has non-list 'tests' field "
+                f"(got {type(raw_tests).__name__})"
+            )
+
         cases: list[CaseResult] = []
-        for raw in doc.get("tests", []):
+        for raw in raw_tests:
             if isinstance(raw, dict):
-                cases.append(self._parse_case(raw))
+                cases.append(self._parse_case(raw, unknown_outcomes_seen))
+
+        if unknown_outcomes_seen:
+            _log.warning(
+                "JSON report %r contained outcome(s) not in the parser's "
+                "mapping (%s); each was treated as %r. This usually means "
+                "pytest-json-report added a new outcome value -- please file "
+                "an issue against airflow-pytest-operator so the mapping is "
+                "updated.",
+                report_path,
+                ", ".join(sorted(unknown_outcomes_seen)),
+                _UNKNOWN_OUTCOME_FALLBACK,
+            )
 
         # Prefer the report's own summary counters when present -- they
         # include collected-but-not-run cases that "tests[]" can miss --
         # and fall back to counting our parsed cases. This keeps the
         # numbers stable on partially-completed runs.
+        bad_summary_keys: list[str] = []
+
+        def coerce(key: str, *, default: int = 0) -> int:
+            return _coerce_int(
+                summary.get(key),
+                default=default,
+                _bad=bad_summary_keys,
+                _key=key,
+            )
+
         summary = doc.get("summary") or {}
         if isinstance(summary, dict) and summary:
-            total = _coerce_int(summary.get("total"), default=len(cases))
-            passed = _coerce_int(summary.get("passed"))
-            failed = _coerce_int(summary.get("failed"))
-            errors = _coerce_int(summary.get("error"))
-            skipped = _coerce_int(summary.get("skipped")) + _coerce_int(
-                summary.get("xfailed")
-            )
-            # xpassed counts as passed in our mapping; reflect it here too.
-            passed += _coerce_int(summary.get("xpassed"))
+            total = coerce("total", default=len(cases))
+            passed = coerce("passed")
+            failed = coerce("failed")
+            errors = coerce("error")  # pytest-json-report uses singular
+            skipped = coerce("skipped") + coerce("xfailed")
+            # xpassed counts as passed in our mapping. NB: with strict
+            # xfail, pytest-json-report classifies the unexpected pass as
+            # "failed" instead and removes it from xpassed -- so there is
+            # no double-count to worry about. See test_xpassed_strict.
+            passed += coerce("xpassed")
         else:
             total = len(cases)
             passed = sum(1 for c in cases if c.outcome == "passed")
             failed = sum(1 for c in cases if c.outcome == "failed")
             errors = sum(1 for c in cases if c.outcome == "error")
             skipped = sum(1 for c in cases if c.outcome == "skipped")
+
+        if bad_summary_keys:
+            _log.warning(
+                "JSON report %r had non-numeric value(s) in summary keys "
+                "(%s); each was treated as 0. The report is likely "
+                "malformed or from an incompatible plugin version.",
+                report_path,
+                ", ".join(sorted(set(bad_summary_keys))),
+            )
 
         # Top-level "duration" is the whole pytest run including
         # collection -- more accurate than summing per-test durations,
@@ -132,10 +218,19 @@ class JSONResultParser(ResultParser):
         )
 
     @staticmethod
-    def _parse_case(raw: dict[str, Any]) -> CaseResult:
+    def _parse_case(
+        raw: dict[str, Any],
+        unknown_outcomes_seen: set[str],
+    ) -> CaseResult:
         nodeid = str(raw.get("nodeid", "") or "")
         outcome_raw = str(raw.get("outcome", "") or "")
-        outcome = _OUTCOME_MAP.get(outcome_raw, "error")
+        outcome = _OUTCOME_MAP.get(outcome_raw)
+        if outcome is None:
+            # Unknown outcome -- record it for the one-shot warning above
+            # and fall back to a non-fatal classification. See the comment
+            # on _UNKNOWN_OUTCOME_FALLBACK for the rationale.
+            unknown_outcomes_seen.add(outcome_raw)
+            outcome = _UNKNOWN_OUTCOME_FALLBACK
 
         call = raw.get("call") or {}
         try:
@@ -162,10 +257,29 @@ class JSONResultParser(ResultParser):
         )
 
 
-def _coerce_int(value: Any, *, default: int = 0) -> int:
+def _coerce_int(
+    value: Any,
+    *,
+    default: int = 0,
+    _bad: list[str] | None = None,
+    _key: str | None = None,
+) -> int:
+    """Best-effort int coercion with optional drift-tracking.
+
+    A missing key (``value is None``) is **not** drift -- a partial summary
+    is normal (zero tests of a kind ran). A *present-but-non-numeric* value
+    IS drift: it means the report's shape is wrong. When ``_bad`` and
+    ``_key`` are supplied, that case records the key into ``_bad`` so the
+    caller can WARN once with the full list rather than silently zero out
+    structural errors.
+    """
+    if value is None:
+        return default
     try:
         return int(value)
     except (TypeError, ValueError):
+        if _bad is not None and _key is not None:
+            _bad.append(_key)
         return default
 
 
@@ -179,6 +293,10 @@ def _extract_message(raw: dict[str, Any], outcome: str) -> str | None:
     """
     if outcome == "passed":
         return None
+
+    if outcome == "skipped":
+        return _extract_skip_reason(raw)
+
     for phase in ("call", "setup", "teardown"):
         section = raw.get(phase)
         if not isinstance(section, dict):
@@ -191,4 +309,49 @@ def _extract_message(raw: dict[str, Any], outcome: str) -> str | None:
             msg = crash.get("message")
             if isinstance(msg, str) and msg.strip():
                 return msg.strip()
+    return None
+
+
+def _extract_skip_reason(raw: dict[str, Any]) -> str | None:
+    """Pull the clean skip reason out of a pytest-json-report skipped entry.
+
+    The plugin records skips with longrepr set to the *repr* (not JSON
+    serialization) of a 3-tuple ``(filename, lineno, 'Skipped: reason')``.
+    We try to recover just the reason; on any mismatch we fall back to
+    returning the raw longrepr so callers at least see something rather
+    than ``None`` -- this keeps the parser tolerant to schema drift
+    (the plugin may eventually switch to a structured object).
+    """
+
+    for phase in ("setup", "call"):
+        section = raw.get(phase)
+        if not isinstance(section, dict):
+            continue
+        longrepr = section.get("longrepr")
+        if not isinstance(longrepr, str) or not longrepr.strip():
+            continue
+
+        text = longrepr.strip()
+
+        # Try the structured shape first. ast.literal_eval safely parses
+        # the repr of a tuple without executing arbitrary code (unlike
+        # eval()), and refuses anything that isn't a Python literal.
+        try:
+            import ast
+
+            parsed = ast.literal_eval(text)
+        except (ValueError, SyntaxError, MemoryError):
+            parsed = None
+
+        if isinstance(parsed, tuple) and len(parsed) == 3:
+            reason = parsed[2]
+            if isinstance(reason, str):
+                # Strip the conventional "Skipped: " prefix the plugin
+                # bakes in so users get just the reason they wrote.
+                if reason.startswith("Skipped: "):
+                    reason = reason[len("Skipped: ") :]
+                return reason.strip() or None
+
+        return text
+
     return None

--- a/src/airflow_pytest_operator/reporters/json_parser.py
+++ b/src/airflow_pytest_operator/reporters/json_parser.py
@@ -1,0 +1,194 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JSON result parser using pytest-json-report.
+
+Parses the JSON document emitted by the ``pytest-json-report`` plugin
+(``--json-report --json-report-file=...``). The plugin must be available
+on the worker that runs the tests; install via the ``json-report`` extra::
+
+    pip install airflow-pytest-operator[json-report]
+
+If the plugin is missing, pytest itself exits with a usage error
+("unrecognized arguments: --json-report"), the runner returns
+``report_path=None``, and the operator surfaces the captured stderr via
+``TestExecutionError`` -- the existing error path for "the run could not
+produce a report". We deliberately do not probe for the plugin at parser
+construction time: the parser lives in the operator's process while
+pytest-json-report is needed wherever the runner spawns pytest, which
+may be a different environment entirely (e.g. a Kubernetes pod started
+by a custom runner). Validating in the wrong place would produce false
+negatives.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from ..exceptions import ReportParseError
+from ..models import CaseResult, ReportRequest, TestRunResult
+from .base import ResultParser
+
+# pytest-json-report outcomes map onto our four canonical states. xfail
+# (expected failure, did fail) and xpass without strict (expected failure,
+# unexpectedly passed) are treated as skipped/passed respectively, matching
+# how pytest's JUnit dialect classifies them.
+_OUTCOME_MAP = {
+    "passed": "passed",
+    "failed": "failed",
+    "error": "error",
+    "skipped": "skipped",
+    "xfailed": "skipped",
+    "xpassed": "passed",
+}
+
+
+class JSONResultParser(ResultParser):
+    """Parse pytest-json-report output into a :class:`TestRunResult`."""
+
+    REPORT_FILENAME = "report.json"
+
+    def report_request(self, report_dir: str) -> ReportRequest:
+        path = os.path.join(report_dir, self.REPORT_FILENAME)
+        return ReportRequest(
+            pytest_args=("--json-report", f"--json-report-file={path}"),
+            report_path=path,
+        )
+
+    def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
+        if not report_path or not os.path.exists(report_path):
+            raise ReportParseError(f"JSON report not found: {report_path!r}")
+
+        try:
+            with open(report_path, encoding="utf-8") as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ReportParseError(
+                f"Failed to parse JSON report {report_path!r}: {exc}"
+            ) from exc
+
+        if not isinstance(doc, dict):
+            raise ReportParseError(
+                f"JSON report {report_path!r} is not an object at the root"
+            )
+
+        cases: list[CaseResult] = []
+        for raw in doc.get("tests", []):
+            if isinstance(raw, dict):
+                cases.append(self._parse_case(raw))
+
+        # Prefer the report's own summary counters when present -- they
+        # include collected-but-not-run cases that "tests[]" can miss --
+        # and fall back to counting our parsed cases. This keeps the
+        # numbers stable on partially-completed runs.
+        summary = doc.get("summary") or {}
+        if isinstance(summary, dict) and summary:
+            total = _coerce_int(summary.get("total"), default=len(cases))
+            passed = _coerce_int(summary.get("passed"))
+            failed = _coerce_int(summary.get("failed"))
+            errors = _coerce_int(summary.get("error"))
+            skipped = _coerce_int(summary.get("skipped")) + _coerce_int(
+                summary.get("xfailed")
+            )
+            # xpassed counts as passed in our mapping; reflect it here too.
+            passed += _coerce_int(summary.get("xpassed"))
+        else:
+            total = len(cases)
+            passed = sum(1 for c in cases if c.outcome == "passed")
+            failed = sum(1 for c in cases if c.outcome == "failed")
+            errors = sum(1 for c in cases if c.outcome == "error")
+            skipped = sum(1 for c in cases if c.outcome == "skipped")
+
+        # Top-level "duration" is the whole pytest run including
+        # collection -- more accurate than summing per-test durations,
+        # which omit collection time entirely.
+        try:
+            duration = float(doc.get("duration", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            duration = 0.0
+
+        return TestRunResult(
+            total=total,
+            passed=passed,
+            failed=failed,
+            skipped=skipped,
+            errors=errors,
+            duration=round(duration, 4),
+            exit_code=exit_code,
+            cases=cases,
+        )
+
+    @staticmethod
+    def _parse_case(raw: dict[str, Any]) -> CaseResult:
+        nodeid = str(raw.get("nodeid", "") or "")
+        outcome_raw = str(raw.get("outcome", "") or "")
+        outcome = _OUTCOME_MAP.get(outcome_raw, "error")
+
+        call = raw.get("call") or {}
+        try:
+            time = (
+                float(call.get("duration", 0.0) or 0.0)
+                if isinstance(call, dict)
+                else 0.0
+            )
+        except (TypeError, ValueError):
+            time = 0.0
+
+        message = _extract_message(raw, outcome)
+
+        # The nodeid already carries the full pytest-style identifier
+        # ("tests/test_x.py::test_y"). We put it in `name` and leave
+        # `classname` empty so CaseResult.node_id returns the nodeid
+        # verbatim via the no-classname fallback.
+        return CaseResult(
+            name=nodeid,
+            classname="",
+            time=time,
+            outcome=outcome,
+            message=message,
+        )
+
+
+def _coerce_int(value: Any, *, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _extract_message(raw: dict[str, Any], outcome: str) -> str | None:
+    """Pull a short failure/error/skip message out of the test record.
+
+    pytest-json-report stores diagnostic text in ``longrepr`` on whichever
+    phase failed -- ``call`` for test-body failures, ``setup`` for fixture
+    errors and skips, ``teardown`` for teardown errors. We probe call →
+    setup → teardown in that order. ``passed`` cases never carry a message.
+    """
+    if outcome == "passed":
+        return None
+    for phase in ("call", "setup", "teardown"):
+        section = raw.get(phase)
+        if not isinstance(section, dict):
+            continue
+        longrepr = section.get("longrepr")
+        if isinstance(longrepr, str) and longrepr.strip():
+            return longrepr.strip()
+        crash = section.get("crash")
+        if isinstance(crash, dict):
+            msg = crash.get("message")
+            if isinstance(msg, str) and msg.strip():
+                return msg.strip()
+    return None

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -42,12 +42,21 @@ except Exception:  # pragma: no cover - fallback path
     from xml.etree.ElementTree import parse as _xml_parse
 
 from ..exceptions import ReportParseError
-from ..models import CaseResult, TestRunResult
+from ..models import CaseResult, ReportRequest, TestRunResult
 from .base import ResultParser
 
 
 class JUnitResultParser(ResultParser):
     """Parse pytest's JUnit XML into a :class:`TestRunResult`."""
+
+    REPORT_FILENAME = "junit.xml"
+
+    def report_request(self, report_dir: str) -> ReportRequest:
+        path = os.path.join(report_dir, self.REPORT_FILENAME)
+        return ReportRequest(
+            pytest_args=(f"--junitxml={path}", "-o", "junit_logging=all"),
+            report_path=path,
+        )
 
     def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
         if not report_path or not os.path.exists(report_path):

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -3,18 +3,6 @@
 Parses the JUnit XML that pytest emits via ``--junitxml``. We use the
 stdlib ``xml.etree`` with ``defusedxml`` when available to avoid XML
 attack vectors on untrusted reports.
-
-JUnit structure recap (pytest dialect)::
-
-    <testsuites>
-      <testsuite tests=".." failures=".." errors=".." skipped=".." time="..">
-        <testcase classname=".." name=".." time="..">
-          <failure message="..">..</failure>   # optional
-          <error message="..">..</error>        # optional
-          <skipped message="..">..</skipped>    # optional
-        </testcase>
-      </testsuite>
-    </testsuites>
 """
 
 # Copyright 2026 the airflow-pytest-operator contributors
@@ -47,7 +35,16 @@ from .base import ResultParser
 
 
 class JUnitResultParser(ResultParser):
-    """Parse pytest's JUnit XML into a :class:`TestRunResult`."""
+    """Parse pytest's JUnit XML into a :class:`TestRunResult`.
+
+    The output filename is fixed (``REPORT_FILENAME``) inside whatever
+    directory the runner provides. If the same ``report_dir`` is reused
+    across runs, each new pytest invocation overwrites the previous
+    report -- there is no per-run uniquification at the parser level.
+    Callers that need to retain historical reports should give the
+    runner a fresh ``report_dir`` per run (the default temp-dir behavior
+    does this automatically).
+    """
 
     REPORT_FILENAME = "junit.xml"
 

--- a/src/airflow_pytest_operator/runners/base.py
+++ b/src/airflow_pytest_operator/runners/base.py
@@ -25,9 +25,9 @@ in later without changing the operator.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
-from ..models import RunArtifacts
+from ..models import ReportRequest, RunArtifacts
 
 
 class PytestRunner(ABC):
@@ -40,16 +40,21 @@ class PytestRunner(ABC):
         *,
         pytest_args: Sequence[str] | None = None,
         env: dict[str, str] | None = None,
+        report_request: Callable[[str], ReportRequest],
     ) -> RunArtifacts:
         """Run pytest and return where to find its outputs.
 
         Implementations MUST:
-          * always produce a JUnit XML path (or set it to None and a
-            non-zero exit code if the run could not start),
-          * never raise on *test* failure — a failing test is a valid
+          * always set ``RunArtifacts.report_path`` to the parser-declared
+            path on success, or ``None`` if the run could not produce it,
+          * never raise on *test* failure -- a failing test is a valid
             outcome reflected in ``exit_code``,
           * raise :class:`TestExecutionError` only when pytest itself
             could not be launched.
+
+        ``report_request`` is keyword-only and required -- there is no
+        sensible default ("just run pytest with no report" produces
+        artifacts no parser can consume).
         """
         raise NotImplementedError
 

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -96,6 +96,12 @@ class SubprocessPytestRunner(PytestRunner):
         remove it on success; ``"never"`` — never remove it (e.g. when it is
         uploaded as a CI artifact). A user-supplied ``report_dir`` is never
         removed under any policy. Invalid values raise :class:`ValueError`.
+    :param max_output_bytes: per-stream cap (in bytes) on captured
+        ``stdout``/``stderr``. Default 10 MiB. Once a stream's captured
+        size reaches the cap, further chunks from that stream are dropped
+        (but the pipe is still drained so the child never blocks on a full
+        buffer), and the returned text is suffixed with a one-line marker
+        noting the cap. Pass ``None`` to disable the cap. Must be positive.
     """
 
     def __init__(
@@ -107,11 +113,17 @@ class SubprocessPytestRunner(PytestRunner):
         cwd: str | None = None,
         grace_period: float = 10.0,
         cleanup: str = "always",
+        max_output_bytes: int | None = 10 * 1024 * 1024,
     ) -> None:
         if cleanup not in ("always", "on_success", "never"):
             raise ValueError(
                 "cleanup must be one of 'always', 'on_success', 'never'; "
                 f"got {cleanup!r}"
+            )
+        if max_output_bytes is not None and max_output_bytes <= 0:
+            raise ValueError(
+                "max_output_bytes must be a positive integer or None; "
+                f"got {max_output_bytes!r}"
             )
         # Default to the worker's own interpreter -> same venv/deps.
         self._python = python_executable or sys.executable
@@ -120,6 +132,7 @@ class SubprocessPytestRunner(PytestRunner):
         self._cwd = cwd
         self._grace_period = grace_period
         self._cleanup = cleanup
+        self._max_output_bytes = max_output_bytes
 
         # Cleanup bookkeeping. We only ever delete a directory we created
         # ourselves via mkdtemp; a user-supplied report_dir is their data
@@ -290,8 +303,15 @@ class SubprocessPytestRunner(PytestRunner):
 
         stdout_chunks: list[str] = []
         stderr_chunks: list[str] = []
+        # Per-stream truncation bookkeeping: [bytes_captured, truncated].
+        # Lists are used as cheap mutable boxes shared with the drainer
+        # thread; reads/writes happen only inside one drainer per stream,
+        # so no extra locking is required.
+        stdout_state: list[int] = [0, 0]
+        stderr_state: list[int] = [0, 0]
+        max_bytes = self._max_output_bytes
 
-        def _drain(stream: Any, sink: list[str]) -> None:
+        def _drain(stream: Any, sink: list[str], state: list[int]) -> None:
             # readline() is the right primitive here: it returns chunks as
             # they arrive (line-buffered), doesn't block waiting for EOF,
             # and exits cleanly when the pipe closes. read() would buffer
@@ -299,7 +319,11 @@ class SubprocessPytestRunner(PytestRunner):
             # long-running suite.
             try:
                 for chunk in iter(stream.readline, ""):
-                    sink.append(chunk)
+                    if max_bytes is None or state[0] < max_bytes:
+                        sink.append(chunk)
+                        state[0] += len(chunk.encode("utf-8", errors="replace"))
+                        if max_bytes is not None and state[0] >= max_bytes:
+                            state[1] = 1
             except (ValueError, OSError) as e:
                 _log.warning(e)
             finally:
@@ -311,10 +335,10 @@ class SubprocessPytestRunner(PytestRunner):
         # daemon=True so a stuck drainer never blocks interpreter exit; in
         # practice they always exit because the child closes the pipe.
         stdout_thread = threading.Thread(
-            target=_drain, args=(proc.stdout, stdout_chunks), daemon=True
+            target=_drain, args=(proc.stdout, stdout_chunks, stdout_state), daemon=True
         )
         stderr_thread = threading.Thread(
-            target=_drain, args=(proc.stderr, stderr_chunks), daemon=True
+            target=_drain, args=(proc.stderr, stderr_chunks, stderr_state), daemon=True
         )
         stdout_thread.start()
         stderr_thread.start()
@@ -349,6 +373,16 @@ class SubprocessPytestRunner(PytestRunner):
 
         stdout = "".join(stdout_chunks)
         stderr = "".join(stderr_chunks)
+        if stdout_state[1]:
+            stdout += (
+                f"\n...(stdout truncated at {max_bytes} bytes; "
+                "Update SubprocessPytestRunner.max_output_bytes to capture more)"
+            )
+        if stderr_state[1]:
+            stderr += (
+                f"\n...(stderr truncated at {max_bytes} bytes; "
+                "Update SubprocessPytestRunner.max_output_bytes to capture more)"
+            )
 
         if timed_out:
             if stdout:

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -288,24 +288,62 @@ class SubprocessPytestRunner(PytestRunner):
             # Terminate outside the lock (graceful wait must not hold it).
             self._terminate(proc)
 
+        stdout_chunks: list[str] = []
+        stderr_chunks: list[str] = []
+
+        def _drain(stream: Any, sink: list[str]) -> None:
+            try:
+                for chunk in iter(stream.readline, ""):
+                    sink.append(chunk)
+            except (ValueError, OSError) as e:
+                _log.warning(e)
+            finally:
+                try:
+                    stream.close()
+                except Exception as e:  # noqa: BLE001 - best-effort
+                    _log.warning(e)
+
+        # daemon=True so a stuck drainer never blocks interpreter exit; in
+        # practice they always exit because the child closes the pipe.
+        stdout_thread = threading.Thread(
+            target=_drain, args=(proc.stdout, stdout_chunks), daemon=True
+        )
+        stderr_thread = threading.Thread(
+            target=_drain, args=(proc.stderr, stderr_chunks), daemon=True
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+
+        timed_out = False
         try:
-            stdout, stderr = proc.communicate(timeout=self._timeout)
-        except subprocess.TimeoutExpired as exc:
+            proc.wait(timeout=self._timeout)
+        except subprocess.TimeoutExpired:
             # Timeout is an execution failure, but we still must not leave
             # the tree running -- reuse the same group-kill path.
+            timed_out = True
             self._terminate(proc)
-
-            tail_stdout, tail_stderr = proc.communicate()
-            if tail_stdout:
-                _log.warning("pytest stdout captured before timeout:\n%s", tail_stdout)
-            if tail_stderr:
-                _log.warning("pytest stderr captured before timeout:\n%s", tail_stderr)
-            raise TestExecutionError(
-                f"pytest run timed out after {self._timeout}s"
-            ) from exc
         finally:
             with self._lock:
                 self._proc = None
+
+        # Wait for the drainer threads to finish collecting. Once the child
+        # is dead, the kernel closes the pipe; readline() then returns "",
+        # the iter() sentinel triggers, and the thread exits. We give it a
+        # bounded wait so a hung drainer cannot wedge the runner forever
+        # -- under that condition we lose the tail but the run still
+        # returns rather than hanging.
+        stdout_thread.join(timeout=5.0)
+        stderr_thread.join(timeout=5.0)
+
+        stdout = "".join(stdout_chunks)
+        stderr = "".join(stderr_chunks)
+
+        if timed_out:
+            if stdout:
+                _log.warning("pytest stdout captured before timeout:\n%s", stdout)
+            if stderr:
+                _log.warning("pytest stderr captured before timeout:\n%s", stderr)
+            raise TestExecutionError(f"pytest run timed out after {self._timeout}s")
 
         produced: str | None = None
         if spec.report_path is not None and os.path.exists(spec.report_path):

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -22,11 +22,11 @@ import subprocess
 import sys
 import tempfile
 import threading
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any
 
 from ..exceptions import TestExecutionError
-from ..models import RunArtifacts
+from ..models import ReportRequest, RunArtifacts
 from .base import PytestRunner
 
 _IS_WINDOWS = os.name == "nt"
@@ -47,10 +47,11 @@ class SubprocessPytestRunner(PytestRunner):
     ``xdist`` workers and subprocesses spawned by tests) can be terminated
     together on cancel or timeout.
 
-    The runner only ever adds ``--junitxml`` (and ``-o junit_logging=all``)
-    to the pytest invocation; all other configuration — plugins such as
-    Allure, ``addopts``, markers — is discovered by pytest itself from the
-    test tree's ``pytest.ini`` / ``pyproject.toml`` as usual.
+    The runner is format-agnostic: it does not know whether the report
+    is JUnit XML, JSON, or anything else. The parser declares its CLI
+    args and report path via the ``report_request`` callback the operator
+    passes to :meth:`run`; the runner splices those args into the pytest
+    invocation and returns the declared path in :class:`RunArtifacts`.
 
     Concurrency model
     -----------------
@@ -73,16 +74,19 @@ class SubprocessPytestRunner(PytestRunner):
         process. On expiry the process tree is terminated and
         :class:`TestExecutionError` is raised; the run is never left
         orphaned.
-    :param report_dir: directory for the JUnit report. If given, it is used
-        as-is and **never removed** by :meth:`cleanup` (it is treated as
-        user-owned data). If omitted, a unique temporary directory is
-        created per run and is subject to the ``cleanup`` policy.
+    :param report_dir: directory for the report file requested by the
+        parser. If given, it is used as-is and **never removed** by
+        :meth:`cleanup` (it is treated as user-owned data). If omitted, a
+        unique temporary directory is created per run and is subject to
+        the ``cleanup`` policy. The filename inside the directory is
+        chosen by the parser, not the runner.
     :param cwd: working directory for the pytest process. If omitted, it is
         derived from ``test_path`` (a directory target becomes the cwd, a
         file target's parent becomes the cwd) so that relative paths in
         pytest ``addopts`` — e.g. Allure's ``--alluredir`` — resolve next to
-        the tests rather than against the worker's cwd. The absolute JUnit
-        path is unaffected.
+        the tests rather than against the worker's cwd. The parser-declared
+        report path is unaffected (parsers compose it from the absolute
+        ``report_dir``).
     :param grace_period: seconds to wait after ``SIGTERM`` before escalating
         to ``SIGKILL`` when terminating the process tree (default 10.0).
     :param cleanup: temporary-directory cleanup policy, one of:
@@ -167,6 +171,7 @@ class SubprocessPytestRunner(PytestRunner):
         *,
         pytest_args: Sequence[str] | None = None,
         env: dict[str, str] | None = None,
+        report_request: Callable[[str], ReportRequest],
     ) -> RunArtifacts:
         # Enforce the single-run contract atomically. A second concurrent
         # run() on the SAME instance would race on the per-run state stored
@@ -186,7 +191,12 @@ class SubprocessPytestRunner(PytestRunner):
             self._cancelled = False  # reset stale cancel from a prior run
 
         try:
-            return self._run_locked(test_path, pytest_args=pytest_args, env=env)
+            return self._run_locked(
+                test_path,
+                pytest_args=pytest_args,
+                env=env,
+                report_request=report_request,
+            )
         finally:
             with self._lock:
                 self._running = False
@@ -197,6 +207,7 @@ class SubprocessPytestRunner(PytestRunner):
         *,
         pytest_args: Sequence[str] | None = None,
         env: dict[str, str] | None = None,
+        report_request: Callable[[str], ReportRequest],
     ) -> RunArtifacts:
         if self._report_dir is not None:
             report_dir = self._report_dir
@@ -210,7 +221,11 @@ class SubprocessPytestRunner(PytestRunner):
             raise TestExecutionError(
                 f"Could not prepare report directory {report_dir!r}: {exc}"
             ) from exc
-        junit_path = os.path.join(report_dir, "junit.xml")
+
+        # Ask the parser what flags to add and where the report will land.
+        # The runner never interprets the result -- it splices the args
+        # verbatim and reports back whatever path the parser declared.
+        spec = report_request(report_dir)
 
         effective_cwd = self._resolve_cwd(test_path)
 
@@ -219,10 +234,7 @@ class SubprocessPytestRunner(PytestRunner):
             "-m",
             "pytest",
             test_path,
-            f"--junitxml={junit_path}",
-            # -o junit_logging makes failure messages land in the XML.
-            "-o",
-            "junit_logging=all",
+            *spec.pytest_args,
         ]
         if pytest_args:
             cmd.extend(pytest_args)
@@ -295,10 +307,12 @@ class SubprocessPytestRunner(PytestRunner):
             with self._lock:
                 self._proc = None
 
-        produced = junit_path if os.path.exists(junit_path) else None
+        produced: str | None = None
+        if spec.report_path is not None and os.path.exists(spec.report_path):
+            produced = spec.report_path
         return RunArtifacts(
             exit_code=proc.returncode,
-            junit_xml_path=produced,
+            report_path=produced,
             stdout=stdout or "",
             stderr=stderr or "",
             working_dir=report_dir,

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -292,6 +292,11 @@ class SubprocessPytestRunner(PytestRunner):
         stderr_chunks: list[str] = []
 
         def _drain(stream: Any, sink: list[str]) -> None:
+            # readline() is the right primitive here: it returns chunks as
+            # they arrive (line-buffered), doesn't block waiting for EOF,
+            # and exits cleanly when the pipe closes. read() would buffer
+            # the entire stream first, which defeats the purpose for a
+            # long-running suite.
             try:
                 for chunk in iter(stream.readline, ""):
                     sink.append(chunk)
@@ -322,6 +327,13 @@ class SubprocessPytestRunner(PytestRunner):
             # the tree running -- reuse the same group-kill path.
             timed_out = True
             self._terminate(proc)
+        except BaseException:
+            # BaseException (not Exception) on purpose -- AirflowTaskTimeout
+            # is an Exception but KeyboardInterrupt is BaseException, and
+            # neither should leak a subprocess. We re-raise without altering
+            # the type, so Airflow still sees its own AirflowTaskTimeout.
+            self._terminate(proc)
+            raise
         finally:
             with self._lock:
                 self._proc = None

--- a/tests/test_base_interfaces.py
+++ b/tests/test_base_interfaces.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import pytest
 
-from airflow_pytest_operator.models import RunArtifacts, TestRunResult
+from airflow_pytest_operator.models import ReportRequest, RunArtifacts, TestRunResult
 from airflow_pytest_operator.reporters.base import ResultParser
 from airflow_pytest_operator.runners.base import PytestRunner
 
@@ -33,11 +33,21 @@ from airflow_pytest_operator.runners.base import PytestRunner
 class _MinimalRunner(PytestRunner):
     """Implements only the abstract ``run``; inherits default cancel/cleanup."""
 
-    def run(self, test_path, *, pytest_args=None, env=None):
-        return RunArtifacts(exit_code=0, junit_xml_path=None)
+    def run(self, test_path, *, pytest_args=None, env=None, report_request):
+        # Honour the contract: ask the parser for its spec even if we don't
+        # actually run pytest, to prove the wiring works end-to-end.
+        spec = report_request("/tmp/fake_report_dir")
+        assert isinstance(spec, ReportRequest)
+        return RunArtifacts(exit_code=0, report_path=None)
 
 
 class _MinimalParser(ResultParser):
+    def report_request(self, report_dir):
+        return ReportRequest(
+            pytest_args=("--minimal-fake-flag",),
+            report_path=None,
+        )
+
     def parse(self, report_path, *, exit_code=0):
         return TestRunResult(
             total=0,
@@ -64,16 +74,28 @@ def test_default_cleanup_is_noop_and_safe():
 
 def test_minimal_runner_run_works():
     runner = _MinimalRunner()
-    artifacts = runner.run("tests/")
+    parser = _MinimalParser()
+    artifacts = runner.run("tests/", report_request=parser.report_request)
+    print(f"artifacts: exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
     assert artifacts.exit_code == 0
-    assert artifacts.junit_xml_path is None
+    assert artifacts.report_path is None
 
 
 def test_minimal_parser_parse_works():
     parser = _MinimalParser()
     result = parser.parse("/some/report.xml", exit_code=0)
+    print(f"result: total={result.total}, success={result.success}, exit_code={result.exit_code}")
     assert result.total == 0
     assert result.success is True
+
+
+def test_minimal_parser_report_request_works():
+    parser = _MinimalParser()
+    spec = parser.report_request("/tmp/x")
+    print(f"spec: pytest_args={spec.pytest_args}, report_path={spec.report_path!r}")
+    assert isinstance(spec, ReportRequest)
+    assert spec.pytest_args == ("--minimal-fake-flag",)
+    assert spec.report_path is None
 
 
 def test_abstract_classes_cannot_be_instantiated_directly():
@@ -83,3 +105,20 @@ def test_abstract_classes_cannot_be_instantiated_directly():
         PytestRunner()  # type: ignore[abstract]
     with pytest.raises(TypeError):
         ResultParser()  # type: ignore[abstract]
+
+
+def test_parser_with_only_parse_cannot_be_instantiated():
+    class _OnlyParse(ResultParser):  # type: ignore[abstract]
+        def parse(self, report_path, *, exit_code=0):
+            return TestRunResult(
+                total=0,
+                passed=0,
+                failed=0,
+                skipped=0,
+                errors=0,
+                duration=0.0,
+                exit_code=exit_code,
+            )
+
+    with pytest.raises(TypeError):
+        _OnlyParse()  # type: ignore[abstract]

--- a/tests/test_base_interfaces.py
+++ b/tests/test_base_interfaces.py
@@ -76,7 +76,9 @@ def test_minimal_runner_run_works():
     runner = _MinimalRunner()
     parser = _MinimalParser()
     artifacts = runner.run("tests/", report_request=parser.report_request)
-    print(f"artifacts: exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
+    print(
+        f"artifacts: exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}"
+    )
     assert artifacts.exit_code == 0
     assert artifacts.report_path is None
 
@@ -84,7 +86,9 @@ def test_minimal_runner_run_works():
 def test_minimal_parser_parse_works():
     parser = _MinimalParser()
     result = parser.parse("/some/report.xml", exit_code=0)
-    print(f"result: total={result.total}, success={result.success}, exit_code={result.exit_code}")
+    print(
+        f"result: total={result.total}, success={result.success}, exit_code={result.exit_code}"
+    )
     assert result.total == 0
     assert result.success is True
 

--- a/tests/test_base_interfaces.py
+++ b/tests/test_base_interfaces.py
@@ -103,8 +103,6 @@ def test_minimal_parser_report_request_works():
 
 
 def test_abstract_classes_cannot_be_instantiated_directly():
-    # Both interfaces declare abstract methods, so direct instantiation must
-    # fail -- proving they are genuine ABCs, not accidentally concrete.
     with pytest.raises(TypeError):
         PytestRunner()  # type: ignore[abstract]
     with pytest.raises(TypeError):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -83,14 +83,12 @@ def test_get_airflow_version_handles_nonnumeric_chunks(monkeypatch):
     ver_mod = _fake_module("airflow.version", version="2.x.0")
     monkeypatch.setitem(sys.modules, "airflow.version", ver_mod)
     try:
-        # Non-numeric chunk -> 0 in that slot, rest parsed normally.
         assert compat.get_airflow_version() == (2, 0, 0)
     finally:
         compat.get_airflow_version.cache_clear()
 
 
 def test_get_airflow_version_returns_zero_when_unavailable(monkeypatch):
-    # If airflow.version cannot be imported, fall back to (0,).
     compat.get_airflow_version.cache_clear()
     monkeypatch.setitem(sys.modules, "airflow.version", None)
     try:
@@ -135,9 +133,6 @@ def test_import_base_operator_falls_back_to_models_baseoperator(monkeypatch):
 
 
 def test_import_base_operator_raises_diagnostic_when_all_fail(monkeypatch):
-    # When every known path is unimportable, a single diagnostic ImportError
-    # is raised that lists each attempted path -- not a confusing internal
-    # traceback from Airflow's deprecation shim.
     monkeypatch.setitem(sys.modules, "airflow.sdk.bases.operator", None)
     monkeypatch.setitem(sys.modules, "airflow.sdk", None)
     monkeypatch.setitem(sys.modules, "airflow.models.baseoperator", None)
@@ -150,7 +145,6 @@ def test_import_base_operator_raises_diagnostic_when_all_fail(monkeypatch):
 
 
 def test_apply_defaults_uses_airflow_decorator_when_present(monkeypatch):
-    # Step where airflow.utils.decorators.apply_defaults exists: we return it.
     sentinel = object()
     decorators = _fake_module("airflow.utils.decorators", apply_defaults=sentinel)
     monkeypatch.setitem(sys.modules, "airflow.utils.decorators", decorators)
@@ -158,8 +152,6 @@ def test_apply_defaults_uses_airflow_decorator_when_present(monkeypatch):
 
 
 def test_apply_defaults_passthrough_when_absent(monkeypatch):
-    # When apply_defaults is unavailable (Airflow 3.x), we return a
-    # passthrough decorator that leaves the function unchanged.
     monkeypatch.setitem(sys.modules, "airflow.utils.decorators", None)
     passthrough = compat._import_apply_defaults()
 

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -90,7 +90,12 @@ def test_parses_mixed_outcomes(tmp_path):
     )
     result = JSONResultParser().parse(report, exit_code=1)
     print(
-        f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}"
+        f"result: total={result.total}, "
+        f"passed={result.passed}, "
+        f"failed={result.failed}, "
+        f"skipped={result.skipped}, "
+        f"errors={result.errors}, "
+        f"success={result.success}"
     )
     print(f"failed_node_ids: {result.failed_node_ids}")
 
@@ -119,8 +124,6 @@ def test_parses_all_passing(tmp_path):
 
 
 def test_parses_errors_in_fixture(tmp_path):
-    # An exception raised in setup shows up as "error" on the JSON side,
-    # mirroring the JUnit dialect. Validates the outcome map covers it.
     report = _make_json(
         tmp_path,
         """
@@ -140,10 +143,6 @@ def test_parses_errors_in_fixture(tmp_path):
 
 
 def test_nodeid_round_trips_through_failed_node_ids(tmp_path):
-    # The whole point of failed_node_ids is to be re-fed to pytest via -k or
-    # as a positional arg. The plugin's "nodeid" is already in pytest's own
-    # canonical form (file::test), so we store it verbatim and the value
-    # must round-trip without losing the "::" structure.
     report = _make_json(
         tmp_path,
         """
@@ -155,16 +154,10 @@ def test_nodeid_round_trips_through_failed_node_ids(tmp_path):
     nid = result.failed_node_ids[0]
     print(f"node_id: {nid!r}")
     assert "::test_x" in nid
-    # Confirm it's not the synthesized "classname::name" form that JUnit
-    # produces -- with no classname, CaseResult.node_id returns name as-is,
-    # which means the JSON parser must put the full nodeid in `name`.
     assert nid.endswith("::test_x")
 
 
 def test_xfail_is_treated_as_skipped(tmp_path):
-    # @pytest.mark.xfail with a failing body produces outcome "xfailed",
-    # which we fold into "skipped" so callers don't have to know about the
-    # extra states (same shape as the JUnit parser).
     report = _make_json(
         tmp_path,
         """
@@ -192,9 +185,6 @@ def test_failure_message_is_captured(tmp_path):
     failed = [c for c in result.cases if c.outcome == "failed"]
     assert len(failed) == 1
     print(f"failure message: {failed[0].message!r}")
-    # longrepr includes the assertion text in some form. We don't pin the
-    # exact format (it changes between pytest versions) -- only that we
-    # surfaced *something* useful instead of leaving the message None.
     assert failed[0].message is not None
     assert failed[0].message.strip() != ""
 
@@ -212,9 +202,6 @@ def test_malformed_json_raises(tmp_path):
 
 
 def test_non_object_root_raises(tmp_path):
-    # The schema requires the root to be an object. A bare list or scalar
-    # is a sign someone handed us the wrong file (e.g. a JUnit XML report
-    # they renamed, or a custom result format).
     bad = tmp_path / "bad.json"
     bad.write_text("[1, 2, 3]")
     with pytest.raises(ReportParseError):
@@ -222,9 +209,6 @@ def test_non_object_root_raises(tmp_path):
 
 
 def test_to_xcom_is_serializable(tmp_path):
-    # Same XCom-safety check we apply to the JUnit parser. The result
-    # dataclass is identical, so this mostly defends against future
-    # JSON-side changes that might sneak a non-JSON-safe field in.
     report = _make_json(tmp_path, "def test_x(): assert True")
     result = JSONResultParser().parse(report)
     payload = result.to_xcom()
@@ -234,19 +218,12 @@ def test_to_xcom_is_serializable(tmp_path):
     assert payload["success"] is True
 
 
-# ---------------------------------------------------------------------------
-# report_request: the parser's declaration of what pytest must produce
-# ---------------------------------------------------------------------------
-
-
 def test_report_request_returns_expected_spec(tmp_path):
     spec = JSONResultParser().report_request(str(tmp_path))
     print(f"spec: report_path={spec.report_path!r}, pytest_args={spec.pytest_args}")
 
     expected_path = str(tmp_path / "report.json")
     assert spec.report_path == expected_path
-    # The flags come in two tokens, not three -- pytest-json-report combines
-    # the toggle and the path into a single --json-report-file=... value.
     assert spec.pytest_args == (
         "--json-report",
         f"--json-report-file={expected_path}",
@@ -268,14 +245,6 @@ def test_report_request_composes_path_inside_given_dir(tmp_path):
     assert Path(spec.report_path).parent == nested
 
 
-# ---------------------------------------------------------------------------
-# Parity check with JUnit: the two built-in parsers are not bit-identical
-# (collection-error semantics differ, durations are measured differently)
-# but for a *clean* run on the same suite they must agree on the summary
-# counts. This guards both parsers against silent drift.
-# ---------------------------------------------------------------------------
-
-
 def test_summary_matches_junit_for_passing_suite(tmp_path):
     from airflow_pytest_operator.reporters import JUnitResultParser
 
@@ -291,7 +260,6 @@ def test_summary_matches_junit_for_passing_suite(tmp_path):
     suite = tmp_path / "test_pair.py"
     suite.write_text(textwrap.dedent(suite_src))
 
-    # Same suite, both parsers, both reports produced in one pytest run.
     junit_spec = JUnitResultParser().report_request(str(tmp_path))
     json_spec = JSONResultParser().report_request(str(tmp_path))
     subprocess.run(
@@ -318,20 +286,11 @@ def test_summary_matches_junit_for_passing_suite(tmp_path):
         f"json:   total={json_result.total}, passed={json_result.passed}, failed={json_result.failed}, skipped={json_result.skipped}, errors={json_result.errors}"
     )
 
-    # Counts must agree; durations and exact failure messages can drift.
     assert junit.total == json_result.total == 4
     assert junit.passed == json_result.passed == 2
     assert junit.failed == json_result.failed == 1
     assert junit.skipped == json_result.skipped == 1
     assert junit.errors == json_result.errors == 0
-
-
-# ---------------------------------------------------------------------------
-# Defensive branches: malformed or partial reports. We can't easily provoke
-# these via real pytest-json-report output, so they use hand-crafted JSON
-# blobs. They protect the parser against schema drift and third-party tools
-# that emit pytest-json-report-like documents with edge cases.
-# ---------------------------------------------------------------------------
 
 
 def _write_json(tmp_path: Path, payload: dict) -> str:
@@ -341,8 +300,6 @@ def _write_json(tmp_path: Path, payload: dict) -> str:
 
 
 def test_summary_falls_back_to_counted_cases_when_absent(tmp_path):
-    # When "summary" is missing or empty, the parser counts the parsed cases
-    # itself rather than reporting zero everything.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -351,7 +308,6 @@ def test_summary_falls_back_to_counted_cases_when_absent(tmp_path):
             {"nodeid": "f.py::c", "outcome": "skipped"},
             {"nodeid": "f.py::d", "outcome": "error"},
         ],
-        # no "summary" key at all
     }
     result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=1)
     assert result.total == 4
@@ -362,8 +318,6 @@ def test_summary_falls_back_to_counted_cases_when_absent(tmp_path):
 
 
 def test_malformed_duration_degrades_to_zero(tmp_path):
-    # A non-numeric top-level "duration" must not sink the parse -- mirrors
-    # the JUnit parser's tolerance for a bad `time` attribute.
     payload = {
         "duration": "not-a-number",
         "tests": [
@@ -393,8 +347,6 @@ def test_malformed_call_duration_degrades_to_zero(tmp_path):
 
 
 def test_non_dict_call_section_handled(tmp_path):
-    # If "call" is somehow not a dict (e.g. None, or a stray string), the
-    # per-case duration must default to 0 instead of raising AttributeError.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -407,24 +359,13 @@ def test_non_dict_call_section_handled(tmp_path):
 
 
 def test_unknown_outcome_maps_to_skipped_with_warning(tmp_path, caplog):
-    # An outcome we don't recognize (future plugin extension, custom hook)
-    # is conservatively folded into "skipped" -- NOT "error" or "failed".
-    # Reasoning: an unknown value most likely means pytest-json-report added
-    # a new state; defaulting to "error" would flip previously-green runs to
-    # red and raise TestsFailedError on the operator side. "skipped" is the
-    # only bucket that's both honest ("we didn't count this as a real pass
-    # or fail") and non-fatal. To stop drift from going silent, the parser
-    # logs a WARNING the first time each unknown outcome is observed.
     import logging as _logging
 
     payload = {
         "duration": 0.0,
         "tests": [
             {"nodeid": "f.py::a", "outcome": "mystery", "call": {"duration": 0.0}},
-            # A second test with the SAME unknown outcome must not produce
-            # a second warning -- we dedupe per report.
             {"nodeid": "f.py::b", "outcome": "mystery", "call": {"duration": 0.0}},
-            # A different unknown outcome IS reported alongside the first.
             {"nodeid": "f.py::c", "outcome": "weirder", "call": {"duration": 0.0}},
         ],
     }
@@ -432,13 +373,9 @@ def test_unknown_outcome_maps_to_skipped_with_warning(tmp_path, caplog):
         result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
 
     assert all(c.outcome == "skipped" for c in result.cases)
-    # The run is not marked failed by an unknown outcome: this is the whole
-    # point of the safer default.
     assert result.failed == 0
     assert result.errors == 0
     assert result.skipped == 3
-    # One WARNING covers both distinct unknown values; the dedupe means the
-    # log doesn't explode on a large drifted suite.
     warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
     assert len(warnings) == 1
     msg = warnings[0].getMessage()
@@ -446,8 +383,6 @@ def test_unknown_outcome_maps_to_skipped_with_warning(tmp_path, caplog):
 
 
 def test_message_pulled_from_setup_when_call_missing(tmp_path):
-    # A fixture error has longrepr on the "setup" phase, not "call". Verify
-    # the call → setup → teardown probe order picks it up.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -463,9 +398,6 @@ def test_message_pulled_from_setup_when_call_missing(tmp_path):
 
 
 def test_message_pulled_from_crash_when_longrepr_absent(tmp_path):
-    # Some pytest-json-report builds emit a structured "crash" object on
-    # failures instead of a free-text "longrepr". The parser falls back to
-    # crash.message so the failure isn't silent.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -484,9 +416,6 @@ def test_message_pulled_from_crash_when_longrepr_absent(tmp_path):
 
 
 def test_non_dict_test_entries_skipped(tmp_path):
-    # If "tests" contains garbage (a string, a number), those entries are
-    # quietly skipped rather than crashing the parse. The real cases are
-    # still produced.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -501,9 +430,6 @@ def test_non_dict_test_entries_skipped(tmp_path):
 
 
 def test_xpassed_counts_as_passed(tmp_path):
-    # xpassed (unexpected pass when xfail was marked) is folded into the
-    # "passed" bucket -- both in case-level mapping AND in the summary path
-    # (where it lives under its own counter). Test exercises both.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -516,19 +442,7 @@ def test_xpassed_counts_as_passed(tmp_path):
     assert result.cases[0].outcome == "passed"
 
 
-# ---------------------------------------------------------------------------
-# Structural validation: malformed inputs should fail loudly with
-# ReportParseError, not with random TypeError/AttributeError from deep
-# inside the parser. These guard against drift in the document shape.
-# ---------------------------------------------------------------------------
-
-
 def test_non_list_tests_raises_report_parse_error(tmp_path):
-    # If "tests" is not a list (scalar, dict, null), the parser must not
-    # plough into a for-loop and crash with TypeError. The user gets a
-    # single, catchable exception type for "this report is malformed".
-    # Null is rejected too: pytest-json-report writes [] for a run with
-    # zero tests, never null, so null is structurally suspect.
     for bad_value in ("not a list", 42, {"nope": True}, None):
         path = _write_json(tmp_path, {"tests": bad_value, "duration": 0.0})
         with pytest.raises(ReportParseError, match="non-list 'tests'"):
@@ -536,10 +450,6 @@ def test_non_list_tests_raises_report_parse_error(tmp_path):
 
 
 def test_malformed_summary_value_warns_once(tmp_path, caplog):
-    # A present-but-non-numeric value in a summary counter is a structural
-    # mismatch with the schema. We coerce to 0 to keep going, but log a
-    # WARNING so silent-zero counts don't disguise a malformed report.
-    # Repeated bad keys deduplicate into a single warning line.
     import logging as _logging
 
     payload = {
@@ -549,18 +459,16 @@ def test_malformed_summary_value_warns_once(tmp_path, caplog):
         ],
         "summary": {
             "total": 1,
-            "passed": "yes please",  # bad
-            "failed": "no thanks",  # bad
+            "passed": "yes please",
+            "failed": "no thanks",
             "skipped": 0,
         },
     }
     with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
         result = JSONResultParser().parse(_write_json(tmp_path, payload))
 
-    # Bad values silently coerced to 0 -- the run keeps going.
     assert result.passed == 0
     assert result.failed == 0
-    # ...but one WARNING surfaced, listing every offending key.
     warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
     assert len(warnings) == 1
     msg = warnings[0].getMessage()
@@ -570,10 +478,6 @@ def test_malformed_summary_value_warns_once(tmp_path, caplog):
 
 
 def test_missing_summary_key_does_not_warn(tmp_path, caplog):
-    # A *missing* counter is normal -- means "zero tests of that kind".
-    # It must not trigger the malformed-summary warning, only a non-numeric
-    # value should. This is the key invariant separating "partial report"
-    # from "broken report".
     import logging as _logging
 
     payload = {
@@ -581,20 +485,12 @@ def test_missing_summary_key_does_not_warn(tmp_path, caplog):
         "tests": [
             {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.0}},
         ],
-        "summary": {"total": 1, "passed": 1},  # 'failed', 'error', 'skipped' absent
+        "summary": {"total": 1, "passed": 1},
     }
     with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
         JSONResultParser().parse(_write_json(tmp_path, payload))
     warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
     assert warnings == []
-
-
-# ---------------------------------------------------------------------------
-# Skip-message extraction: pytest-json-report stores the skip reason as the
-# repr of a 3-tuple (filename, lineno, 'Skipped: reason'). The parser must
-# return the bare reason, not the tuple repr -- otherwise user-facing
-# CaseResult.message reads like an error rather than a clean explanation.
-# ---------------------------------------------------------------------------
 
 
 def test_skipped_message_is_clean_reason_not_tuple(tmp_path):
@@ -612,15 +508,11 @@ def test_skipped_message_is_clean_reason_not_tuple(tmp_path):
     assert len(skipped) == 1
     msg = skipped[0].message
     assert msg == "not relevant in this env"
-    # Negative assertions: the tuple repr leakage we're guarding against.
     assert "(" not in msg
     assert "Skipped:" not in msg
 
 
 def test_skipped_message_falls_back_on_schema_drift(tmp_path):
-    # If pytest-json-report ever switches to a non-tuple longrepr (a plain
-    # string), the parser must still return *something* useful rather
-    # than swallowing the message. Fallback: hand back the text as-is.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -639,10 +531,6 @@ def test_skipped_message_falls_back_on_schema_drift(tmp_path):
 
 
 def test_skipped_message_handles_unsafe_input(tmp_path):
-    # ast.literal_eval refuses anything that isn't a Python literal -- if
-    # the longrepr is structurally weird (e.g. someone hand-crafted a
-    # report with code-looking text), we must NOT execute it and must NOT
-    # crash. The fallback returns the raw text.
     payload = {
         "duration": 0.0,
         "tests": [
@@ -657,14 +545,10 @@ def test_skipped_message_handles_unsafe_input(tmp_path):
         ],
     }
     result = JSONResultParser().parse(_write_json(tmp_path, payload))
-    # Did not execute, did not crash, returned the literal text.
     assert "__import__" in result.cases[0].message
 
 
 def test_skipped_via_pytest_skip_in_body(tmp_path):
-    # When pytest.skip(...) is called from the test body (not setup),
-    # the longrepr lands on "call". The fallback probe order must pick
-    # it up so users still see a clean reason.
     report = _make_json(
         tmp_path,
         """
@@ -680,15 +564,6 @@ def test_skipped_via_pytest_skip_in_body(tmp_path):
     assert skipped[0].message == "computed reason at runtime"
 
 
-# ---------------------------------------------------------------------------
-# xpassed under strict xfail: pytest-json-report classifies the unexpected
-# pass as "failed" (not "xpassed") when strict=True. This means our
-# summary-arithmetic (passed += summary["xpassed"]) does NOT double-count
-# strict cases. This test pins that invariant so a future plugin change
-# can't quietly break it.
-# ---------------------------------------------------------------------------
-
-
 def test_xpassed_strict_counts_as_failed_not_xpassed(tmp_path):
     report = _make_json(
         tmp_path,
@@ -699,15 +574,9 @@ def test_xpassed_strict_counts_as_failed_not_xpassed(tmp_path):
         def test_actually_passes(): assert True
         """,
     )
-    # exit_code=1 because strict-xpass is a failure as far as pytest is
-    # concerned (it's the whole point of strict).
     result = JSONResultParser().parse(report, exit_code=1)
 
-    # Strict xpass: counted as a failure, not a pass, not an xpassed.
     assert result.failed == 1
     assert result.passed == 0
     assert result.skipped == 0
-    # If the plugin ever started ALSO incrementing "xpassed" for strict
-    # cases, our summary-arithmetic would yield passed=1 -- catching this
-    # in CI before it leaks to users.
     assert result.success is False

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -1,0 +1,320 @@
+"""Parser tests against real pytest-json-report output.
+
+Same approach as test_junit_parser.py: we run pytest on tiny throwaway
+suites with the json-report plugin, then assert the parser interprets
+the resulting JSON correctly. Catches drift in the plugin's schema far
+better than hand-crafted JSON fixtures would.
+
+These tests require the ``pytest-json-report`` plugin, which is part of
+the package's ``[json-report]`` extra and is also pulled in by ``[dev]``.
+If the plugin is missing the tests skip cleanly rather than failing.
+"""
+
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from airflow_pytest_operator.exceptions import ReportParseError
+from airflow_pytest_operator.reporters import JSONResultParser
+
+# Skip the entire module if the plugin isn't on the path. The parser itself
+# does not require pytest-json-report to be importable (it just parses
+# whatever JSON it is handed), but every test below needs a *real* report
+# to assert against -- and we generate those by actually running pytest
+# with the plugin. No plugin -> no real fixtures -> nothing meaningful to
+# assert.
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("pytest_jsonreport") is None,
+    reason="pytest-json-report not installed; install via [json-report] or [dev] extra",
+)
+
+
+def _make_json(tmp_path: Path, suite_src: str) -> str:
+    """Run pytest on a throwaway suite and return the JSON report path.
+
+    Flags come from ``JSONResultParser().report_request(...)`` -- same
+    principle as ``_make_junit`` in ``test_junit_parser.py``. Hardcoding
+    them in two places is exactly the kind of drift 0.4.0's
+    ``report_request`` abstraction is meant to prevent.
+    """
+    suite = tmp_path / "test_sample.py"
+    suite.write_text(textwrap.dedent(suite_src))
+
+    parser = JSONResultParser()
+    spec = parser.report_request(str(tmp_path))
+
+    subprocess.run(
+        [sys.executable, "-m", "pytest", str(suite), *spec.pytest_args, "-q"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert spec.report_path is not None
+    report = Path(spec.report_path)
+    assert report.exists(), "pytest did not produce a JSON report"
+    return str(report)
+
+
+def test_parses_mixed_outcomes(tmp_path):
+    report = _make_json(
+        tmp_path,
+        """
+        import pytest
+
+        def test_pass(): assert True
+        def test_fail(): assert 1 == 2
+        @pytest.mark.skip(reason="nope")
+        def test_skip(): pass
+    """,
+    )
+    result = JSONResultParser().parse(report, exit_code=1)
+    print(f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}")
+    print(f"failed_node_ids: {result.failed_node_ids}")
+
+    assert result.total == 3
+    assert result.passed == 1
+    assert result.failed == 1
+    assert result.skipped == 1
+    assert result.errors == 0
+    assert result.success is False
+    assert result.exit_code == 1
+    assert any("test_fail" in nid for nid in result.failed_node_ids)
+
+
+def test_parses_all_passing(tmp_path):
+    report = _make_json(
+        tmp_path,
+        """
+        def test_a(): assert True
+        def test_b(): assert True
+    """,
+    )
+    result = JSONResultParser().parse(report, exit_code=0)
+    assert result.success is True
+    assert result.passed == 2
+    assert result.failed_node_ids == []
+
+
+def test_parses_errors_in_fixture(tmp_path):
+    # An exception raised in setup shows up as "error" on the JSON side,
+    # mirroring the JUnit dialect. Validates the outcome map covers it.
+    report = _make_json(
+        tmp_path,
+        """
+        import pytest
+
+        @pytest.fixture
+        def broken():
+            raise RuntimeError("boom")
+
+        def test_uses_broken(broken): pass
+    """,
+    )
+    result = JSONResultParser().parse(report, exit_code=1)
+    print(f"result: errors={result.errors}, success={result.success}")
+    assert result.errors >= 1
+    assert result.success is False
+
+
+def test_nodeid_round_trips_through_failed_node_ids(tmp_path):
+    # The whole point of failed_node_ids is to be re-fed to pytest via -k or
+    # as a positional arg. The plugin's "nodeid" is already in pytest's own
+    # canonical form (file::test), so we store it verbatim and the value
+    # must round-trip without losing the "::" structure.
+    report = _make_json(
+        tmp_path,
+        """
+        def test_x(): assert False
+    """,
+    )
+    result = JSONResultParser().parse(report, exit_code=1)
+    assert len(result.failed_node_ids) == 1
+    nid = result.failed_node_ids[0]
+    print(f"node_id: {nid!r}")
+    assert "::test_x" in nid
+    # Confirm it's not the synthesized "classname::name" form that JUnit
+    # produces -- with no classname, CaseResult.node_id returns name as-is,
+    # which means the JSON parser must put the full nodeid in `name`.
+    assert nid.endswith("::test_x")
+
+
+def test_xfail_is_treated_as_skipped(tmp_path):
+    # @pytest.mark.xfail with a failing body produces outcome "xfailed",
+    # which we fold into "skipped" so callers don't have to know about the
+    # extra states (same shape as the JUnit parser).
+    report = _make_json(
+        tmp_path,
+        """
+        import pytest
+
+        @pytest.mark.xfail
+        def test_expected_failure(): assert False
+    """,
+    )
+    result = JSONResultParser().parse(report, exit_code=0)
+    assert result.skipped == 1
+    assert result.failed == 0
+
+
+def test_failure_message_is_captured(tmp_path):
+    report = _make_json(
+        tmp_path,
+        """
+        def test_fail():
+            x = 1
+            assert x == 999, "x was not 999"
+    """,
+    )
+    result = JSONResultParser().parse(report, exit_code=1)
+    failed = [c for c in result.cases if c.outcome == "failed"]
+    assert len(failed) == 1
+    print(f"failure message: {failed[0].message!r}")
+    # longrepr includes the assertion text in some form. We don't pin the
+    # exact format (it changes between pytest versions) -- only that we
+    # surfaced *something* useful instead of leaving the message None.
+    assert failed[0].message is not None
+    assert failed[0].message.strip() != ""
+
+
+def test_missing_report_raises():
+    with pytest.raises(ReportParseError):
+        JSONResultParser().parse("/nonexistent/report.json")
+
+
+def test_malformed_json_raises(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{this is not valid json")
+    with pytest.raises(ReportParseError):
+        JSONResultParser().parse(str(bad))
+
+
+def test_non_object_root_raises(tmp_path):
+    # The schema requires the root to be an object. A bare list or scalar
+    # is a sign someone handed us the wrong file (e.g. a JUnit XML report
+    # they renamed, or a custom result format).
+    bad = tmp_path / "bad.json"
+    bad.write_text("[1, 2, 3]")
+    with pytest.raises(ReportParseError):
+        JSONResultParser().parse(str(bad))
+
+
+def test_to_xcom_is_serializable(tmp_path):
+    # Same XCom-safety check we apply to the JUnit parser. The result
+    # dataclass is identical, so this mostly defends against future
+    # JSON-side changes that might sneak a non-JSON-safe field in.
+    report = _make_json(tmp_path, "def test_x(): assert True")
+    result = JSONResultParser().parse(report)
+    payload = result.to_xcom()
+    print(f"xcom payload: {payload}")
+    json.dumps(payload)
+    assert "cases" not in payload
+    assert payload["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# report_request: the parser's declaration of what pytest must produce
+# ---------------------------------------------------------------------------
+
+
+def test_report_request_returns_expected_spec(tmp_path):
+    spec = JSONResultParser().report_request(str(tmp_path))
+    print(f"spec: report_path={spec.report_path!r}, pytest_args={spec.pytest_args}")
+
+    expected_path = str(tmp_path / "report.json")
+    assert spec.report_path == expected_path
+    # The flags come in two tokens, not three -- pytest-json-report combines
+    # the toggle and the path into a single --json-report-file=... value.
+    assert spec.pytest_args == (
+        "--json-report",
+        f"--json-report-file={expected_path}",
+    )
+
+
+def test_report_request_uses_class_filename_constant(tmp_path):
+    parser = JSONResultParser()
+    spec = parser.report_request(str(tmp_path))
+    assert spec.report_path is not None
+    assert spec.report_path.endswith(parser.REPORT_FILENAME)
+
+
+def test_report_request_composes_path_inside_given_dir(tmp_path):
+    nested = tmp_path / "deep" / "nested"
+    nested.mkdir(parents=True)
+    spec = JSONResultParser().report_request(str(nested))
+    assert spec.report_path is not None
+    assert Path(spec.report_path).parent == nested
+
+
+# ---------------------------------------------------------------------------
+# Parity check with JUnit: the two built-in parsers are not bit-identical
+# (collection-error semantics differ, durations are measured differently)
+# but for a *clean* run on the same suite they must agree on the summary
+# counts. This guards both parsers against silent drift.
+# ---------------------------------------------------------------------------
+
+
+def test_summary_matches_junit_for_passing_suite(tmp_path):
+    from airflow_pytest_operator.reporters import JUnitResultParser
+
+    suite_src = """
+        import pytest
+
+        def test_a(): assert True
+        def test_b(): assert True
+        def test_c(): assert 1 == 2
+        @pytest.mark.skip(reason="nope")
+        def test_d(): pass
+    """
+    suite = tmp_path / "test_pair.py"
+    suite.write_text(textwrap.dedent(suite_src))
+
+    # Same suite, both parsers, both reports produced in one pytest run.
+    junit_spec = JUnitResultParser().report_request(str(tmp_path))
+    json_spec = JSONResultParser().report_request(str(tmp_path))
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(suite),
+            *junit_spec.pytest_args,
+            *json_spec.pytest_args,
+            "-q",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    junit = JUnitResultParser().parse(junit_spec.report_path, exit_code=1)
+    json_result = JSONResultParser().parse(json_spec.report_path, exit_code=1)
+    print(f"junit:  total={junit.total}, passed={junit.passed}, failed={junit.failed}, skipped={junit.skipped}, errors={junit.errors}")
+    print(f"json:   total={json_result.total}, passed={json_result.passed}, failed={json_result.failed}, skipped={json_result.skipped}, errors={json_result.errors}")
+
+    # Counts must agree; durations and exact failure messages can drift.
+    assert junit.total == json_result.total == 4
+    assert junit.passed == json_result.passed == 2
+    assert junit.failed == json_result.failed == 1
+    assert junit.skipped == json_result.skipped == 1
+    assert junit.errors == json_result.errors == 0

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -89,7 +89,9 @@ def test_parses_mixed_outcomes(tmp_path):
     """,
     )
     result = JSONResultParser().parse(report, exit_code=1)
-    print(f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}")
+    print(
+        f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}"
+    )
     print(f"failed_node_ids: {result.failed_node_ids}")
 
     assert result.total == 3
@@ -133,7 +135,7 @@ def test_parses_errors_in_fixture(tmp_path):
     )
     result = JSONResultParser().parse(report, exit_code=1)
     print(f"result: errors={result.errors}, success={result.success}")
-    assert result.errors >= 1
+    assert result.errors == 1
     assert result.success is False
 
 
@@ -309,8 +311,12 @@ def test_summary_matches_junit_for_passing_suite(tmp_path):
 
     junit = JUnitResultParser().parse(junit_spec.report_path, exit_code=1)
     json_result = JSONResultParser().parse(json_spec.report_path, exit_code=1)
-    print(f"junit:  total={junit.total}, passed={junit.passed}, failed={junit.failed}, skipped={junit.skipped}, errors={junit.errors}")
-    print(f"json:   total={json_result.total}, passed={json_result.passed}, failed={json_result.failed}, skipped={json_result.skipped}, errors={json_result.errors}")
+    print(
+        f"junit:  total={junit.total}, passed={junit.passed}, failed={junit.failed}, skipped={junit.skipped}, errors={junit.errors}"
+    )
+    print(
+        f"json:   total={json_result.total}, passed={json_result.passed}, failed={json_result.failed}, skipped={json_result.skipped}, errors={json_result.errors}"
+    )
 
     # Counts must agree; durations and exact failure messages can drift.
     assert junit.total == json_result.total == 4
@@ -318,3 +324,390 @@ def test_summary_matches_junit_for_passing_suite(tmp_path):
     assert junit.failed == json_result.failed == 1
     assert junit.skipped == json_result.skipped == 1
     assert junit.errors == json_result.errors == 0
+
+
+# ---------------------------------------------------------------------------
+# Defensive branches: malformed or partial reports. We can't easily provoke
+# these via real pytest-json-report output, so they use hand-crafted JSON
+# blobs. They protect the parser against schema drift and third-party tools
+# that emit pytest-json-report-like documents with edge cases.
+# ---------------------------------------------------------------------------
+
+
+def _write_json(tmp_path: Path, payload: dict) -> str:
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(payload))
+    return str(p)
+
+
+def test_summary_falls_back_to_counted_cases_when_absent(tmp_path):
+    # When "summary" is missing or empty, the parser counts the parsed cases
+    # itself rather than reporting zero everything.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.0}},
+            {"nodeid": "f.py::b", "outcome": "failed", "call": {"duration": 0.0}},
+            {"nodeid": "f.py::c", "outcome": "skipped"},
+            {"nodeid": "f.py::d", "outcome": "error"},
+        ],
+        # no "summary" key at all
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=1)
+    assert result.total == 4
+    assert result.passed == 1
+    assert result.failed == 1
+    assert result.skipped == 1
+    assert result.errors == 1
+
+
+def test_malformed_duration_degrades_to_zero(tmp_path):
+    # A non-numeric top-level "duration" must not sink the parse -- mirrors
+    # the JUnit parser's tolerance for a bad `time` attribute.
+    payload = {
+        "duration": "not-a-number",
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.0}},
+        ],
+        "summary": {"total": 1, "passed": 1},
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+    assert result.duration == 0.0
+    assert result.passed == 1
+
+
+def test_malformed_call_duration_degrades_to_zero(tmp_path):
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {
+                "nodeid": "f.py::a",
+                "outcome": "passed",
+                "call": {"duration": "boom"},
+            },
+        ],
+        "summary": {"total": 1, "passed": 1},
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+    assert result.cases[0].time == 0.0
+
+
+def test_non_dict_call_section_handled(tmp_path):
+    # If "call" is somehow not a dict (e.g. None, or a stray string), the
+    # per-case duration must default to 0 instead of raising AttributeError.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "passed", "call": None},
+        ],
+        "summary": {"total": 1, "passed": 1},
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+    assert result.cases[0].time == 0.0
+
+
+def test_unknown_outcome_maps_to_skipped_with_warning(tmp_path, caplog):
+    # An outcome we don't recognize (future plugin extension, custom hook)
+    # is conservatively folded into "skipped" -- NOT "error" or "failed".
+    # Reasoning: an unknown value most likely means pytest-json-report added
+    # a new state; defaulting to "error" would flip previously-green runs to
+    # red and raise TestsFailedError on the operator side. "skipped" is the
+    # only bucket that's both honest ("we didn't count this as a real pass
+    # or fail") and non-fatal. To stop drift from going silent, the parser
+    # logs a WARNING the first time each unknown outcome is observed.
+    import logging as _logging
+
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "mystery", "call": {"duration": 0.0}},
+            # A second test with the SAME unknown outcome must not produce
+            # a second warning -- we dedupe per report.
+            {"nodeid": "f.py::b", "outcome": "mystery", "call": {"duration": 0.0}},
+            # A different unknown outcome IS reported alongside the first.
+            {"nodeid": "f.py::c", "outcome": "weirder", "call": {"duration": 0.0}},
+        ],
+    }
+    with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
+        result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+
+    assert all(c.outcome == "skipped" for c in result.cases)
+    # The run is not marked failed by an unknown outcome: this is the whole
+    # point of the safer default.
+    assert result.failed == 0
+    assert result.errors == 0
+    assert result.skipped == 3
+    # One WARNING covers both distinct unknown values; the dedupe means the
+    # log doesn't explode on a large drifted suite.
+    warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "mystery" in msg and "weirder" in msg
+
+
+def test_message_pulled_from_setup_when_call_missing(tmp_path):
+    # A fixture error has longrepr on the "setup" phase, not "call". Verify
+    # the call → setup → teardown probe order picks it up.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {
+                "nodeid": "f.py::test_with_broken_fixture",
+                "outcome": "error",
+                "setup": {"duration": 0.0, "longrepr": "RuntimeError: broken"},
+            },
+        ],
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=1)
+    assert result.cases[0].message == "RuntimeError: broken"
+
+
+def test_message_pulled_from_crash_when_longrepr_absent(tmp_path):
+    # Some pytest-json-report builds emit a structured "crash" object on
+    # failures instead of a free-text "longrepr". The parser falls back to
+    # crash.message so the failure isn't silent.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {
+                "nodeid": "f.py::test_fail",
+                "outcome": "failed",
+                "call": {
+                    "duration": 0.0,
+                    "crash": {"message": "AssertionError: boom"},
+                },
+            },
+        ],
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=1)
+    assert result.cases[0].message == "AssertionError: boom"
+
+
+def test_non_dict_test_entries_skipped(tmp_path):
+    # If "tests" contains garbage (a string, a number), those entries are
+    # quietly skipped rather than crashing the parse. The real cases are
+    # still produced.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            "not a dict",
+            42,
+            {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.0}},
+        ],
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+    assert len(result.cases) == 1
+    assert result.cases[0].name == "f.py::a"
+
+
+def test_xpassed_counts_as_passed(tmp_path):
+    # xpassed (unexpected pass when xfail was marked) is folded into the
+    # "passed" bucket -- both in case-level mapping AND in the summary path
+    # (where it lives under its own counter). Test exercises both.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "xpassed", "call": {"duration": 0.0}},
+        ],
+        "summary": {"total": 1, "xpassed": 1},
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+    assert result.passed == 1
+    assert result.cases[0].outcome == "passed"
+
+
+# ---------------------------------------------------------------------------
+# Structural validation: malformed inputs should fail loudly with
+# ReportParseError, not with random TypeError/AttributeError from deep
+# inside the parser. These guard against drift in the document shape.
+# ---------------------------------------------------------------------------
+
+
+def test_non_list_tests_raises_report_parse_error(tmp_path):
+    # If "tests" is not a list (scalar, dict, null), the parser must not
+    # plough into a for-loop and crash with TypeError. The user gets a
+    # single, catchable exception type for "this report is malformed".
+    # Null is rejected too: pytest-json-report writes [] for a run with
+    # zero tests, never null, so null is structurally suspect.
+    for bad_value in ("not a list", 42, {"nope": True}, None):
+        path = _write_json(tmp_path, {"tests": bad_value, "duration": 0.0})
+        with pytest.raises(ReportParseError, match="non-list 'tests'"):
+            JSONResultParser().parse(path)
+
+
+def test_malformed_summary_value_warns_once(tmp_path, caplog):
+    # A present-but-non-numeric value in a summary counter is a structural
+    # mismatch with the schema. We coerce to 0 to keep going, but log a
+    # WARNING so silent-zero counts don't disguise a malformed report.
+    # Repeated bad keys deduplicate into a single warning line.
+    import logging as _logging
+
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.0}},
+        ],
+        "summary": {
+            "total": 1,
+            "passed": "yes please",  # bad
+            "failed": "no thanks",  # bad
+            "skipped": 0,
+        },
+    }
+    with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
+        result = JSONResultParser().parse(_write_json(tmp_path, payload))
+
+    # Bad values silently coerced to 0 -- the run keeps going.
+    assert result.passed == 0
+    assert result.failed == 0
+    # ...but one WARNING surfaced, listing every offending key.
+    warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "passed" in msg
+    assert "failed" in msg
+    assert "non-numeric" in msg
+
+
+def test_missing_summary_key_does_not_warn(tmp_path, caplog):
+    # A *missing* counter is normal -- means "zero tests of that kind".
+    # It must not trigger the malformed-summary warning, only a non-numeric
+    # value should. This is the key invariant separating "partial report"
+    # from "broken report".
+    import logging as _logging
+
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.0}},
+        ],
+        "summary": {"total": 1, "passed": 1},  # 'failed', 'error', 'skipped' absent
+    }
+    with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
+        JSONResultParser().parse(_write_json(tmp_path, payload))
+    warnings = [r for r in caplog.records if r.levelno == _logging.WARNING]
+    assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Skip-message extraction: pytest-json-report stores the skip reason as the
+# repr of a 3-tuple (filename, lineno, 'Skipped: reason'). The parser must
+# return the bare reason, not the tuple repr -- otherwise user-facing
+# CaseResult.message reads like an error rather than a clean explanation.
+# ---------------------------------------------------------------------------
+
+
+def test_skipped_message_is_clean_reason_not_tuple(tmp_path):
+    report = _make_json(
+        tmp_path,
+        """
+        import pytest
+
+        @pytest.mark.skip(reason="not relevant in this env")
+        def test_skipme(): pass
+        """,
+    )
+    result = JSONResultParser().parse(report, exit_code=0)
+    skipped = [c for c in result.cases if c.outcome == "skipped"]
+    assert len(skipped) == 1
+    msg = skipped[0].message
+    assert msg == "not relevant in this env"
+    # Negative assertions: the tuple repr leakage we're guarding against.
+    assert "(" not in msg
+    assert "Skipped:" not in msg
+
+
+def test_skipped_message_falls_back_on_schema_drift(tmp_path):
+    # If pytest-json-report ever switches to a non-tuple longrepr (a plain
+    # string), the parser must still return *something* useful rather
+    # than swallowing the message. Fallback: hand back the text as-is.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {
+                "nodeid": "f.py::test_x",
+                "outcome": "skipped",
+                "setup": {
+                    "duration": 0.0,
+                    "longrepr": "this is just a plain string, not a tuple repr",
+                },
+            },
+        ],
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload))
+    assert result.cases[0].message == "this is just a plain string, not a tuple repr"
+
+
+def test_skipped_message_handles_unsafe_input(tmp_path):
+    # ast.literal_eval refuses anything that isn't a Python literal -- if
+    # the longrepr is structurally weird (e.g. someone hand-crafted a
+    # report with code-looking text), we must NOT execute it and must NOT
+    # crash. The fallback returns the raw text.
+    payload = {
+        "duration": 0.0,
+        "tests": [
+            {
+                "nodeid": "f.py::test_x",
+                "outcome": "skipped",
+                "setup": {
+                    "duration": 0.0,
+                    "longrepr": "__import__('os').system('echo pwned')",
+                },
+            },
+        ],
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload))
+    # Did not execute, did not crash, returned the literal text.
+    assert "__import__" in result.cases[0].message
+
+
+def test_skipped_via_pytest_skip_in_body(tmp_path):
+    # When pytest.skip(...) is called from the test body (not setup),
+    # the longrepr lands on "call". The fallback probe order must pick
+    # it up so users still see a clean reason.
+    report = _make_json(
+        tmp_path,
+        """
+        import pytest
+
+        def test_dyn_skip():
+            pytest.skip("computed reason at runtime")
+        """,
+    )
+    result = JSONResultParser().parse(report, exit_code=0)
+    skipped = [c for c in result.cases if c.outcome == "skipped"]
+    assert len(skipped) == 1
+    assert skipped[0].message == "computed reason at runtime"
+
+
+# ---------------------------------------------------------------------------
+# xpassed under strict xfail: pytest-json-report classifies the unexpected
+# pass as "failed" (not "xpassed") when strict=True. This means our
+# summary-arithmetic (passed += summary["xpassed"]) does NOT double-count
+# strict cases. This test pins that invariant so a future plugin change
+# can't quietly break it.
+# ---------------------------------------------------------------------------
+
+
+def test_xpassed_strict_counts_as_failed_not_xpassed(tmp_path):
+    report = _make_json(
+        tmp_path,
+        """
+        import pytest
+
+        @pytest.mark.xfail(strict=True)
+        def test_actually_passes(): assert True
+        """,
+    )
+    # exit_code=1 because strict-xpass is a failure as far as pytest is
+    # concerned (it's the whole point of strict).
+    result = JSONResultParser().parse(report, exit_code=1)
+
+    # Strict xpass: counted as a failure, not a pass, not an xpassed.
+    assert result.failed == 1
+    assert result.passed == 0
+    assert result.skipped == 0
+    # If the plugin ever started ALSO incrementing "xpassed" for strict
+    # cases, our summary-arithmetic would yield passed=1 -- catching this
+    # in CI before it leaks to users.
+    assert result.success is False

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -33,24 +33,28 @@ from airflow_pytest_operator.reporters import JUnitResultParser
 
 
 def _make_junit(tmp_path: Path, suite_src: str) -> str:
+    """Run pytest on a throwaway suite and return the JUnit report path.
+
+    Flags come from ``JUnitResultParser().report_request(...)`` rather than
+    being hardcoded here. This is deliberate: hardcoding them in two places
+    is exactly the bug 0.4.0 is meant to prevent (runner had its own copy
+    of ``--junitxml`` / ``junit_logging=all``). If the parser ever changes
+    which flags it requests, these tests follow automatically.
+    """
     suite = tmp_path / "test_sample.py"
     suite.write_text(textwrap.dedent(suite_src))
-    junit = tmp_path / "junit.xml"
+
+    parser = JUnitResultParser()
+    spec = parser.report_request(str(tmp_path))
+
     subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            str(suite),
-            f"--junitxml={junit}",
-            "-o",
-            "junit_logging=all",
-            "-q",
-        ],
+        [sys.executable, "-m", "pytest", str(suite), *spec.pytest_args, "-q"],
         cwd=tmp_path,
         capture_output=True,
         text=True,
     )
+    assert spec.report_path is not None
+    junit = Path(spec.report_path)
     assert junit.exists(), "pytest did not produce a JUnit report"
     return str(junit)
 
@@ -68,6 +72,8 @@ def test_parses_mixed_outcomes(tmp_path):
     """,
     )
     result = JUnitResultParser().parse(junit, exit_code=1)
+    print(f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}")
+    print(f"failed_node_ids: {result.failed_node_ids}")
 
     assert result.total == 3
     assert result.passed == 1
@@ -107,6 +113,7 @@ def test_parses_errors_in_fixture(tmp_path):
     """,
     )
     result = JUnitResultParser().parse(junit, exit_code=1)
+    print(f"result: errors={result.errors}, success={result.success}")
     assert result.errors >= 1
     assert result.success is False
 
@@ -129,6 +136,7 @@ def test_to_xcom_is_serializable(tmp_path):
     junit = _make_junit(tmp_path, "def test_x(): assert True")
     result = JUnitResultParser().parse(junit)
     payload = result.to_xcom()
+    print(f"xcom payload: {payload}")
     # must round-trip through JSON for XCom
     json.dumps(payload)
     assert "cases" not in payload
@@ -147,7 +155,43 @@ def test_malformed_time_attribute_defaults_to_zero(tmp_path):
         "</testsuite>"
     )
     result = JUnitResultParser().parse(str(junit), exit_code=0)
+    print(f"result: total={result.total}, passed={result.passed}, duration={result.duration}")
     assert result.total == 1
     assert result.passed == 1
     # The unparseable time degraded to 0.0, so total duration is 0.0.
     assert result.duration == 0.0
+
+
+def test_report_request_returns_expected_spec(tmp_path):
+    spec = JUnitResultParser().report_request(str(tmp_path))
+    print(f"spec: report_path={spec.report_path!r}, pytest_args={spec.pytest_args}")
+
+    expected_path = str(tmp_path / "junit.xml")
+    assert spec.report_path == expected_path
+    # Order matters here: pytest sees these tokens as separate argv items,
+    # so "-o" and "junit_logging=all" must be adjacent and in that order.
+    assert spec.pytest_args == (
+        f"--junitxml={expected_path}",
+        "-o",
+        "junit_logging=all",
+    )
+
+
+def test_report_request_uses_class_filename_constant(tmp_path):
+    # The filename is a class constant so subclasses can override it without
+    # rewriting report_request. Guard against accidental drift between the
+    # constant and the path the method composes.
+    parser = JUnitResultParser()
+    spec = parser.report_request(str(tmp_path))
+    assert spec.report_path is not None
+    assert spec.report_path.endswith(parser.REPORT_FILENAME)
+
+
+def test_report_request_composes_path_inside_given_dir(tmp_path):
+    nested = tmp_path / "deep" / "nested"
+    nested.mkdir(parents=True)
+    spec = JUnitResultParser().report_request(str(nested))
+    assert spec.report_path is not None
+    # report_dir is treated as an absolute prefix -- the parser must not
+    # second-guess it (e.g. by inserting its own temp dir).
+    assert Path(spec.report_path).parent == nested

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -139,17 +139,12 @@ def test_to_xcom_is_serializable(tmp_path):
     result = JUnitResultParser().parse(junit)
     payload = result.to_xcom()
     print(f"xcom payload: {payload}")
-    # must round-trip through JSON for XCom
     json.dumps(payload)
     assert "cases" not in payload
     assert payload["success"] is True
 
 
 def test_malformed_time_attribute_defaults_to_zero(tmp_path):
-    # pytest never emits a non-numeric `time`, but a hand-rolled or
-    # third-party report might. The parser must not crash: a bad `time`
-    # falls back to 0.0 (junit_parser ValueError branch) rather than
-    # raising, so one malformed attribute can't sink the whole report.
     junit = tmp_path / "junit.xml"
     junit.write_text(
         '<testsuite name="pytest" tests="1" failures="0" errors="0" skipped="0">'
@@ -162,7 +157,6 @@ def test_malformed_time_attribute_defaults_to_zero(tmp_path):
     )
     assert result.total == 1
     assert result.passed == 1
-    # The unparseable time degraded to 0.0, so total duration is 0.0.
     assert result.duration == 0.0
 
 
@@ -172,8 +166,6 @@ def test_report_request_returns_expected_spec(tmp_path):
 
     expected_path = str(tmp_path / "junit.xml")
     assert spec.report_path == expected_path
-    # Order matters here: pytest sees these tokens as separate argv items,
-    # so "-o" and "junit_logging=all" must be adjacent and in that order.
     assert spec.pytest_args == (
         f"--junitxml={expected_path}",
         "-o",
@@ -182,9 +174,6 @@ def test_report_request_returns_expected_spec(tmp_path):
 
 
 def test_report_request_uses_class_filename_constant(tmp_path):
-    # The filename is a class constant so subclasses can override it without
-    # rewriting report_request. Guard against accidental drift between the
-    # constant and the path the method composes.
     parser = JUnitResultParser()
     spec = parser.report_request(str(tmp_path))
     assert spec.report_path is not None
@@ -196,6 +185,46 @@ def test_report_request_composes_path_inside_given_dir(tmp_path):
     nested.mkdir(parents=True)
     spec = JUnitResultParser().report_request(str(nested))
     assert spec.report_path is not None
-    # report_dir is treated as an absolute prefix -- the parser must not
-    # second-guess it (e.g. by inserting its own temp dir).
     assert Path(spec.report_path).parent == nested
+
+
+def test_parses_testsuites_root_element(tmp_path):
+    """The parser must handle a <testsuites> wrapper (plural) as the root,
+    not just the bare <testsuite> that pytest normally emits."""
+    junit = tmp_path / "junit.xml"
+    junit.write_text(
+        '<?xml version="1.0" encoding="utf-8"?>'
+        "<testsuites>"
+        '<testsuite name="suite_a" tests="2">'
+        '<testcase classname="mod_a" name="test_pass" time="0.1"/>'
+        '<testcase classname="mod_a" name="test_fail" time="0.2">'
+        '<failure message="assert False">long repr</failure>'
+        "</testcase>"
+        "</testsuite>"
+        '<testsuite name="suite_b" tests="1">'
+        '<testcase classname="mod_b" name="test_skip" time="0.0">'
+        "<skipped/>"
+        "</testcase>"
+        "</testsuite>"
+        "</testsuites>"
+    )
+    result = JUnitResultParser().parse(str(junit), exit_code=1)
+    print(
+        f"total={result.total} passed={result.passed} "
+        f"failed={result.failed} skipped={result.skipped}"
+    )
+    assert result.total == 3
+    assert result.passed == 1
+    assert result.failed == 1
+    assert result.skipped == 1
+    assert result.errors == 0
+    assert result.success is False
+
+
+def test_parses_empty_report(tmp_path):
+    """A valid but empty JUnit report (zero tests) must not crash."""
+    junit = tmp_path / "junit.xml"
+    junit.write_text('<testsuite name="pytest" tests="0"/>')
+    result = JUnitResultParser().parse(str(junit), exit_code=0)
+    assert result.total == 0
+    assert result.success is True

--- a/tests/test_junit_parser.py
+++ b/tests/test_junit_parser.py
@@ -72,7 +72,9 @@ def test_parses_mixed_outcomes(tmp_path):
     """,
     )
     result = JUnitResultParser().parse(junit, exit_code=1)
-    print(f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}")
+    print(
+        f"result: total={result.total}, passed={result.passed}, failed={result.failed}, skipped={result.skipped}, errors={result.errors}, success={result.success}"
+    )
     print(f"failed_node_ids: {result.failed_node_ids}")
 
     assert result.total == 3
@@ -155,7 +157,9 @@ def test_malformed_time_attribute_defaults_to_zero(tmp_path):
         "</testsuite>"
     )
     result = JUnitResultParser().parse(str(junit), exit_code=0)
-    print(f"result: total={result.total}, passed={result.passed}, duration={result.duration}")
+    print(
+        f"result: total={result.total}, passed={result.passed}, duration={result.duration}"
+    )
     assert result.total == 1
     assert result.passed == 1
     # The unparseable time degraded to 0.0, so total duration is 0.0.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,13 +21,16 @@ drops per-case detail. They need no Airflow, no subprocess, no XML.
 
 from __future__ import annotations
 
-from airflow_pytest_operator.models import CaseResult, TestRunResult
+import pytest
+
+from airflow_pytest_operator.models import CaseResult, ReportRequest, TestRunResult
 
 
 def test_node_id_with_classname():
     case = CaseResult(
         name="test_a", classname="tests.test_mod", time=0.0, outcome="passed"
     )
+    print(f"node_id: {case.node_id!r}")
     assert case.node_id == "tests.test_mod::test_a"
 
 
@@ -35,6 +38,7 @@ def test_node_id_without_classname_falls_back_to_name():
     # Covers the branch where classname is empty: the node id is just the
     # bare test name (models.py node_id fallback).
     case = CaseResult(name="test_a", classname="", time=0.0, outcome="passed")
+    print(f"node_id (no classname): {case.node_id!r}")
     assert case.node_id == "test_a"
 
 
@@ -70,6 +74,7 @@ def test_failed_node_ids_include_errors_and_failures_only():
         exit_code=1,
         cases=cases,
     )
+    print(f"failed_node_ids: {result.failed_node_ids}")
     assert result.failed_node_ids == ["m::t_fail", "m::t_err"]
 
 
@@ -86,9 +91,36 @@ def test_to_xcom_drops_cases_and_adds_derived_fields():
         cases=cases,
     )
     payload = result.to_xcom()
+    print(f"xcom payload: {payload}")
     # Per-case blobs are dropped from the compact XCom summary...
     assert "cases" not in payload
     # ...and derived fields are present.
     assert payload["success"] is False
     assert payload["failed_node_ids"] == ["m::t"]
     assert payload["total"] == 1
+
+
+def test_report_request_carries_args_and_path():
+    spec = ReportRequest(
+        pytest_args=("--junitxml=/tmp/r.xml", "-o", "junit_logging=all"),
+        report_path="/tmp/r.xml",
+    )
+    assert spec.pytest_args == ("--junitxml=/tmp/r.xml", "-o", "junit_logging=all")
+    assert spec.report_path == "/tmp/r.xml"
+
+
+def test_report_request_allows_none_report_path():
+    # None is the documented signal for parsers that read stdout instead
+    # of a file (no implementation ships in 0.4.0, but the type permits it).
+    spec = ReportRequest(pytest_args=("-v",), report_path=None)
+    assert spec.report_path is None
+
+
+def test_report_request_is_frozen():
+    import dataclasses
+
+    spec = ReportRequest(pytest_args=("--x",), report_path="/p")
+    # frozen=True is part of the contract: parsers must not mutate a spec
+    # after declaring it (runners may pass it around).
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        spec.report_path = "/other"  # type: ignore[misc]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,8 +35,6 @@ def test_node_id_with_classname():
 
 
 def test_node_id_without_classname_falls_back_to_name():
-    # Covers the branch where classname is empty: the node id is just the
-    # bare test name (models.py node_id fallback).
     case = CaseResult(name="test_a", classname="", time=0.0, outcome="passed")
     print(f"node_id (no classname): {case.node_id!r}")
     assert case.node_id == "test_a"
@@ -110,10 +108,6 @@ def test_report_request_carries_args_and_path():
 
 
 def test_report_request_allows_none_report_path():
-    # None tells the runner not to expect any report file. No built-in
-    # parser uses this -- it exists so a future format that consumes
-    # stdout/stderr (or relies on side effects) wouldn't need a model
-    # change -- but the type permits it today.
     spec = ReportRequest(pytest_args=("-v",), report_path=None)
     assert spec.report_path is None
 
@@ -122,7 +116,63 @@ def test_report_request_is_frozen():
     import dataclasses
 
     spec = ReportRequest(pytest_args=("--x",), report_path="/p")
-    # frozen=True is part of the contract: parsers must not mutate a spec
-    # after declaring it (runners may pass it around).
     with pytest.raises(dataclasses.FrozenInstanceError):
         spec.report_path = "/other"  # type: ignore[misc]
+
+
+def test_success_false_when_exit_code_nonzero_but_no_test_failures():
+    """exit_code != 0 alone is enough to flip success to False."""
+    result = TestRunResult(
+        total=1, passed=1, failed=0, skipped=0, errors=0, duration=0.0, exit_code=2
+    )
+    assert result.success is False
+
+
+def test_success_false_with_errors_only():
+    result = TestRunResult(
+        total=1, passed=0, failed=0, skipped=0, errors=1, duration=0.0, exit_code=0
+    )
+    assert result.success is False
+
+
+def test_exception_hierarchy():
+    from airflow_pytest_operator.exceptions import (
+        AirflowPytestError,
+        ReportParseError,
+        TestExecutionError,
+        TestsFailedError,
+    )
+
+    assert issubclass(TestExecutionError, AirflowPytestError)
+    assert issubclass(ReportParseError, AirflowPytestError)
+    assert issubclass(TestsFailedError, AirflowPytestError)
+
+
+def test_tests_failed_error_carries_result():
+    from airflow_pytest_operator.exceptions import TestsFailedError
+
+    result = TestRunResult(
+        total=2, passed=1, failed=1, skipped=0, errors=0, duration=0.1, exit_code=1
+    )
+    exc = TestsFailedError(result)
+    assert exc.result is result
+    assert "1 failed" in str(exc)
+    assert "2 tests" in str(exc)
+
+
+def test_cases_list_is_mutable_in_frozen_result():
+    """Document: cases is a list despite frozen=True. The dataclass is frozen
+    at the field level (can't reassign .cases) but the list itself is mutable.
+    This test is a living spec of the current behaviour, not an endorsement.
+    See issue: consider changing to tuple[CaseResult, ...].
+    """
+    import dataclasses
+
+    result = TestRunResult(
+        total=0, passed=0, failed=0, skipped=0, errors=0, duration=0.0, exit_code=0
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        result.cases = []  # type: ignore[misc]  # can't reassign the field …
+    result.cases.append(  # … but can mutate the list itself
+        CaseResult(name="t", classname="", time=0.0, outcome="passed")
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -110,8 +110,10 @@ def test_report_request_carries_args_and_path():
 
 
 def test_report_request_allows_none_report_path():
-    # None is the documented signal for parsers that read stdout instead
-    # of a file (no implementation ships in 0.4.0, but the type permits it).
+    # None tells the runner not to expect any report file. No built-in
+    # parser uses this -- it exists so a future format that consumes
+    # stdout/stderr (or relies on side effects) wouldn't need a model
+    # change -- but the type permits it today.
     spec = ReportRequest(pytest_args=("-v",), report_path=None)
     assert spec.report_path is None
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -39,10 +39,6 @@ class FakeRunner:
         self.cleanup_calls = []
 
     def run(self, test_path, *, pytest_args=None, env=None, report_request):
-        # Capture the report_request callback so tests can assert the
-        # operator wired it through. We also call it (with a fake dir) to
-        # mirror what a real runner would do -- this exercises the parser's
-        # report_request method as part of normal operator execution.
         spec = report_request("/fake/report/dir")
         self.calls.append(
             {
@@ -71,10 +67,6 @@ class FakeParser:
         self.report_request_calls = []
 
     def report_request(self, report_dir):
-        # Return a stable spec the operator can hand to the runner. The
-        # concrete values don't matter for orchestration tests; what matters
-        # is that the method exists with the right signature, so the
-        # operator can wire `parser.report_request` to the runner.
         from airflow_pytest_operator.models import ReportRequest
 
         self.report_request_calls.append(report_dir)
@@ -122,13 +114,10 @@ def test_passing_run_returns_summary_for_xcom():
     out = op.execute(ctx)
     print(f"xcom summary: {out}")
 
-    # The summary is the return value; Airflow pushes it under return_value.
     assert out["success"] is True
     assert out["passed"] == 3
-    # No custom key is pushed -- we rely solely on return_value now.
     assert ctx["ti"].pushed == {}
-    assert op.do_xcom_push is True  # default: Airflow will push return_value
-    # orchestration order: runner called, then parser fed its xml path
+    assert op.do_xcom_push is True
     assert runner.calls[0]["test_path"] == "tests/"
     assert parser.parsed_paths[0] == ("/x.xml", 0)
 
@@ -155,7 +144,7 @@ def test_fail_on_test_failure_false_swallows_failure():
         fail_on_test_failure=False,
     )
 
-    out = op.execute(_ctx())  # must NOT raise
+    out = op.execute(_ctx())
     print(f"out: success={out['success']}, failed={out['failed']}")
     assert out["success"] is False
     assert out["failed"] == 2
@@ -166,13 +155,11 @@ def test_do_xcom_push_defaults_true_and_returns_summary():
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
     out = op.execute(_ctx())
-    # Default: Airflow will push the returned summary under return_value.
     assert op.do_xcom_push is True
     assert out["success"] is True
 
 
 def test_do_xcom_push_false_is_respected():
-    # No custom flag: users disable XCom with Airflow's standard parameter.
     runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(
@@ -184,7 +171,6 @@ def test_do_xcom_push_false_is_respected():
     )
     out = op.execute(_ctx())
     assert op.do_xcom_push is False
-    # execute still returns the summary for in-process callers/tests.
     assert out["success"] is True
 
 
@@ -207,7 +193,6 @@ def test_args_and_env_forwarded_to_runner():
 
 
 def test_missing_report_raises_execution_error():
-    # Runner ran but produced no JUnit XML (crash/collection error).
     runner = FakeRunner(
         RunArtifacts(
             exit_code=2,
@@ -215,7 +200,7 @@ def test_missing_report_raises_execution_error():
             stderr="ERROR: file or directory not found",
         )
     )
-    parser = FakeParser(_result(passed=1))  # should never be called
+    parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="bad/path", runner=runner, parser=parser)
 
     from airflow_pytest_operator.exceptions import TestExecutionError
@@ -230,8 +215,8 @@ def test_missing_report_raises_execution_error():
     assert "produced no" in msg
     assert "FakeParser" in msg
     assert "report" in msg
-    assert "not found" in msg  # stderr is surfaced
-    assert parser.parsed_paths == []  # parser never reached
+    assert "not found" in msg
+    assert parser.parsed_paths == []
 
 
 def test_cleanup_called_on_success():
@@ -256,7 +241,7 @@ def test_cleanup_called_false_on_test_failure():
     )
     with pytest.raises(TestsFailedError):
         op.execute(_ctx())
-    assert runner.cleanup_calls == [False]  # ran via finally, reported failure
+    assert runner.cleanup_calls == [False]
 
 
 def test_cleanup_called_false_on_missing_report():
@@ -281,7 +266,6 @@ def test_on_kill_delegates_to_runner():
 
     op.on_kill()
     assert runner.cancelled == 1
-    # Killed run must also clean up the temp dir (default "always" policy).
     assert runner.cleanup_calls == [False]
 
 
@@ -298,7 +282,6 @@ def test_on_kill_never_raises_even_if_cancel_fails():
         parser=FakeParser(_result(passed=1)),
     )
 
-    # Must swallow the error -- teardown must not raise. cleanup still runs.
     op.on_kill()
     assert runner.cleanup_calls == [False]
 
@@ -315,11 +298,10 @@ def test_on_kill_never_raises_even_if_cleanup_fails():
         runner=runner,
         parser=FakeParser(_result(passed=1)),
     )
-    op.on_kill()  # must not raise despite cleanup blowing up
+    op.on_kill()
 
 
 def test_default_collaborators_are_wired():
-    # No injection -> real defaults, proving the DI defaults exist.
     from airflow_pytest_operator.reporters import JUnitResultParser
     from airflow_pytest_operator.runners import SubprocessPytestRunner
 
@@ -329,15 +311,6 @@ def test_default_collaborators_are_wired():
 
 
 def test_stdout_and_stderr_are_logged():
-    # The operator must surface child stdout/stderr in the task log. We assert
-    # on the operator's own logging contract by spying on the logger's methods
-    # rather than using `caplog`: on Airflow 3 the operator logger is
-    # `airflow.task...`, whose records Airflow routes through its own
-    # task-logging, so a root-handler `caplog` wouldn't see them. Patching the
-    # logger methods proves the contract ("we called self.log.info/warning
-    # with this content") independent of how any Airflow version wires
-    # handlers. `BaseOperator.log` is a read-only property on real Airflow, so
-    # we patch its methods in place rather than reassigning `op.log`.
     from unittest import mock
 
     runner = FakeRunner(
@@ -367,13 +340,9 @@ def test_stdout_and_stderr_are_logged():
 
 
 def test_failed_node_ids_are_logged():
-    # When the parsed result has failed cases, the operator logs their node
-    # ids at error level. Same logger-spy rationale as above.
     from unittest import mock
 
     def _result_with_failed_cases():
-        # A result whose cases yield non-empty failed_node_ids, exercising the
-        # operator's "Failed tests:" logging branch (pytest_operator.py:127).
         from airflow_pytest_operator.models import CaseResult
 
         cases = [
@@ -401,7 +370,7 @@ def test_failed_node_ids_are_logged():
         test_path="tests/",
         runner=runner,
         parser=FakeParser(_result_with_failed_cases()),
-        fail_on_test_failure=False,  # don't raise; we only check logging
+        fail_on_test_failure=False,
     )
     with mock.patch.object(op.log, "error") as error:
         op.execute(_ctx())
@@ -417,24 +386,14 @@ def test_operator_forwards_parser_report_request_to_runner():
     op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
     op.execute(_ctx())
 
-    # The runner received the parser's bound method. Bound methods are
-    # not singletons -- `parser.report_request` creates a fresh bound
-    # object on each attribute access -- so we compare the underlying
-    # callable identity (`__self__` and `__func__`) instead of `is`.
     forwarded = runner.calls[0]["report_request"]
     assert forwarded.__self__ is parser
     assert forwarded.__func__ is type(parser).report_request
-    # And the parser's report_request was actually invoked (by the runner stub).
     assert parser.report_request_calls == ["/fake/report/dir"]
-    # The spec the runner got contains what the parser produced -- proving
-    # the round trip works end-to-end through the operator.
     assert runner.calls[0]["spec"].pytest_args == ("--fake-report",)
 
 
 def test_missing_report_error_names_the_parser_class():
-    # Twin of test_missing_report_raises_execution_error but focused on the
-    # parser-name surfacing: callers should be able to tell at a glance
-    # which report format the run was configured for.
     runner = FakeRunner(RunArtifacts(exit_code=2, report_path=None, stderr="boom"))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="x/", runner=runner, parser=parser)
@@ -447,10 +406,6 @@ def test_missing_report_error_names_the_parser_class():
 
 
 def test_missing_report_error_truncates_huge_stderr():
-    # The error message embeds the captured stderr to help diagnose
-    # collection crashes, but a runaway plugin can dump megabytes there.
-    # The operator truncates to 4096 chars + a sentinel so the Airflow task
-    # log stays readable and downstream log shippers don't choke.
     huge = "x" * 4097
     runner = FakeRunner(RunArtifacts(exit_code=2, report_path=None, stderr=huge))
     parser = FakeParser(_result(passed=1))
@@ -463,14 +418,10 @@ def test_missing_report_error_truncates_huge_stderr():
     msg = str(exc.value)
     print(f"truncated msg (len={len(msg)}): {msg[:200]!r}")
     assert "...(truncated)" in msg
-    # The original 10k payload must not be embedded verbatim.
     assert huge not in msg
 
 
 def test_missing_report_error_handles_empty_stderr():
-    # When pytest dies before writing anything to stderr (e.g. SIGKILL),
-    # the error should still be informative -- "<empty>" is the documented
-    # placeholder, so we assert on it explicitly.
     runner = FakeRunner(RunArtifacts(exit_code=137, report_path=None, stderr=""))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="x/", runner=runner, parser=parser)
@@ -481,3 +432,53 @@ def test_missing_report_error_handles_empty_stderr():
         op.execute(_ctx())
     print(f"empty stderr msg: {str(exc.value)!r}")
     assert "<empty>" in str(exc.value)
+
+
+def test_report_parse_error_propagates_and_cleanup_called():
+    """If the parser raises ReportParseError, it propagates out of execute()
+    and cleanup() is still called with success=False."""
+    from airflow_pytest_operator.exceptions import ReportParseError
+    from airflow_pytest_operator.models import ReportRequest
+
+    class ErrorParser:
+        def report_request(self, report_dir):
+            return ReportRequest(pytest_args=(), report_path=f"{report_dir}/x.json")
+
+        def parse(self, report_path, *, exit_code=0):
+            raise ReportParseError("malformed report")
+
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.json"))
+    op = PytestOperator(
+        task_id="t", test_path="tests/", runner=runner, parser=ErrorParser()
+    )
+
+    with pytest.raises(ReportParseError, match="malformed"):
+        op.execute(_ctx())
+
+    assert runner.cleanup_calls == [False]
+
+
+def test_report_parse_error_is_not_swallowed_by_fail_on_test_failure_false():
+    """fail_on_test_failure=False must NOT suppress ReportParseError -- that is
+    an infrastructure error, not a test-result decision."""
+    from airflow_pytest_operator.exceptions import ReportParseError
+    from airflow_pytest_operator.models import ReportRequest
+
+    class ErrorParser:
+        def report_request(self, report_dir):
+            return ReportRequest(pytest_args=(), report_path=f"{report_dir}/x.json")
+
+        def parse(self, report_path, *, exit_code=0):
+            raise ReportParseError("corrupt")
+
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.json"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=ErrorParser(),
+        fail_on_test_failure=False,
+    )
+
+    with pytest.raises(ReportParseError):
+        op.execute(_ctx())

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -38,9 +38,20 @@ class FakeRunner:
         self.cancelled = 0
         self.cleanup_calls = []
 
-    def run(self, test_path, *, pytest_args=None, env=None):
+    def run(self, test_path, *, pytest_args=None, env=None, report_request):
+        # Capture the report_request callback so tests can assert the
+        # operator wired it through. We also call it (with a fake dir) to
+        # mirror what a real runner would do -- this exercises the parser's
+        # report_request method as part of normal operator execution.
+        spec = report_request("/fake/report/dir")
         self.calls.append(
-            {"test_path": test_path, "pytest_args": pytest_args, "env": env}
+            {
+                "test_path": test_path,
+                "pytest_args": pytest_args,
+                "env": env,
+                "report_request": report_request,
+                "spec": spec,
+            }
         )
         return self._artifacts
 
@@ -57,6 +68,20 @@ class FakeParser:
     def __init__(self, result: TestRunResult):
         self._result = result
         self.parsed_paths = []
+        self.report_request_calls = []
+
+    def report_request(self, report_dir):
+        # Return a stable spec the operator can hand to the runner. The
+        # concrete values don't matter for orchestration tests; what matters
+        # is that the method exists with the right signature, so the
+        # operator can wire `parser.report_request` to the runner.
+        from airflow_pytest_operator.models import ReportRequest
+
+        self.report_request_calls.append(report_dir)
+        return ReportRequest(
+            pytest_args=("--fake-report",),
+            report_path=f"{report_dir}/fake.report",
+        )
 
     def parse(self, report_path, *, exit_code=0):
         self.parsed_paths.append((report_path, exit_code))
@@ -89,12 +114,13 @@ def _ctx():
 
 
 def test_passing_run_returns_summary_for_xcom():
-    runner = FakeRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=3))
     op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
 
     ctx = _ctx()
     out = op.execute(ctx)
+    print(f"xcom summary: {out}")
 
     # The summary is the return value; Airflow pushes it under return_value.
     assert out["success"] is True
@@ -108,17 +134,18 @@ def test_passing_run_returns_summary_for_xcom():
 
 
 def test_failing_run_raises_by_default():
-    runner = FakeRunner(RunArtifacts(exit_code=1, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=1, report_path="/x.xml"))
     parser = FakeParser(_result(failed=2))
     op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
 
     with pytest.raises(TestsFailedError) as exc:
         op.execute(_ctx())
+    print(f"TestsFailedError: result.failed={exc.value.result.failed}")
     assert exc.value.result.failed == 2
 
 
 def test_fail_on_test_failure_false_swallows_failure():
-    runner = FakeRunner(RunArtifacts(exit_code=1, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=1, report_path="/x.xml"))
     parser = FakeParser(_result(failed=2))
     op = PytestOperator(
         task_id="t",
@@ -129,12 +156,13 @@ def test_fail_on_test_failure_false_swallows_failure():
     )
 
     out = op.execute(_ctx())  # must NOT raise
+    print(f"out: success={out['success']}, failed={out['failed']}")
     assert out["success"] is False
     assert out["failed"] == 2
 
 
 def test_do_xcom_push_defaults_true_and_returns_summary():
-    runner = FakeRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
     out = op.execute(_ctx())
@@ -145,7 +173,7 @@ def test_do_xcom_push_defaults_true_and_returns_summary():
 
 def test_do_xcom_push_false_is_respected():
     # No custom flag: users disable XCom with Airflow's standard parameter.
-    runner = FakeRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(
         task_id="t",
@@ -161,7 +189,7 @@ def test_do_xcom_push_false_is_respected():
 
 
 def test_args_and_env_forwarded_to_runner():
-    runner = FakeRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(
         task_id="t",
@@ -172,6 +200,8 @@ def test_args_and_env_forwarded_to_runner():
         parser=parser,
     )
     op.execute(_ctx())
+    print(f"pytest_args forwarded: {runner.calls[0]['pytest_args']}")
+    print(f"env forwarded: {runner.calls[0]['env']}")
     assert runner.calls[0]["pytest_args"] == ["-k", "smoke"]
     assert runner.calls[0]["env"] == {"E": "1"}
 
@@ -181,7 +211,7 @@ def test_missing_report_raises_execution_error():
     runner = FakeRunner(
         RunArtifacts(
             exit_code=2,
-            junit_xml_path=None,
+            report_path=None,
             stderr="ERROR: file or directory not found",
         )
     )
@@ -192,13 +222,20 @@ def test_missing_report_raises_execution_error():
 
     with pytest.raises(TestExecutionError) as exc:
         op.execute(_ctx())
-    assert "no JUnit report" in str(exc.value)
-    assert "not found" in str(exc.value)  # stderr is surfaced
+    msg = str(exc.value)
+    print(f"TestExecutionError: {msg!r}")
+    # The error names the parser class so users can tell which format was
+    # expected (FakeParser here; "JUnitResultParser" / "JSONResultParser"
+    # in real installs).
+    assert "produced no" in msg
+    assert "FakeParser" in msg
+    assert "report" in msg
+    assert "not found" in msg  # stderr is surfaced
     assert parser.parsed_paths == []  # parser never reached
 
 
 def test_cleanup_called_on_success():
-    runner = FakeRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     op = PytestOperator(
         task_id="t",
         test_path="tests/",
@@ -210,7 +247,7 @@ def test_cleanup_called_on_success():
 
 
 def test_cleanup_called_false_on_test_failure():
-    runner = FakeRunner(RunArtifacts(exit_code=1, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=1, report_path="/x.xml"))
     op = PytestOperator(
         task_id="t",
         test_path="tests/",
@@ -223,7 +260,7 @@ def test_cleanup_called_false_on_test_failure():
 
 
 def test_cleanup_called_false_on_missing_report():
-    runner = FakeRunner(RunArtifacts(exit_code=2, junit_xml_path=None))
+    runner = FakeRunner(RunArtifacts(exit_code=2, report_path=None))
     op = PytestOperator(
         task_id="t",
         test_path="bad/",
@@ -238,7 +275,7 @@ def test_cleanup_called_false_on_missing_report():
 
 
 def test_on_kill_delegates_to_runner():
-    runner = FakeRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
 
@@ -253,7 +290,7 @@ def test_on_kill_never_raises_even_if_cancel_fails():
         def cancel(self):
             raise RuntimeError("cannot cancel")
 
-    runner = ExplodingRunner(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = ExplodingRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     op = PytestOperator(
         task_id="t",
         test_path="tests/",
@@ -271,7 +308,7 @@ def test_on_kill_never_raises_even_if_cleanup_fails():
         def cleanup(self, *, success=True):
             raise RuntimeError("cannot clean")
 
-    runner = ExplodingCleanup(RunArtifacts(exit_code=0, junit_xml_path="/x.xml"))
+    runner = ExplodingCleanup(RunArtifacts(exit_code=0, report_path="/x.xml"))
     op = PytestOperator(
         task_id="t",
         test_path="tests/",
@@ -306,7 +343,7 @@ def test_stdout_and_stderr_are_logged():
     runner = FakeRunner(
         RunArtifacts(
             exit_code=0,
-            junit_xml_path="/x.xml",
+            report_path="/x.xml",
             stdout="some-stdout-line",
             stderr="some-stderr-line",
         )
@@ -324,6 +361,7 @@ def test_stdout_and_stderr_are_logged():
         op.execute(_ctx())
 
     logged = " ".join(str(c) for c in info.call_args_list + warning.call_args_list)
+    print(f"logged (stdout+stderr calls): {logged[:300]!r}")
     assert "some-stdout-line" in logged
     assert "some-stderr-line" in logged
 
@@ -357,7 +395,7 @@ def test_failed_node_ids_are_logged():
             cases=cases,
         )
 
-    runner = FakeRunner(RunArtifacts(exit_code=1, junit_xml_path="/x.xml"))
+    runner = FakeRunner(RunArtifacts(exit_code=1, report_path="/x.xml"))
     op = PytestOperator(
         task_id="t",
         test_path="tests/",
@@ -369,4 +407,77 @@ def test_failed_node_ids_are_logged():
         op.execute(_ctx())
 
     logged = " ".join(str(c) for c in error.call_args_list)
+    print(f"error logged: {logged!r}")
     assert "tests.test_api::test_bad" in logged
+
+
+def test_operator_forwards_parser_report_request_to_runner():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(task_id="t", test_path="tests/", runner=runner, parser=parser)
+    op.execute(_ctx())
+
+    # The runner received the parser's bound method. Bound methods are
+    # not singletons -- `parser.report_request` creates a fresh bound
+    # object on each attribute access -- so we compare the underlying
+    # callable identity (`__self__` and `__func__`) instead of `is`.
+    forwarded = runner.calls[0]["report_request"]
+    assert forwarded.__self__ is parser
+    assert forwarded.__func__ is type(parser).report_request
+    # And the parser's report_request was actually invoked (by the runner stub).
+    assert parser.report_request_calls == ["/fake/report/dir"]
+    # The spec the runner got contains what the parser produced -- proving
+    # the round trip works end-to-end through the operator.
+    assert runner.calls[0]["spec"].pytest_args == ("--fake-report",)
+
+
+def test_missing_report_error_names_the_parser_class():
+    # Twin of test_missing_report_raises_execution_error but focused on the
+    # parser-name surfacing: callers should be able to tell at a glance
+    # which report format the run was configured for.
+    runner = FakeRunner(RunArtifacts(exit_code=2, report_path=None, stderr="boom"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(task_id="t", test_path="x/", runner=runner, parser=parser)
+
+    from airflow_pytest_operator.exceptions import TestExecutionError
+
+    with pytest.raises(TestExecutionError) as exc:
+        op.execute(_ctx())
+    assert "FakeParser" in str(exc.value)
+
+
+def test_missing_report_error_truncates_huge_stderr():
+    # The error message embeds the captured stderr to help diagnose
+    # collection crashes, but a runaway plugin can dump megabytes there.
+    # The operator truncates to 4096 chars + a sentinel so the Airflow task
+    # log stays readable and downstream log shippers don't choke.
+    huge = "x" * 10000
+    runner = FakeRunner(RunArtifacts(exit_code=2, report_path=None, stderr=huge))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(task_id="t", test_path="x/", runner=runner, parser=parser)
+
+    from airflow_pytest_operator.exceptions import TestExecutionError
+
+    with pytest.raises(TestExecutionError) as exc:
+        op.execute(_ctx())
+    msg = str(exc.value)
+    print(f"truncated msg (len={len(msg)}): {msg[:200]!r}")
+    assert "...(truncated)" in msg
+    # The original 10k payload must not be embedded verbatim.
+    assert huge not in msg
+
+
+def test_missing_report_error_handles_empty_stderr():
+    # When pytest dies before writing anything to stderr (e.g. SIGKILL),
+    # the error should still be informative -- "<empty>" is the documented
+    # placeholder, so we assert on it explicitly.
+    runner = FakeRunner(RunArtifacts(exit_code=137, report_path=None, stderr=""))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(task_id="t", test_path="x/", runner=runner, parser=parser)
+
+    from airflow_pytest_operator.exceptions import TestExecutionError
+
+    with pytest.raises(TestExecutionError) as exc:
+        op.execute(_ctx())
+    print(f"empty stderr msg: {str(exc.value)!r}")
+    assert "<empty>" in str(exc.value)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -451,7 +451,7 @@ def test_missing_report_error_truncates_huge_stderr():
     # collection crashes, but a runaway plugin can dump megabytes there.
     # The operator truncates to 4096 chars + a sentinel so the Airflow task
     # log stays readable and downstream log shippers don't choke.
-    huge = "x" * 10000
+    huge = "x" * 4097
     runner = FakeRunner(RunArtifacts(exit_code=2, report_path=None, stderr=huge))
     parser = FakeParser(_result(passed=1))
     op = PytestOperator(task_id="t", test_path="x/", runner=runner, parser=parser)

--- a/tests/test_provider_discovery.py
+++ b/tests/test_provider_discovery.py
@@ -29,9 +29,6 @@ import sys
 
 
 def test_provider_info_is_import_light():
-    # The provider_info module must not pull in the operator/compat/Airflow.
-    # We import it in a fresh interpreter and assert none of the heavy
-    # modules ended up loaded as a side effect.
     code = (
         "import airflow_pytest_operator.provider_info as p;"
         "import sys;"
@@ -53,9 +50,6 @@ def test_provider_info_is_import_light():
 
 
 def test_importing_package_does_not_import_operator():
-    # Importing the top-level package (as Airflow's discovery does) must not
-    # eagerly import the operator -- that would trigger the Airflow import
-    # chain at startup and crash on a not-yet-ready SDK (Airflow 3.2.x).
     code = (
         "import airflow_pytest_operator;"
         "import sys;"
@@ -72,13 +66,10 @@ def test_importing_package_does_not_import_operator():
 
 
 def test_version_is_resolved_from_metadata():
-    # __version__ comes from installed package metadata (single source of
-    # truth = pyproject.toml), not a hardcoded string.
     import airflow_pytest_operator
 
     v = airflow_pytest_operator.__version__
     assert isinstance(v, str) and v, "version must be a non-empty string"
-    # provider_info exposes the same value.
     from airflow_pytest_operator.provider_info import (
         __version__ as pi_version,
     )
@@ -89,8 +80,6 @@ def test_version_is_resolved_from_metadata():
 
 
 def test_version_fallback_when_not_installed(monkeypatch):
-    # If metadata is missing (running from an uninstalled source tree), the
-    # resolver must not raise -- it returns a sentinel instead.
     import importlib.metadata as md
 
     import airflow_pytest_operator
@@ -103,7 +92,6 @@ def test_version_fallback_when_not_installed(monkeypatch):
 
 
 def test_lazy_operator_attribute_resolves():
-    # Accessing PytestOperator triggers the lazy import and returns the class.
     import airflow_pytest_operator
 
     op_cls = airflow_pytest_operator.PytestOperator

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -734,7 +734,7 @@ def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch
     import subprocess as _sp
     import time
 
-    class FakeTaskTimeout(Exception): # noqa: N818
+    class FakeTaskTimeout(Exception):  # noqa: N818
         pass
 
     suite = tmp_path / "test_long.py"
@@ -800,7 +800,7 @@ def test_cancel_after_unexpected_exception_is_safe_noop(tmp_path, monkeypatch):
     import subprocess as _sp
     import time
 
-    class FakeTaskTimeout(Exception): # noqa: N818
+    class FakeTaskTimeout(Exception):  # noqa: N818
         pass
 
     suite = tmp_path / "test_long.py"

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -24,7 +24,20 @@ from pathlib import Path
 import pytest
 
 from airflow_pytest_operator.exceptions import TestExecutionError
+from airflow_pytest_operator.reporters import JUnitResultParser
 from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+_JUNIT_REPORT_REQUEST = JUnitResultParser().report_request
+
+
+def _run(runner, *args, **kwargs):
+    """Thin wrapper around ``runner.run`` that supplies the required
+    ``report_request`` kwarg, so the body of each test stays focused on
+    what it is actually testing (timeout, env, cwd, ...) rather than on
+    the runner/parser plumbing.
+    """
+    kwargs.setdefault("report_request", _JUNIT_REPORT_REQUEST)
+    return runner.run(*args, **kwargs)
 
 
 def _suite(tmp_path: Path, src: str) -> str:
@@ -33,20 +46,22 @@ def _suite(tmp_path: Path, src: str) -> str:
     return str(f)
 
 
-def test_runner_produces_junit_and_zero_exit_on_pass(tmp_path):
+def test_runner_produces_report_and_zero_exit_on_pass(tmp_path):
     path = _suite(tmp_path, "def test_ok(): assert True")
-    artifacts = SubprocessPytestRunner(report_dir=str(tmp_path / "rep")).run(path)
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")), path)
+    print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
     assert artifacts.exit_code == 0
-    assert artifacts.junit_xml_path is not None
-    assert Path(artifacts.junit_xml_path).exists()
+    assert artifacts.report_path is not None
+    assert Path(artifacts.report_path).exists()
 
 
 def test_runner_nonzero_exit_on_failure_but_does_not_raise(tmp_path):
     path = _suite(tmp_path, "def test_bad(): assert False")
-    artifacts = SubprocessPytestRunner(report_dir=str(tmp_path / "rep")).run(path)
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")), path)
+    print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
     # A failing test is a valid outcome, not an execution error.
     assert artifacts.exit_code != 0
-    assert artifacts.junit_xml_path is not None
+    assert artifacts.report_path is not None
 
 
 def test_runner_passes_extra_args(tmp_path):
@@ -57,9 +72,12 @@ def test_runner_passes_extra_args(tmp_path):
         def test_two(): assert True
     """,
     )
-    artifacts = SubprocessPytestRunner(report_dir=str(tmp_path / "rep")).run(
-        path, pytest_args=["-k", "test_one"]
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        pytest_args=["-k", "test_one"],
     )
+    print(f"exit_code={artifacts.exit_code}, stdout snippet: {artifacts.stdout[:120]!r}")
     assert artifacts.exit_code == 0
     assert "test_one" in artifacts.stdout or artifacts.exit_code == 0
 
@@ -72,9 +90,12 @@ def test_runner_forwards_env(tmp_path):
         def test_env(): assert os.environ.get("MY_FLAG") == "42"
     """,
     )
-    artifacts = SubprocessPytestRunner(report_dir=str(tmp_path / "rep")).run(
-        path, env={"MY_FLAG": "42"}
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        env={"MY_FLAG": "42"},
     )
+    print(f"exit_code={artifacts.exit_code}")
     assert artifacts.exit_code == 0
 
 
@@ -82,7 +103,7 @@ def test_runner_bad_interpreter_raises_execution_error(tmp_path):
     path = _suite(tmp_path, "def test_ok(): assert True")
     runner = SubprocessPytestRunner(python_executable="/no/such/python")
     with pytest.raises(TestExecutionError):
-        runner.run(path)
+        _run(runner, path)
 
 
 def test_cancel_kills_running_tree(tmp_path):
@@ -102,10 +123,10 @@ def test_cancel_kills_running_tree(tmp_path):
 
     result_box = {}
 
-    def _run():
-        result_box["artifacts"] = runner.run(path)
+    def _do_run():
+        result_box["artifacts"] = _run(runner, path)
 
-    t = threading.Thread(target=_run)
+    t = threading.Thread(target=_do_run)
     started = time.monotonic()
     t.start()
 
@@ -115,6 +136,7 @@ def test_cancel_kills_running_tree(tmp_path):
     t.join(timeout=15)
 
     elapsed = time.monotonic() - started
+    print(f"cancel elapsed: {elapsed:.2f}s")
     assert not t.is_alive(), "run() did not return after cancel"
     # Must have ended well before the 60s sleep would have finished.
     assert elapsed < 20, f"cancel was too slow: {elapsed:.1f}s"
@@ -131,7 +153,7 @@ def test_cancel_before_completion_then_run_normally(tmp_path):
     # A normal fast run should still work on a fresh runner instance.
     path = _suite(tmp_path, "def test_ok(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
     assert artifacts.exit_code == 0
 
 
@@ -150,11 +172,12 @@ def test_auto_cwd_for_directory_target(tmp_path):
         "    open('cwd_marker.txt', 'w').write(os.getcwd())\n"
     )
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    artifacts = runner.run(str(tests_dir))
+    artifacts = _run(runner, str(tests_dir))
 
     assert artifacts.exit_code == 0
     marker = tests_dir / "cwd_marker.txt"
     assert marker.exists(), "pytest did not run from the tests directory"
+    print(f"cwd_marker: {marker.read_text()!r}")
     assert marker.read_text() == str(tests_dir.resolve())
 
 
@@ -169,9 +192,10 @@ def test_auto_cwd_for_file_target_uses_parent(tmp_path):
         "    open('cwd_marker.txt', 'w').write(os.getcwd())\n"
     )
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    artifacts = runner.run(str(test_file))
+    artifacts = _run(runner, str(test_file))
 
     assert artifacts.exit_code == 0
+    print(f"cwd_marker: {(tests_dir / 'cwd_marker.txt').read_text()!r}")
     assert (tests_dir / "cwd_marker.txt").read_text() == str(tests_dir.resolve())
 
 
@@ -188,32 +212,38 @@ def test_explicit_cwd_overrides_auto(tmp_path):
     explicit = tmp_path / "elsewhere"
     explicit.mkdir()
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"), cwd=str(explicit))
-    artifacts = runner.run(str(tests_dir), env={"MARK_DIR": str(explicit)})
+    artifacts = _run(runner, str(tests_dir), env={"MARK_DIR": str(explicit)})
 
     assert artifacts.exit_code == 0
+    print(f"m.txt content: {(explicit / 'm.txt').read_text()!r}")
     assert (explicit / "m.txt").read_text() == str(explicit.resolve())
 
 
-def test_junit_report_unaffected_by_auto_cwd(tmp_path):
-    # The junit path is absolute, so changing cwd must not misplace it.
+def test_report_path_unaffected_by_auto_cwd(tmp_path):
+    # The report path is absolute (parser-declared, inside report_dir), so
+    # changing cwd for the child must not misplace it. The literal filename
+    # belongs to the parser, not this test -- we source it via the parser to
+    # avoid a second source of truth for "what file pytest produces".
     tests_dir = tmp_path / "suite"
     tests_dir.mkdir()
     (tests_dir / "test_x.py").write_text("def test_a(): assert True\n")
     rep = tmp_path / "rep"
     runner = SubprocessPytestRunner(report_dir=str(rep))
-    artifacts = runner.run(str(tests_dir))
+    artifacts = _run(runner, str(tests_dir))
 
-    assert artifacts.junit_xml_path == str(rep / "junit.xml")
-    assert (rep / "junit.xml").exists()
+    expected = JUnitResultParser().report_request(str(rep)).report_path
+    assert artifacts.report_path == expected
+    assert Path(expected).exists()
 
 
 def test_cleanup_removes_auto_dir_by_default(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner()  # cleanup="always", auto report_dir
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
     auto_dir = artifacts.working_dir
     assert auto_dir is not None and os.path.isdir(auto_dir)
 
+    print(f"auto_dir={auto_dir!r}")
     runner.cleanup(success=True)
     assert not os.path.exists(auto_dir)
 
@@ -221,7 +251,7 @@ def test_cleanup_removes_auto_dir_by_default(tmp_path):
 def test_cleanup_never_keeps_auto_dir(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(cleanup="never")
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
     runner.cleanup(success=True)
     assert os.path.isdir(artifacts.working_dir)
 
@@ -229,16 +259,17 @@ def test_cleanup_never_keeps_auto_dir(tmp_path):
 def test_cleanup_on_success_keeps_dir_on_failure(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(cleanup="on_success")
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
     # Simulate a failed run -> directory must be retained for post-mortem.
     runner.cleanup(success=False)
+
     assert os.path.isdir(artifacts.working_dir)
 
 
 def test_cleanup_on_success_removes_dir_on_success(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(cleanup="on_success")
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
     runner.cleanup(success=True)
     assert not os.path.exists(artifacts.working_dir)
 
@@ -248,7 +279,7 @@ def test_cleanup_never_touches_user_supplied_dir(tmp_path):
     user_dir.mkdir()
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(user_dir))  # cleanup="always"
-    runner.run(path)
+    _run(runner, path)
     runner.cleanup(success=True)
     # User-owned directory is never removed, even under "always".
     assert user_dir.is_dir()
@@ -271,7 +302,7 @@ def test_report_dir_pointing_at_file_raises_execution_error(tmp_path):
     not_a_dir.write_text("x")
     runner = SubprocessPytestRunner(report_dir=str(not_a_dir))
     with pytest.raises(TestExecutionError, match="report directory"):
-        runner.run(str(tmp_path))
+        _run(runner, str(tmp_path))
 
 
 def test_cancel_does_not_block_cleanup_during_grace(tmp_path):
@@ -293,13 +324,13 @@ def test_cancel_does_not_block_cleanup_during_grace(tmp_path):
     )
     runner = SubprocessPytestRunner(grace_period=5.0)
 
-    def _run():
+    def _do_run():
         try:
-            runner.run(path)
+            _run(runner, path)
         except Exception:  # noqa: BLE001
             pass
 
-    t = threading.Thread(target=_run)
+    t = threading.Thread(target=_do_run)
     t.start()
     time.sleep(1.5)  # let the child start
 
@@ -331,7 +362,7 @@ def test_concurrent_run_on_same_instance_is_rejected(tmp_path):
 
     def _slow():
         try:
-            runner.run(slow)
+            _run(runner, slow)
         except Exception as e:  # noqa: BLE001
             errors["slow"] = e
 
@@ -340,7 +371,7 @@ def test_concurrent_run_on_same_instance_is_rejected(tmp_path):
     time.sleep(1.0)  # ensure the first run is in progress
 
     with pytest.raises(TestExecutionError, match="already executing"):
-        runner.run(slow)
+        _run(runner, slow)
 
     runner.cancel()  # stop the slow one
     t.join(timeout=15)
@@ -350,9 +381,10 @@ def test_sequential_reuse_of_same_instance_works(tmp_path):
     # After a run finishes, the same instance can run again (e.g. retry).
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    a = runner.run(path)
+    a = _run(runner, path)
     assert a.exit_code == 0
-    b = runner.run(path)  # must not raise "already executing"
+    b = _run(runner, path)  # must not raise "already executing"
+    print(f"first run exit_code={a.exit_code}, second run exit_code={b.exit_code}")
     assert b.exit_code == 0
 
 
@@ -364,7 +396,7 @@ def test_run_times_out_raises_execution_error(tmp_path):
         report_dir=str(tmp_path / "rep"), timeout=1, grace_period=2.0
     )
     with pytest.raises(TestExecutionError, match="timed out"):
-        runner.run(path)
+        _run(runner, path)
 
 
 def test_stdout_and_stderr_are_captured(tmp_path):
@@ -380,31 +412,43 @@ def test_stdout_and_stderr_are_captured(tmp_path):
     )
     # -s disables pytest's capture so the prints reach the child's real
     # stdout/stderr, which is exactly what the runner pipes back.
-    artifacts = SubprocessPytestRunner(report_dir=str(tmp_path / "rep")).run(
-        path, pytest_args=["-s"]
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        pytest_args=["-s"],
     )
+    print(f"stdout: {artifacts.stdout!r}")
+    print(f"stderr: {artifacts.stderr!r}")
     assert artifacts.exit_code == 0
     assert "hello-stdout" in artifacts.stdout
     assert "hello-stderr" in artifacts.stderr
 
 
-def test_usage_error_yields_none_junit_without_raising(tmp_path):
+def test_usage_error_yields_none_report_path_without_raising(tmp_path):
     # An unrecognized pytest option is a usage error (exit 4): pytest exits
     # before writing junit. That's a non-zero outcome, NOT a launch failure,
-    # so run() must return artifacts with junit_xml_path=None rather than
+    # so run() must return artifacts with report_path=None rather than
     # raising TestExecutionError.
     path = _suite(tmp_path, "def test_a(): assert True")
-    artifacts = SubprocessPytestRunner(report_dir=str(tmp_path / "rep")).run(
-        path, pytest_args=["--definitely-not-a-real-option"]
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        pytest_args=["--definitely-not-a-real-option"],
     )
+    print(artifacts.exit_code)
+    print(artifacts.report_path)
+
     assert artifacts.exit_code != 0
-    assert artifacts.junit_xml_path is None
+    assert artifacts.report_path is None
 
 
 def test_working_dir_is_the_report_dir(tmp_path):
     rep = tmp_path / "rep"
     path = _suite(tmp_path, "def test_a(): assert True")
-    artifacts = SubprocessPytestRunner(report_dir=str(rep)).run(path)
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(rep)), path)
+
+    print(artifacts.working_dir)
+
     assert artifacts.working_dir == str(rep)
 
 
@@ -423,9 +467,13 @@ def test_stale_cancel_does_not_abort_next_run(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     runner.cancel()  # no run active -> just records the stale intent
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
+
+    print(artifacts.exit_code)
+    print(artifacts.report_path)
+
     assert artifacts.exit_code == 0
-    assert artifacts.junit_xml_path is not None
+    assert artifacts.report_path is not None
 
 
 def test_separate_instances_run_in_parallel_safely(tmp_path):
@@ -440,7 +488,7 @@ def test_separate_instances_run_in_parallel_safely(tmp_path):
         d.mkdir()
         (d / "test_x.py").write_text("def test_a(): assert True\n")
         r = SubprocessPytestRunner()  # auto temp dir, independent instance
-        art = r.run(str(d))
+        art = _run(r, str(d))
         results[key] = art.working_dir
         r.cleanup(success=True)
 
@@ -523,6 +571,7 @@ def test_terminate_handles_process_lookup_on_sigkill(tmp_path, monkeypatch):
     monkeypatch.setattr(runner, "_signal_group", _signal)
     runner._terminate(_FakeProc())  # type: ignore[arg-type]
     # Both SIGTERM and SIGKILL were attempted.
+    print(f"signal calls: {calls['n']}")
     assert calls["n"] == 2
 
 
@@ -538,7 +587,7 @@ def test_concurrent_cleanup_only_one_rmtree(tmp_path):
     # state the loser would observe.
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner()  # auto temp dir, cleanup="always"
-    artifacts = runner.run(path)
+    artifacts = _run(runner, path)
     auto_dir = artifacts.working_dir
     assert auto_dir is not None and os.path.isdir(auto_dir)
 
@@ -606,9 +655,59 @@ def test_timeout_logs_drained_stdout_and_stderr(tmp_path, monkeypatch, caplog):
     path = _suite(tmp_path, "def test_a(): assert True")
     with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
         with pytest.raises(TestExecutionError, match="timed out"):
-            runner.run(path)
+            _run(runner, path)
 
     # Both tail channels were logged...
     joined = "\n".join(r.getMessage() for r in caplog.records)
+    print(f"caplog records: {joined!r}")
     assert "tail-stdout-data" in joined
     assert "tail-stderr-data" in joined
+
+
+def test_runner_splices_arbitrary_parser_args(tmp_path):
+    # A made-up "no-report" parser: it asks pytest to do nothing special and
+    # reports no file. The runner must (a) not add any junit args of its own,
+    # and (b) still execute pytest successfully.
+    from airflow_pytest_operator.models import ReportRequest
+
+    captured = {}
+
+    def no_report(report_dir):
+        captured["dir"] = report_dir
+        return ReportRequest(pytest_args=(), report_path=None)
+
+    path = _suite(tmp_path, "def test_ok(): assert True")
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    artifacts = _run(runner, path, report_request=no_report)
+
+    print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}, captured dir={captured['dir']!r}")
+    # pytest exited cleanly with zero report-related args added by the runner.
+    assert artifacts.exit_code == 0
+    # No file was declared, so the runner must report None.
+    assert artifacts.report_path is None
+    # The callback got the runner's prepared dir.
+    assert captured["dir"] == str(tmp_path / "rep")
+
+
+def test_runner_reports_none_when_parser_path_missing(tmp_path):
+    # If the parser declares a path but pytest never writes there (e.g. the
+    # plugin isn't installed, or args are wrong), the runner returns
+    # report_path=None rather than a lying path. This is what the operator
+    # relies on to raise "produced no report".
+    from airflow_pytest_operator.models import ReportRequest
+
+    def wrong_path(report_dir):
+        # Real declared path -- but the args we hand pytest don't actually
+        # produce a file there, so the file will be missing post-run.
+        return ReportRequest(
+            pytest_args=(),  # no plugin args -> no file produced
+            report_path=str(tmp_path / "rep" / "wishful.report"),
+        )
+
+    path = _suite(tmp_path, "def test_ok(): assert True")
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    artifacts = _run(runner, path, report_request=wrong_path)
+
+    print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
+    assert artifacts.exit_code == 0
+    assert artifacts.report_path is None

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -72,10 +72,14 @@ def test_runner_passes_extra_args(tmp_path):
         def test_two(): assert True
     """,
     )
-    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path, pytest_args=["-k", "test_one"]
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        pytest_args=["-k", "test_one"],
     )
-    print(f"exit_code={artifacts.exit_code}, stdout snippet: {artifacts.stdout[:120]!r}")
+    print(
+        f"exit_code={artifacts.exit_code}, stdout snippet: {artifacts.stdout[:120]!r}"
+    )
     assert artifacts.exit_code == 0
     assert "test_one" in artifacts.stdout or artifacts.exit_code == 0
 
@@ -88,8 +92,10 @@ def test_runner_forwards_env(tmp_path):
         def test_env(): assert os.environ.get("MY_FLAG") == "42"
     """,
     )
-    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path, env={"MY_FLAG": "42"}
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        env={"MY_FLAG": "42"},
     )
     print(f"exit_code={artifacts.exit_code}")
     assert artifacts.exit_code == 0
@@ -408,8 +414,10 @@ def test_stdout_and_stderr_are_captured(tmp_path):
     )
     # -s disables pytest's capture so the prints reach the child's real
     # stdout/stderr, which is exactly what the runner pipes back.
-    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path, pytest_args=["-s"]
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        pytest_args=["-s"],
     )
     print(f"stdout: {artifacts.stdout!r}")
     print(f"stderr: {artifacts.stderr!r}")
@@ -424,8 +432,10 @@ def test_usage_error_yields_none_report_path_without_raising(tmp_path):
     # so run() must return artifacts with report_path=None rather than
     # raising TestExecutionError.
     path = _suite(tmp_path, "def test_a(): assert True")
-    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path, pytest_args=["--definitely-not-a-real-option"]
+    artifacts = _run(
+        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path,
+        pytest_args=["--definitely-not-a-real-option"],
     )
     print(artifacts.exit_code)
     print(artifacts.report_path)
@@ -700,7 +710,9 @@ def test_runner_splices_arbitrary_parser_args(tmp_path):
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     artifacts = _run(runner, path, report_request=no_report)
 
-    print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}, captured dir={captured['dir']!r}")
+    print(
+        f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}, captured dir={captured['dir']!r}"
+    )
     # pytest exited cleanly with zero report-related args added by the runner.
     assert artifacts.exit_code == 0
     # No file was declared, so the runner must report None.
@@ -1050,9 +1062,7 @@ def test_on_kill_during_active_run_kills_subprocess(tmp_path):
     )
 
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    op = PytestOperator(
-        task_id="t", test_path=str(suite), runner=runner
-    )
+    op = PytestOperator(task_id="t", test_path=str(suite), runner=runner)
 
     # Snapshot of the live PID, captured from a tick thread that polls
     # the runner. We can't read it directly because execute() is going

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -72,10 +72,8 @@ def test_runner_passes_extra_args(tmp_path):
         def test_two(): assert True
     """,
     )
-    artifacts = _run(
-        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path,
-        pytest_args=["-k", "test_one"],
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path, pytest_args=["-k", "test_one"]
     )
     print(f"exit_code={artifacts.exit_code}, stdout snippet: {artifacts.stdout[:120]!r}")
     assert artifacts.exit_code == 0
@@ -90,10 +88,8 @@ def test_runner_forwards_env(tmp_path):
         def test_env(): assert os.environ.get("MY_FLAG") == "42"
     """,
     )
-    artifacts = _run(
-        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path,
-        env={"MY_FLAG": "42"},
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path, env={"MY_FLAG": "42"}
     )
     print(f"exit_code={artifacts.exit_code}")
     assert artifacts.exit_code == 0
@@ -412,10 +408,8 @@ def test_stdout_and_stderr_are_captured(tmp_path):
     )
     # -s disables pytest's capture so the prints reach the child's real
     # stdout/stderr, which is exactly what the runner pipes back.
-    artifacts = _run(
-        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path,
-        pytest_args=["-s"],
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path, pytest_args=["-s"]
     )
     print(f"stdout: {artifacts.stdout!r}")
     print(f"stderr: {artifacts.stderr!r}")
@@ -430,10 +424,8 @@ def test_usage_error_yields_none_report_path_without_raising(tmp_path):
     # so run() must return artifacts with report_path=None rather than
     # raising TestExecutionError.
     path = _suite(tmp_path, "def test_a(): assert True")
-    artifacts = _run(
-        SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
-        path,
-        pytest_args=["--definitely-not-a-real-option"],
+    artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
+        path, pytest_args=["--definitely-not-a-real-option"]
     )
     print(artifacts.exit_code)
     print(artifacts.report_path)
@@ -617,51 +609,79 @@ def test_concurrent_cleanup_only_one_rmtree(tmp_path):
     _shutil.rmtree(auto_dir, ignore_errors=True)
 
 
-def test_timeout_logs_drained_stdout_and_stderr(tmp_path, monkeypatch, caplog):
-    # When the child times out we kill it and drain the pipes one final time.
-    # That tail output should land in the worker log at WARNING level (it is
-    # genuinely useful for diagnosing a hang) but must NOT be embedded into
-    # the TestExecutionError message -- because it can be megabytes and the
-    # message propagates into XCom and the UI.
+def test_timeout_logs_drained_stdout_and_stderr(tmp_path, caplog):
+    # 0.4.0 rewrites pipe-collection: instead of calling communicate() a
+    # second time after the kill (documented as best-effort, races SIGKILL),
+    # two background threads drain stdout and stderr from the moment Popen
+    # returns. By the time we tear the child down, every line it printed is
+    # already in our buffers.
+    #
+    # This test verifies that contract end-to-end with a real subprocess:
+    # a child that prints to BOTH streams and then hangs gets killed by the
+    # timeout, and both lines must show up in the WARNING log -- even
+    # though the child never exited cleanly.
     import logging as _logging
-    import subprocess as _sp
+    import sys as _sys
+    import textwrap
 
-    runner = SubprocessPytestRunner(
-        report_dir=str(tmp_path / "rep"), timeout=0.01, grace_period=0.1
+    # A real pytest test that prints, flushes, then hangs forever.
+    # Flushing is critical: without it the data sits in stdio buffers,
+    # never reaches the pipe, and no drainer (ours or the old design)
+    # could possibly recover it. We want to test the runner's collection,
+    # not Python's stdio buffering.
+    suite = tmp_path / "test_hang.py"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            import sys, time
+
+            def test_hang():
+                # pytest disables stdout capture for output to actually
+                # leave the child by default; -s on the runner side is
+                # not how we ship, so write straight to fd 1/2 instead.
+                # That bypasses pytest's capture and goes to the pipe
+                # the runner is draining.
+                import os
+                os.write(1, b"drained-stdout-line\\n")
+                os.write(2, b"drained-stderr-line\\n")
+                time.sleep(30)  # hang until SIGKILL
+            """
+        ).strip()
     )
 
-    class _HangThenLeak:
-        """First communicate() times out; second one returns the tail data."""
+    # timeout=1.5s is short enough to keep the test fast but long enough
+    # for pytest to collect the suite, start test_hang, write the two
+    # lines, and have the drainer threads pick them up before we kill.
+    runner = SubprocessPytestRunner(
+        python_executable=_sys.executable,
+        report_dir=str(tmp_path / "rep"),
+        timeout=1.5,
+        grace_period=0.5,
+    )
 
-        returncode = -9
-        _calls = 0
-
-        def poll(self):
-            return None
-
-        def communicate(self, timeout=None):
-            type(self)._calls += 1
-            if type(self)._calls == 1:
-                raise _sp.TimeoutExpired(cmd="pytest", timeout=timeout)
-            return ("tail-stdout-data\n", "tail-stderr-data\n")
-
-        def wait(self, timeout=None):
-            return -9
-
-    # Force the runner to use our fake process and skip real kill machinery.
-    monkeypatch.setattr(_sp, "Popen", lambda *_a, **_k: _HangThenLeak())
-    monkeypatch.setattr(runner, "_terminate", lambda proc: None)
-
-    path = _suite(tmp_path, "def test_a(): assert True")
     with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
         with pytest.raises(TestExecutionError, match="timed out"):
-            _run(runner, path)
+            # -s disables pytest's stdout/stderr capture so our os.write
+            # calls reach the actual pipes the runner is draining. Without
+            # it pytest captures fd 1/2 and our markers never leave the
+            # child -- which is a pytest quirk, not the runner's concern.
+            _run(runner, str(suite), pytest_args=["-s"])
 
-    # Both tail channels were logged...
+    # Both lines made it through the drainer threads into the WARNING log,
+    # even though the child was killed mid-sleep and never closed stdio
+    # itself. If the rewrite regressed -- e.g. someone re-introduced a
+    # second communicate() that races the SIGKILL -- one or both of these
+    # would intermittently come up empty.
     joined = "\n".join(r.getMessage() for r in caplog.records)
-    print(f"caplog records: {joined!r}")
-    assert "tail-stdout-data" in joined
-    assert "tail-stderr-data" in joined
+    assert "drained-stdout-line" in joined
+    assert "drained-stderr-line" in joined
+
+
+# ---------------------------------------------------------------------------
+# 0.4.0: the runner is format-agnostic. These tests prove it stays that way
+# by exercising it with a non-JUnit ReportRequest -- if the runner ever
+# acquired JUnit-specific behavior again, these would fail.
+# ---------------------------------------------------------------------------
 
 
 def test_runner_splices_arbitrary_parser_args(tmp_path):
@@ -711,3 +731,389 @@ def test_runner_reports_none_when_parser_path_missing(tmp_path):
     print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
     assert artifacts.exit_code == 0
     assert artifacts.report_path is None
+
+
+# ---------------------------------------------------------------------------
+# Drainer robustness: the background pipe-drainers run on threads we don't
+# control teardown timing for, so they must tolerate the underlying stream
+# being closed underneath them. These tests exercise the defensive except
+# branches that real-process tests can't reliably hit.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_handles_drained_stream_closed_mid_read(tmp_path, monkeypatch):
+    # If the OS or another thread closes the pipe between readline()
+    # iterations, readline() raises ValueError("I/O operation on closed
+    # file"). The drainer must catch it and exit cleanly so .join()
+    # returns -- otherwise the runner hangs on shutdown.
+    #
+    # We exercise this by injecting a fake Popen whose stdout raises
+    # ValueError on the second readline call. Everything else is wired
+    # to look like a normal, instantly-finishing pytest run.
+    import subprocess as _sp
+
+    class _BadStream:
+        def __init__(self):
+            self._calls = 0
+
+        def readline(self):
+            self._calls += 1
+            if self._calls == 1:
+                return "first-line\n"
+            raise ValueError("I/O operation on closed file")
+
+        def close(self):
+            pass
+
+    class _OKStream:
+        def readline(self):
+            return ""
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        returncode = 0
+
+        def __init__(self):
+            self.stdout = _BadStream()
+            self.stderr = _OKStream()
+
+        def poll(self):
+            return 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr(_sp, "Popen", lambda *_a, **_k: _FakeProc())
+    # No real process means _terminate has nothing to do.
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    monkeypatch.setattr(runner, "_terminate", lambda proc: None)
+
+    artifacts = _run(runner, str(tmp_path))
+    # The drainer caught the ValueError and exited; the run completed
+    # rather than hanging. Whatever was drained before the error is
+    # preserved -- in this case the single "first-line".
+    assert artifacts.exit_code == 0
+    assert "first-line" in artifacts.stdout
+
+
+def test_runner_tolerates_close_failure_on_drained_stream(tmp_path, monkeypatch):
+    # Some stream-like objects raise from close() during teardown (a real
+    # case: certain wrapped/buffered streams on systems with restricted
+    # filesystem permissions). The drainer's `finally` swallows any
+    # exception from close() so a teardown hiccup never wedges the runner.
+    import subprocess as _sp
+
+    class _CloseRaiser:
+        def __init__(self):
+            self._done = False
+
+        def readline(self):
+            if not self._done:
+                self._done = True
+                return "one-line\n"
+            return ""  # EOF
+
+        def close(self):
+            raise OSError("close failed for reasons")
+
+    class _OKStream:
+        def readline(self):
+            return ""
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        returncode = 0
+
+        def __init__(self):
+            self.stdout = _CloseRaiser()
+            self.stderr = _OKStream()
+
+        def poll(self):
+            return 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    monkeypatch.setattr(_sp, "Popen", lambda *_a, **_k: _FakeProc())
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    monkeypatch.setattr(runner, "_terminate", lambda proc: None)
+
+    # The run completes without surfacing the close() failure.
+    artifacts = _run(runner, str(tmp_path))
+    assert artifacts.exit_code == 0
+    assert "one-line" in artifacts.stdout
+
+
+def _process_alive(pid: int) -> bool:
+    """Return True if the OS still has a live process with this PID.
+
+    `os.kill(pid, 0)` is the POSIX idiom -- signal 0 does nothing, but
+    the call still fails with OSError/ProcessLookupError if the process
+    is gone (or with PermissionError if we lack rights, which is fine
+    for our purposes: still alive).
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # pragma: no cover -- not expected under test
+        return True
+    return True
+
+
+def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch):
+    # Models Airflow's execution_timeout: an exception that's NOT
+    # subprocess.TimeoutExpired and NOT a normal control-flow exit
+    # interrupts proc.wait() in the main thread (Airflow raises it from
+    # the SIGALRM handler). The runner must kill the child process tree
+    # before the exception propagates out of run() -- otherwise the next
+    # thing Airflow does (calling on_kill -> cancel()) sees self._proc
+    # cleared by the finally and can't terminate anything.
+    import subprocess as _sp
+    import time
+
+    # Stand-in exception class -- mirrors AirflowTaskTimeout's shape (an
+    # Exception subclass that the runner has no special handling for).
+    class FakeTaskTimeout(Exception):
+        pass
+
+    # A real pytest subprocess that hangs for plenty long enough for
+    # our monkeypatched wait() to fire before it would naturally exit.
+    suite = tmp_path / "test_long.py"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            import time
+            def test_long_sleeper(): time.sleep(30)
+            """
+        ).strip()
+    )
+
+    # We monkeypatch proc.wait on the actual Popen instance the runner
+    # creates, but ONLY the first call raises. Subsequent calls fall back
+    # to the real wait(). This matches real Airflow: signal.alarm() fires
+    # once and is then cleared, so AirflowTaskTimeout can only interrupt
+    # one wait. If we made every wait raise, _terminate's own wait
+    # (which it uses to confirm the SIGTERM took effect and to reap the
+    # zombie) would also raise, leaving the child as an un-reaped zombie
+    # that os.kill(pid, 0) wrongly reports as "alive".
+    original_popen = _sp.Popen
+    captured_proc: dict = {}
+
+    def patched_popen(*args, **kwargs):
+        proc = original_popen(*args, **kwargs)
+        captured_proc["proc"] = proc
+        real_wait = proc.wait
+        wait_call_count = {"n": 0}
+
+        def evil_wait(timeout=None):
+            wait_call_count["n"] += 1
+            if wait_call_count["n"] == 1:
+                # Let pytest genuinely start before we "fire the alarm",
+                # so _terminate has a live PID to act on.
+                time.sleep(0.6)
+                raise FakeTaskTimeout("simulated Airflow execution_timeout")
+            # _terminate's wait, and any reap-the-zombie wait, get the
+            # real implementation: they need to actually block on the
+            # OS to confirm the kill landed.
+            return real_wait(timeout=timeout)
+
+        proc.wait = evil_wait  # type: ignore[method-assign]
+        return proc
+
+    monkeypatch.setattr(_sp, "Popen", patched_popen)
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+
+    # The fake exception must propagate UNCHANGED -- the operator's
+    # caller (Airflow) needs to see its own exception type back, not
+    # have it laundered into TestExecutionError.
+    with pytest.raises(FakeTaskTimeout, match="simulated"):
+        _run(runner, str(suite))
+
+    proc = captured_proc["proc"]
+    pid = proc.pid
+
+    # By the time the exception propagates out of run(), _terminate has
+    # already run -- it sent SIGTERM, waited for the grace period via
+    # the *real* wait(), reaped the process, and (if needed) escalated
+    # to SIGKILL. So the child should be gone immediately. We still
+    # give it a tiny budget to cover OS scheduling slack on cold CI.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and _process_alive(pid):
+        time.sleep(0.05)
+    alive_after = _process_alive(pid)
+    print(
+        f"[unexpected_exc_kills_proc] pid={pid} alive_after_propagation={alive_after} "
+        f"returncode={proc.returncode!r} "
+        f"(alive_after must be False, returncode should be -SIGTERM=-15 or -SIGKILL=-9)"
+    )
+
+    assert not alive_after, (
+        f"pytest subprocess (pid={pid}) survived the FakeTaskTimeout: this "
+        "means _run_locked's `except BaseException -> _terminate` clause "
+        "regressed, and Airflow's execution_timeout would now leak orphans."
+    )
+    # Sanity: the process exited because of a signal we sent. Returncode
+    # is negative for signal-induced exits. -15 = SIGTERM (clean grace
+    # path), -9 = SIGKILL (escalation after grace_period elapsed).
+    assert proc.returncode in (-15, -9), (
+        f"unexpected exit cause: returncode={proc.returncode}"
+    )
+
+
+def test_cancel_after_unexpected_exception_is_safe_noop(tmp_path, monkeypatch):
+    # Companion to the above: after the runner has terminated the child
+    # because of an unexpected wait() exception, a SUBSEQUENT cancel()
+    # (which Airflow's on_kill will perform) must be a safe no-op. The
+    # finally has already cleared self._proc, and cancel() sees None.
+    # This guards against a future refactor that, say, retains self._proc
+    # for diagnostics and ends up double-signalling a recycled PID.
+    import subprocess as _sp
+    import time
+
+    class FakeTaskTimeout(Exception):
+        pass
+
+    suite = tmp_path / "test_long.py"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            import time
+            def test_long_sleeper(): time.sleep(30)
+            """
+        ).strip()
+    )
+
+    original_popen = _sp.Popen
+
+    def patched_popen(*args, **kwargs):
+        proc = original_popen(*args, **kwargs)
+        real_wait = proc.wait
+        wait_calls = {"n": 0}
+
+        def evil_wait(timeout=None):
+            wait_calls["n"] += 1
+            if wait_calls["n"] == 1:
+                time.sleep(0.4)
+                raise FakeTaskTimeout("airflow-style timeout")
+            return real_wait(timeout=timeout)
+
+        proc.wait = evil_wait  # type: ignore[method-assign]
+        return proc
+
+    monkeypatch.setattr(_sp, "Popen", patched_popen)
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    with pytest.raises(FakeTaskTimeout):
+        _run(runner, str(suite))
+
+    # The runner's _proc has been cleared. The follow-up cancel() that
+    # Airflow's on_kill triggers must NOT raise and must NOT do anything
+    # observable -- we just verify it returns cleanly.
+    print(
+        "[cancel_after_unexpected_exc] calling cancel() post-exception, "
+        "expecting silent no-op"
+    )
+    runner.cancel()
+    runner.cancel()  # idempotent
+    print("[cancel_after_unexpected_exc] cancel() completed without error")
+
+
+def test_on_kill_during_active_run_kills_subprocess(tmp_path):
+    # Integration-level twin of test_cancel_kills_running_tree, but goes
+    # through PytestOperator.on_kill() instead of calling runner.cancel()
+    # directly. This is the actual call path Airflow uses for SIGTERM
+    # (manual clear, executor kill, heartbeat-detected zombie): a kill
+    # signal is delivered to the worker, Airflow's signal handler calls
+    # task.on_kill(), and we must end up with no live child process.
+    #
+    # We don't have a real Airflow worker here, so we drive on_kill()
+    # directly from a background thread while execute() blocks in run().
+    import threading
+    import time
+
+    from airflow_pytest_operator.operators import PytestOperator
+
+    suite = tmp_path / "test_long.py"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            import time
+            def test_long(): time.sleep(30)
+            """
+        ).strip()
+    )
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    op = PytestOperator(
+        task_id="t", test_path=str(suite), runner=runner
+    )
+
+    # Snapshot of the live PID, captured from a tick thread that polls
+    # the runner. We can't read it directly because execute() is going
+    # to block in the main test thread.
+    captured_pid: dict = {}
+
+    def watcher():
+        # Wait briefly for run() to register the child process, then snap.
+        for _ in range(50):  # up to 5s
+            time.sleep(0.1)
+            proc = runner._proc  # noqa: SLF001 — test introspection
+            if proc is not None:
+                captured_pid["pid"] = proc.pid
+                return
+
+    def killer():
+        # Give pytest a moment to actually start collecting/running.
+        time.sleep(1.0)
+        op.on_kill()  # the actual Airflow call path
+
+    threading.Thread(target=watcher, daemon=True).start()
+    kill_thread = threading.Thread(target=killer, daemon=True)
+    kill_thread.start()
+
+    # execute() runs in the main thread. We expect it to surface a
+    # TestExecutionError ("no report") once the killed pytest exits
+    # without finishing -- a *failure* outcome, not a clean return.
+    from airflow_pytest_operator.exceptions import TestExecutionError
+
+    started = time.monotonic()
+    with pytest.raises(TestExecutionError):
+        op.execute({})  # context unused
+    elapsed = time.monotonic() - started
+
+    kill_thread.join(timeout=3.0)
+
+    pid = captured_pid.get("pid")
+    assert pid is not None, "watcher never saw a live child PID"
+
+    # Same liveness probe as the previous test: the child must be gone.
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and _process_alive(pid):
+        time.sleep(0.05)
+    alive_after = _process_alive(pid)
+    print(
+        f"[on_kill_during_run] pid={pid} elapsed={elapsed:.2f}s "
+        f"alive_after_on_kill={alive_after} (must be False)"
+    )
+
+    # Cleanup also ran: PytestOperator.on_kill() calls
+    # self._runner.cleanup(success=False) defensively. We don't assert
+    # the directory state here (the operator's own finally also runs and
+    # cleanup is idempotent under lock), only that no exception leaked.
+    assert not alive_after, (
+        f"on_kill failed to terminate pytest subprocess (pid={pid}); "
+        "Airflow's SIGTERM path would leave an orphan."
+    )
+    # Sanity: the run did NOT linger past the kill -- elapsed should be
+    # well under the test_long's 30s, demonstrating the kill actually
+    # short-circuited the wait.
+    assert elapsed < 10.0, (
+        f"execute() took {elapsed:.2f}s -- on_kill should short-circuit "
+        "the wait, but the test ran far too long."
+    )

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -59,7 +59,6 @@ def test_runner_nonzero_exit_on_failure_but_does_not_raise(tmp_path):
     path = _suite(tmp_path, "def test_bad(): assert False")
     artifacts = _run(SubprocessPytestRunner(report_dir=str(tmp_path / "rep")), path)
     print(f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}")
-    # A failing test is a valid outcome, not an execution error.
     assert artifacts.exit_code != 0
     assert artifacts.report_path is not None
 
@@ -112,7 +111,6 @@ def test_cancel_kills_running_tree(tmp_path):
     import threading
     import time
 
-    # A test that would hang for a long time if not cancelled.
     path = _suite(
         tmp_path,
         """
@@ -132,7 +130,6 @@ def test_cancel_kills_running_tree(tmp_path):
     started = time.monotonic()
     t.start()
 
-    # Give pytest a moment to actually start the child, then cancel.
     time.sleep(2.0)
     runner.cancel()
     t.join(timeout=15)
@@ -140,19 +137,16 @@ def test_cancel_kills_running_tree(tmp_path):
     elapsed = time.monotonic() - started
     print(f"cancel elapsed: {elapsed:.2f}s")
     assert not t.is_alive(), "run() did not return after cancel"
-    # Must have ended well before the 60s sleep would have finished.
     assert elapsed < 20, f"cancel was too slow: {elapsed:.1f}s"
 
 
 def test_cancel_is_idempotent_and_safe_without_run(tmp_path):
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    # No active run -> no-op, must not raise.
     runner.cancel()
     runner.cancel()
 
 
 def test_cancel_before_completion_then_run_normally(tmp_path):
-    # A normal fast run should still work on a fresh runner instance.
     path = _suite(tmp_path, "def test_ok(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     artifacts = _run(runner, path)
@@ -160,14 +154,9 @@ def test_cancel_before_completion_then_run_normally(tmp_path):
 
 
 def test_auto_cwd_for_directory_target(tmp_path):
-    # Relative paths in addopts should resolve next to the tests, not the
-    # process's inherited cwd. We prove it by having pytest write a file
-    # via a relative --junit-prefix-style side effect: simplest check is
-    # that a relative-output plugin arg lands inside the test dir.
     tests_dir = tmp_path / "suite"
     tests_dir.mkdir()
     (tests_dir / "test_x.py").write_text("def test_a(): assert True\n")
-    # conftest writes a marker file in the *current* working dir at runtime
     (tests_dir / "conftest.py").write_text(
         "import os\n"
         "def pytest_configure(config):\n"
@@ -222,10 +211,6 @@ def test_explicit_cwd_overrides_auto(tmp_path):
 
 
 def test_report_path_unaffected_by_auto_cwd(tmp_path):
-    # The report path is absolute (parser-declared, inside report_dir), so
-    # changing cwd for the child must not misplace it. The literal filename
-    # belongs to the parser, not this test -- we source it via the parser to
-    # avoid a second source of truth for "what file pytest produces".
     tests_dir = tmp_path / "suite"
     tests_dir.mkdir()
     (tests_dir / "test_x.py").write_text("def test_a(): assert True\n")
@@ -240,7 +225,7 @@ def test_report_path_unaffected_by_auto_cwd(tmp_path):
 
 def test_cleanup_removes_auto_dir_by_default(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
-    runner = SubprocessPytestRunner()  # cleanup="always", auto report_dir
+    runner = SubprocessPytestRunner()
     artifacts = _run(runner, path)
     auto_dir = artifacts.working_dir
     assert auto_dir is not None and os.path.isdir(auto_dir)
@@ -262,7 +247,6 @@ def test_cleanup_on_success_keeps_dir_on_failure(tmp_path):
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(cleanup="on_success")
     artifacts = _run(runner, path)
-    # Simulate a failed run -> directory must be retained for post-mortem.
     runner.cleanup(success=False)
 
     assert os.path.isdir(artifacts.working_dir)
@@ -280,16 +264,15 @@ def test_cleanup_never_touches_user_supplied_dir(tmp_path):
     user_dir = tmp_path / "my_reports"
     user_dir.mkdir()
     path = _suite(tmp_path, "def test_a(): assert True")
-    runner = SubprocessPytestRunner(report_dir=str(user_dir))  # cleanup="always"
+    runner = SubprocessPytestRunner(report_dir=str(user_dir))
     _run(runner, path)
     runner.cleanup(success=True)
-    # User-owned directory is never removed, even under "always".
     assert user_dir.is_dir()
 
 
 def test_cleanup_is_safe_without_run(tmp_path):
     runner = SubprocessPytestRunner()
-    runner.cleanup(success=True)  # nothing created yet -> no-op, no raise
+    runner.cleanup(success=True)
 
 
 def test_invalid_cleanup_policy_rejected():
@@ -298,8 +281,6 @@ def test_invalid_cleanup_policy_rejected():
 
 
 def test_report_dir_pointing_at_file_raises_execution_error(tmp_path):
-    # A user-supplied report_dir that is actually a file must surface as
-    # TestExecutionError (launch failure), not a bare OSError.
     not_a_dir = tmp_path / "iam_a_file"
     not_a_dir.write_text("x")
     runner = SubprocessPytestRunner(report_dir=str(not_a_dir))
@@ -308,14 +289,9 @@ def test_report_dir_pointing_at_file_raises_execution_error(tmp_path):
 
 
 def test_cancel_does_not_block_cleanup_during_grace(tmp_path):
-    # Regression for the lock-held-during-grace bug: while cancel() is in its
-    # graceful wait, other lock users (here, cleanup) must not be blocked for
-    # the whole grace period. We assert cleanup returns quickly even though a
-    # cancel of a stubborn (SIGTERM-ignoring) process is mid-grace.
     import threading
     import time
 
-    # A child that ignores SIGTERM, forcing cancel() into the full grace wait.
     path = _suite(
         tmp_path,
         """
@@ -334,14 +310,12 @@ def test_cancel_does_not_block_cleanup_during_grace(tmp_path):
 
     t = threading.Thread(target=_do_run)
     t.start()
-    time.sleep(1.5)  # let the child start
+    time.sleep(1.5)
 
-    # Kick cancel() in another thread; it will sit in the 5s grace wait.
     canceller = threading.Thread(target=runner.cancel)
     canceller.start()
-    time.sleep(0.5)  # ensure cancel() has entered the grace wait
+    time.sleep(0.5)
 
-    # cleanup() must not be blocked for the whole grace period.
     t0 = time.monotonic()
     runner.cleanup(success=False)
     elapsed = time.monotonic() - t0
@@ -352,8 +326,6 @@ def test_cancel_does_not_block_cleanup_during_grace(tmp_path):
 
 
 def test_concurrent_run_on_same_instance_is_rejected(tmp_path):
-    # One slow run holds the instance; a second concurrent run() on the
-    # SAME instance must fail fast rather than race on shared state.
     import threading
     import time
 
@@ -370,29 +342,26 @@ def test_concurrent_run_on_same_instance_is_rejected(tmp_path):
 
     t = threading.Thread(target=_slow)
     t.start()
-    time.sleep(1.0)  # ensure the first run is in progress
+    time.sleep(1.0)
 
     with pytest.raises(TestExecutionError, match="already executing"):
         _run(runner, slow)
 
-    runner.cancel()  # stop the slow one
+    runner.cancel()
     t.join(timeout=15)
 
 
 def test_sequential_reuse_of_same_instance_works(tmp_path):
-    # After a run finishes, the same instance can run again (e.g. retry).
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     a = _run(runner, path)
     assert a.exit_code == 0
-    b = _run(runner, path)  # must not raise "already executing"
+    b = _run(runner, path)
     print(f"first run exit_code={a.exit_code}, second run exit_code={b.exit_code}")
     assert b.exit_code == 0
 
 
 def test_run_times_out_raises_execution_error(tmp_path):
-    # A test slower than the timeout must surface as TestExecutionError and
-    # the child must not be left running.
     path = _suite(tmp_path, "import time\ndef test_slow(): time.sleep(60)\n")
     runner = SubprocessPytestRunner(
         report_dir=str(tmp_path / "rep"), timeout=1, grace_period=2.0
@@ -412,8 +381,6 @@ def test_stdout_and_stderr_are_captured(tmp_path):
             assert True
         """,
     )
-    # -s disables pytest's capture so the prints reach the child's real
-    # stdout/stderr, which is exactly what the runner pipes back.
     artifacts = _run(
         SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
         path,
@@ -427,10 +394,6 @@ def test_stdout_and_stderr_are_captured(tmp_path):
 
 
 def test_usage_error_yields_none_report_path_without_raising(tmp_path):
-    # An unrecognized pytest option is a usage error (exit 4): pytest exits
-    # before writing junit. That's a non-zero outcome, NOT a launch failure,
-    # so run() must return artifacts with report_path=None rather than
-    # raising TestExecutionError.
     path = _suite(tmp_path, "def test_a(): assert True")
     artifacts = _run(
         SubprocessPytestRunner(report_dir=str(tmp_path / "rep")),
@@ -455,20 +418,15 @@ def test_working_dir_is_the_report_dir(tmp_path):
 
 
 def test_resolve_cwd_none_for_node_id_or_glob_target(tmp_path):
-    # Node-id ("tests/x.py::test_a") and glob targets don't exist as paths,
-    # so the runner declines to guess a cwd and lets pytest use the inherited
-    # one. _resolve_cwd is the single decision point for that behavior.
     runner = SubprocessPytestRunner()
     assert runner._resolve_cwd(str(tmp_path / "x.py::test_a")) is None
     assert runner._resolve_cwd(str(tmp_path / "tests" / "*.py")) is None
 
 
 def test_stale_cancel_does_not_abort_next_run(tmp_path):
-    # cancel() with no active run sets a flag; the next run() must reset it so
-    # a stale cancel from a prior lifecycle doesn't kill a fresh run.
     path = _suite(tmp_path, "def test_a(): assert True")
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
-    runner.cancel()  # no run active -> just records the stale intent
+    runner.cancel()
     artifacts = _run(runner, path)
 
     print(artifacts.exit_code)
@@ -479,8 +437,6 @@ def test_stale_cancel_does_not_abort_next_run(tmp_path):
 
 
 def test_separate_instances_run_in_parallel_safely(tmp_path):
-    # The normal Airflow case: independent runners don't interfere, and each
-    # cleans up only its own temp dir.
     import threading
 
     results = {}
@@ -489,7 +445,7 @@ def test_separate_instances_run_in_parallel_safely(tmp_path):
         d = tmp_path / f"suite_{key}"
         d.mkdir()
         (d / "test_x.py").write_text("def test_a(): assert True\n")
-        r = SubprocessPytestRunner()  # auto temp dir, independent instance
+        r = SubprocessPytestRunner()
         art = _run(r, str(d))
         results[key] = art.working_dir
         r.cleanup(success=True)
@@ -500,7 +456,6 @@ def test_separate_instances_run_in_parallel_safely(tmp_path):
     for t in threads:
         t.join(timeout=30)
 
-    # All three got distinct temp dirs and all were cleaned up.
     dirs = list(results.values())
     assert len(set(dirs)) == 3, "temp dirs collided across instances"
     for d in dirs:
@@ -508,28 +463,19 @@ def test_separate_instances_run_in_parallel_safely(tmp_path):
 
 
 def test_terminate_returns_early_when_process_already_dead(tmp_path):
-    # _terminate must no-op when the process has already exited (poll()
-    # returns a code), exercising its early-return guard (subprocess_runner
-    # _terminate poll() branch). We use a real, already-finished process.
     import subprocess as _sp
 
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     dead = _sp.Popen([sys.executable, "-c", "pass"])
-    dead.wait()  # ensure it has fully exited
+    dead.wait()
     assert dead.poll() is not None
-    # Must return cleanly without trying to signal a dead process.
     runner._terminate(dead)
 
 
 def test_terminate_handles_process_lookup_on_sigterm(tmp_path, monkeypatch):
-    # If the process dies between the poll() check and the SIGTERM, killpg
-    # raises ProcessLookupError; _terminate must swallow it and return
-    # (the "race: gone before SIGTERM" branch).
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
 
     class _FakeProc:
-        # poll() returns None (looks alive) so we get past the early guard,
-        # then _signal_group raises ProcessLookupError as if it just died.
         returncode = None
 
         def poll(self):
@@ -539,14 +485,10 @@ def test_terminate_handles_process_lookup_on_sigterm(tmp_path, monkeypatch):
         raise ProcessLookupError
 
     monkeypatch.setattr(runner, "_signal_group", _raise_lookup)
-    # Must not raise.
     runner._terminate(_FakeProc())  # type: ignore[arg-type]
 
 
 def test_terminate_handles_process_lookup_on_sigkill(tmp_path, monkeypatch):
-    # The process survives SIGTERM and the grace wait, then disappears right
-    # before SIGKILL: the second _signal_group raises ProcessLookupError,
-    # which _terminate must also swallow (the SIGKILL-race branch).
     import signal as _signal_module
     import subprocess as _sp
 
@@ -559,7 +501,6 @@ def test_terminate_handles_process_lookup_on_sigkill(tmp_path, monkeypatch):
             return None
 
         def wait(self, timeout=None):
-            # Never exits during grace -> forces escalation to SIGKILL.
             raise _sp.TimeoutExpired(cmd="pytest", timeout=timeout)
 
     calls = {"n": 0}
@@ -568,27 +509,16 @@ def test_terminate_handles_process_lookup_on_sigkill(tmp_path, monkeypatch):
         calls["n"] += 1
         if sig == _signal_module.SIGKILL:
             raise ProcessLookupError
-        # SIGTERM path returns normally.
 
     monkeypatch.setattr(runner, "_signal_group", _signal)
     runner._terminate(_FakeProc())  # type: ignore[arg-type]
-    # Both SIGTERM and SIGKILL were attempted.
     print(f"signal calls: {calls['n']}")
     assert calls["n"] == 2
 
 
 def test_concurrent_cleanup_only_one_rmtree(tmp_path):
-    # Two cleanup() calls racing (e.g. operator post-run + on_kill) must not
-    # both rmtree: the loser sees _created_report_dir already claimed as None
-    # under the lock and bails (the cleanup race-guard branch).
-    #
-    # The race is between the unlocked first read (sees a path) and the
-    # locked re-read (sees None because the winner cleared it). We make it
-    # deterministic by wrapping the runner's lock so that the instant this
-    # cleanup() acquires it, the path has already been claimed -- exactly the
-    # state the loser would observe.
     path = _suite(tmp_path, "def test_a(): assert True")
-    runner = SubprocessPytestRunner()  # auto temp dir, cleanup="always"
+    runner = SubprocessPytestRunner()
     artifacts = _run(runner, path)
     auto_dir = artifacts.working_dir
     assert auto_dir is not None and os.path.isdir(auto_dir)
@@ -596,7 +526,6 @@ def test_concurrent_cleanup_only_one_rmtree(tmp_path):
     real_lock = runner._lock
 
     class _ClaimingLock:
-        # On acquire, simulate the winner having already taken the path.
         def __enter__(self):
             runner._created_report_dir = None
             return real_lock.__enter__()
@@ -605,40 +534,20 @@ def test_concurrent_cleanup_only_one_rmtree(tmp_path):
             return real_lock.__exit__(*exc)
 
     runner._lock = _ClaimingLock()  # type: ignore[assignment]
-    # First (unlocked) read sees the real path; locked re-read sees None ->
-    # the guard returns without rmtree and without raising.
     runner.cleanup(success=True)
     runner._lock = real_lock  # type: ignore[assignment]
 
-    # Because the loser bailed, the directory is NOT removed here -- proving
-    # the guard prevented a double-rmtree rather than racing into one.
     assert os.path.isdir(auto_dir)
-    # Clean up the leftover dir ourselves so the test leaves no trace.
     import shutil as _shutil
 
     _shutil.rmtree(auto_dir, ignore_errors=True)
 
 
 def test_timeout_logs_drained_stdout_and_stderr(tmp_path, caplog):
-    # 0.4.0 rewrites pipe-collection: instead of calling communicate() a
-    # second time after the kill (documented as best-effort, races SIGKILL),
-    # two background threads drain stdout and stderr from the moment Popen
-    # returns. By the time we tear the child down, every line it printed is
-    # already in our buffers.
-    #
-    # This test verifies that contract end-to-end with a real subprocess:
-    # a child that prints to BOTH streams and then hangs gets killed by the
-    # timeout, and both lines must show up in the WARNING log -- even
-    # though the child never exited cleanly.
     import logging as _logging
     import sys as _sys
     import textwrap
 
-    # A real pytest test that prints, flushes, then hangs forever.
-    # Flushing is critical: without it the data sits in stdio buffers,
-    # never reaches the pipe, and no drainer (ours or the old design)
-    # could possibly recover it. We want to test the runner's collection,
-    # not Python's stdio buffering.
     suite = tmp_path / "test_hang.py"
     suite.write_text(
         textwrap.dedent(
@@ -659,9 +568,6 @@ def test_timeout_logs_drained_stdout_and_stderr(tmp_path, caplog):
         ).strip()
     )
 
-    # timeout=1.5s is short enough to keep the test fast but long enough
-    # for pytest to collect the suite, start test_hang, write the two
-    # lines, and have the drainer threads pick them up before we kill.
     runner = SubprocessPytestRunner(
         python_executable=_sys.executable,
         report_dir=str(tmp_path / "rep"),
@@ -671,33 +577,14 @@ def test_timeout_logs_drained_stdout_and_stderr(tmp_path, caplog):
 
     with caplog.at_level(_logging.WARNING, logger="airflow_pytest_operator"):
         with pytest.raises(TestExecutionError, match="timed out"):
-            # -s disables pytest's stdout/stderr capture so our os.write
-            # calls reach the actual pipes the runner is draining. Without
-            # it pytest captures fd 1/2 and our markers never leave the
-            # child -- which is a pytest quirk, not the runner's concern.
             _run(runner, str(suite), pytest_args=["-s"])
 
-    # Both lines made it through the drainer threads into the WARNING log,
-    # even though the child was killed mid-sleep and never closed stdio
-    # itself. If the rewrite regressed -- e.g. someone re-introduced a
-    # second communicate() that races the SIGKILL -- one or both of these
-    # would intermittently come up empty.
     joined = "\n".join(r.getMessage() for r in caplog.records)
     assert "drained-stdout-line" in joined
     assert "drained-stderr-line" in joined
 
 
-# ---------------------------------------------------------------------------
-# 0.4.0: the runner is format-agnostic. These tests prove it stays that way
-# by exercising it with a non-JUnit ReportRequest -- if the runner ever
-# acquired JUnit-specific behavior again, these would fail.
-# ---------------------------------------------------------------------------
-
-
 def test_runner_splices_arbitrary_parser_args(tmp_path):
-    # A made-up "no-report" parser: it asks pytest to do nothing special and
-    # reports no file. The runner must (a) not add any junit args of its own,
-    # and (b) still execute pytest successfully.
     from airflow_pytest_operator.models import ReportRequest
 
     captured = {}
@@ -713,26 +600,17 @@ def test_runner_splices_arbitrary_parser_args(tmp_path):
     print(
         f"exit_code={artifacts.exit_code}, report_path={artifacts.report_path!r}, captured dir={captured['dir']!r}"
     )
-    # pytest exited cleanly with zero report-related args added by the runner.
     assert artifacts.exit_code == 0
-    # No file was declared, so the runner must report None.
     assert artifacts.report_path is None
-    # The callback got the runner's prepared dir.
     assert captured["dir"] == str(tmp_path / "rep")
 
 
 def test_runner_reports_none_when_parser_path_missing(tmp_path):
-    # If the parser declares a path but pytest never writes there (e.g. the
-    # plugin isn't installed, or args are wrong), the runner returns
-    # report_path=None rather than a lying path. This is what the operator
-    # relies on to raise "produced no report".
     from airflow_pytest_operator.models import ReportRequest
 
     def wrong_path(report_dir):
-        # Real declared path -- but the args we hand pytest don't actually
-        # produce a file there, so the file will be missing post-run.
         return ReportRequest(
-            pytest_args=(),  # no plugin args -> no file produced
+            pytest_args=(),
             report_path=str(tmp_path / "rep" / "wishful.report"),
         )
 
@@ -745,23 +623,7 @@ def test_runner_reports_none_when_parser_path_missing(tmp_path):
     assert artifacts.report_path is None
 
 
-# ---------------------------------------------------------------------------
-# Drainer robustness: the background pipe-drainers run on threads we don't
-# control teardown timing for, so they must tolerate the underlying stream
-# being closed underneath them. These tests exercise the defensive except
-# branches that real-process tests can't reliably hit.
-# ---------------------------------------------------------------------------
-
-
 def test_runner_handles_drained_stream_closed_mid_read(tmp_path, monkeypatch):
-    # If the OS or another thread closes the pipe between readline()
-    # iterations, readline() raises ValueError("I/O operation on closed
-    # file"). The drainer must catch it and exit cleanly so .join()
-    # returns -- otherwise the runner hangs on shutdown.
-    #
-    # We exercise this by injecting a fake Popen whose stdout raises
-    # ValueError on the second readline call. Everything else is wired
-    # to look like a normal, instantly-finishing pytest run.
     import subprocess as _sp
 
     class _BadStream:
@@ -798,23 +660,15 @@ def test_runner_handles_drained_stream_closed_mid_read(tmp_path, monkeypatch):
             return 0
 
     monkeypatch.setattr(_sp, "Popen", lambda *_a, **_k: _FakeProc())
-    # No real process means _terminate has nothing to do.
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     monkeypatch.setattr(runner, "_terminate", lambda proc: None)
 
     artifacts = _run(runner, str(tmp_path))
-    # The drainer caught the ValueError and exited; the run completed
-    # rather than hanging. Whatever was drained before the error is
-    # preserved -- in this case the single "first-line".
     assert artifacts.exit_code == 0
     assert "first-line" in artifacts.stdout
 
 
 def test_runner_tolerates_close_failure_on_drained_stream(tmp_path, monkeypatch):
-    # Some stream-like objects raise from close() during teardown (a real
-    # case: certain wrapped/buffered streams on systems with restricted
-    # filesystem permissions). The drainer's `finally` swallows any
-    # exception from close() so a teardown hiccup never wedges the runner.
     import subprocess as _sp
 
     class _CloseRaiser:
@@ -825,7 +679,7 @@ def test_runner_tolerates_close_failure_on_drained_stream(tmp_path, monkeypatch)
             if not self._done:
                 self._done = True
                 return "one-line\n"
-            return ""  # EOF
+            return ""
 
         def close(self):
             raise OSError("close failed for reasons")
@@ -854,7 +708,6 @@ def test_runner_tolerates_close_failure_on_drained_stream(tmp_path, monkeypatch)
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     monkeypatch.setattr(runner, "_terminate", lambda proc: None)
 
-    # The run completes without surfacing the close() failure.
     artifacts = _run(runner, str(tmp_path))
     assert artifacts.exit_code == 0
     assert "one-line" in artifacts.stdout
@@ -878,23 +731,12 @@ def _process_alive(pid: int) -> bool:
 
 
 def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch):
-    # Models Airflow's execution_timeout: an exception that's NOT
-    # subprocess.TimeoutExpired and NOT a normal control-flow exit
-    # interrupts proc.wait() in the main thread (Airflow raises it from
-    # the SIGALRM handler). The runner must kill the child process tree
-    # before the exception propagates out of run() -- otherwise the next
-    # thing Airflow does (calling on_kill -> cancel()) sees self._proc
-    # cleared by the finally and can't terminate anything.
     import subprocess as _sp
     import time
 
-    # Stand-in exception class -- mirrors AirflowTaskTimeout's shape (an
-    # Exception subclass that the runner has no special handling for).
-    class FakeTaskTimeout(Exception):
+    class FakeTaskTimeout(Exception): # noqa: N818
         pass
 
-    # A real pytest subprocess that hangs for plenty long enough for
-    # our monkeypatched wait() to fire before it would naturally exit.
     suite = tmp_path / "test_long.py"
     suite.write_text(
         textwrap.dedent(
@@ -905,14 +747,6 @@ def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch
         ).strip()
     )
 
-    # We monkeypatch proc.wait on the actual Popen instance the runner
-    # creates, but ONLY the first call raises. Subsequent calls fall back
-    # to the real wait(). This matches real Airflow: signal.alarm() fires
-    # once and is then cleared, so AirflowTaskTimeout can only interrupt
-    # one wait. If we made every wait raise, _terminate's own wait
-    # (which it uses to confirm the SIGTERM took effect and to reap the
-    # zombie) would also raise, leaving the child as an un-reaped zombie
-    # that os.kill(pid, 0) wrongly reports as "alive".
     original_popen = _sp.Popen
     captured_proc: dict = {}
 
@@ -925,13 +759,8 @@ def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch
         def evil_wait(timeout=None):
             wait_call_count["n"] += 1
             if wait_call_count["n"] == 1:
-                # Let pytest genuinely start before we "fire the alarm",
-                # so _terminate has a live PID to act on.
                 time.sleep(0.6)
                 raise FakeTaskTimeout("simulated Airflow execution_timeout")
-            # _terminate's wait, and any reap-the-zombie wait, get the
-            # real implementation: they need to actually block on the
-            # OS to confirm the kill landed.
             return real_wait(timeout=timeout)
 
         proc.wait = evil_wait  # type: ignore[method-assign]
@@ -941,20 +770,12 @@ def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch
 
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
 
-    # The fake exception must propagate UNCHANGED -- the operator's
-    # caller (Airflow) needs to see its own exception type back, not
-    # have it laundered into TestExecutionError.
     with pytest.raises(FakeTaskTimeout, match="simulated"):
         _run(runner, str(suite))
 
     proc = captured_proc["proc"]
     pid = proc.pid
 
-    # By the time the exception propagates out of run(), _terminate has
-    # already run -- it sent SIGTERM, waited for the grace period via
-    # the *real* wait(), reaped the process, and (if needed) escalated
-    # to SIGKILL. So the child should be gone immediately. We still
-    # give it a tiny budget to cover OS scheduling slack on cold CI.
     deadline = time.monotonic() + 2.0
     while time.monotonic() < deadline and _process_alive(pid):
         time.sleep(0.05)
@@ -970,25 +791,16 @@ def test_unexpected_exception_during_wait_kills_subprocess(tmp_path, monkeypatch
         "means _run_locked's `except BaseException -> _terminate` clause "
         "regressed, and Airflow's execution_timeout would now leak orphans."
     )
-    # Sanity: the process exited because of a signal we sent. Returncode
-    # is negative for signal-induced exits. -15 = SIGTERM (clean grace
-    # path), -9 = SIGKILL (escalation after grace_period elapsed).
     assert proc.returncode in (-15, -9), (
         f"unexpected exit cause: returncode={proc.returncode}"
     )
 
 
 def test_cancel_after_unexpected_exception_is_safe_noop(tmp_path, monkeypatch):
-    # Companion to the above: after the runner has terminated the child
-    # because of an unexpected wait() exception, a SUBSEQUENT cancel()
-    # (which Airflow's on_kill will perform) must be a safe no-op. The
-    # finally has already cleared self._proc, and cancel() sees None.
-    # This guards against a future refactor that, say, retains self._proc
-    # for diagnostics and ends up double-signalling a recycled PID.
     import subprocess as _sp
     import time
 
-    class FakeTaskTimeout(Exception):
+    class FakeTaskTimeout(Exception): # noqa: N818
         pass
 
     suite = tmp_path / "test_long.py"
@@ -1024,28 +836,16 @@ def test_cancel_after_unexpected_exception_is_safe_noop(tmp_path, monkeypatch):
     with pytest.raises(FakeTaskTimeout):
         _run(runner, str(suite))
 
-    # The runner's _proc has been cleared. The follow-up cancel() that
-    # Airflow's on_kill triggers must NOT raise and must NOT do anything
-    # observable -- we just verify it returns cleanly.
     print(
         "[cancel_after_unexpected_exc] calling cancel() post-exception, "
         "expecting silent no-op"
     )
     runner.cancel()
-    runner.cancel()  # idempotent
+    runner.cancel()
     print("[cancel_after_unexpected_exc] cancel() completed without error")
 
 
 def test_on_kill_during_active_run_kills_subprocess(tmp_path):
-    # Integration-level twin of test_cancel_kills_running_tree, but goes
-    # through PytestOperator.on_kill() instead of calling runner.cancel()
-    # directly. This is the actual call path Airflow uses for SIGTERM
-    # (manual clear, executor kill, heartbeat-detected zombie): a kill
-    # signal is delivered to the worker, Airflow's signal handler calls
-    # task.on_kill(), and we must end up with no live child process.
-    #
-    # We don't have a real Airflow worker here, so we drive on_kill()
-    # directly from a background thread while execute() blocks in run().
     import threading
     import time
 
@@ -1064,14 +864,10 @@ def test_on_kill_during_active_run_kills_subprocess(tmp_path):
     runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
     op = PytestOperator(task_id="t", test_path=str(suite), runner=runner)
 
-    # Snapshot of the live PID, captured from a tick thread that polls
-    # the runner. We can't read it directly because execute() is going
-    # to block in the main test thread.
     captured_pid: dict = {}
 
     def watcher():
-        # Wait briefly for run() to register the child process, then snap.
-        for _ in range(50):  # up to 5s
+        for _ in range(50):
             time.sleep(0.1)
             proc = runner._proc  # noqa: SLF001 — test introspection
             if proc is not None:
@@ -1079,22 +875,18 @@ def test_on_kill_during_active_run_kills_subprocess(tmp_path):
                 return
 
     def killer():
-        # Give pytest a moment to actually start collecting/running.
         time.sleep(1.0)
-        op.on_kill()  # the actual Airflow call path
+        op.on_kill()
 
     threading.Thread(target=watcher, daemon=True).start()
     kill_thread = threading.Thread(target=killer, daemon=True)
     kill_thread.start()
 
-    # execute() runs in the main thread. We expect it to surface a
-    # TestExecutionError ("no report") once the killed pytest exits
-    # without finishing -- a *failure* outcome, not a clean return.
     from airflow_pytest_operator.exceptions import TestExecutionError
 
     started = time.monotonic()
     with pytest.raises(TestExecutionError):
-        op.execute({})  # context unused
+        op.execute({})
     elapsed = time.monotonic() - started
 
     kill_thread.join(timeout=3.0)
@@ -1102,7 +894,6 @@ def test_on_kill_during_active_run_kills_subprocess(tmp_path):
     pid = captured_pid.get("pid")
     assert pid is not None, "watcher never saw a live child PID"
 
-    # Same liveness probe as the previous test: the child must be gone.
     deadline = time.monotonic() + 2.0
     while time.monotonic() < deadline and _process_alive(pid):
         time.sleep(0.05)
@@ -1127,3 +918,77 @@ def test_on_kill_during_active_run_kills_subprocess(tmp_path):
         f"execute() took {elapsed:.2f}s -- on_kill should short-circuit "
         "the wait, but the test ran far too long."
     )
+
+
+@pytest.mark.parametrize("bad", [0, -1, -1024])
+def test_runner_rejects_non_positive_max_output_bytes(bad):
+    with pytest.raises(ValueError, match="max_output_bytes"):
+        SubprocessPytestRunner(max_output_bytes=bad)
+
+
+def test_runner_truncates_stdout_when_cap_exceeded(tmp_path):
+    cap = 4096
+    path = _suite(
+        tmp_path,
+        """
+        def test_noisy():
+            # ~200 KiB of stdout, an order of magnitude above the cap.
+            for i in range(2000):
+                print('x' * 100)
+            assert True
+        """,
+    )
+    runner = SubprocessPytestRunner(
+        report_dir=str(tmp_path / "rep"), max_output_bytes=cap
+    )
+    artifacts = _run(runner, path, pytest_args=["-s"])
+    print(
+        f"[truncate] exit={artifacts.exit_code} "
+        f"stdout_len={len(artifacts.stdout)} cap={cap}"
+    )
+    assert artifacts.exit_code == 0
+    assert artifacts.report_path is not None
+    assert "stdout truncated at" in artifacts.stdout
+    assert len(artifacts.stdout.encode("utf-8")) <= cap + 1024
+
+
+def test_runner_truncates_stderr_when_cap_exceeded(tmp_path):
+    cap = 4096
+    path = _suite(
+        tmp_path,
+        """
+        import sys
+        def test_noisy_stderr():
+            for i in range(2000):
+                print('e' * 100, file=sys.stderr)
+            assert True
+        """,
+    )
+    runner = SubprocessPytestRunner(
+        report_dir=str(tmp_path / "rep"), max_output_bytes=cap
+    )
+    artifacts = _run(runner, path, pytest_args=["-s"])
+    assert artifacts.exit_code == 0
+    assert artifacts.report_path is not None
+    assert "stderr truncated at" in artifacts.stderr
+    assert len(artifacts.stderr.encode("utf-8")) <= cap + 1024
+
+
+def test_runner_does_not_truncate_when_cap_disabled(tmp_path):
+    path = _suite(
+        tmp_path,
+        """
+        def test_quiet():
+            print('hello-from-child')
+            assert True
+        """,
+    )
+    runner = SubprocessPytestRunner(
+        report_dir=str(tmp_path / "rep"), max_output_bytes=None
+    )
+    artifacts = _run(runner, path, pytest_args=["-s"])
+    print(f"[no-cap] stdout_len={len(artifacts.stdout)}")
+    assert artifacts.exit_code == 0
+    assert "hello-from-child" in artifacts.stdout
+    assert "truncated" not in artifacts.stdout
+    assert "truncated" not in artifacts.stderr


### PR DESCRIPTION
### Breaking changes
This release removes the runner's hardcoded knowledge of the JUnit format.
Parsers now declare which pytest CLI flags they need and where their report
will land; the runner just splices those args verbatim and reports back the
declared path. No deprecation aliases are provided -- breakage is intentional
and loud, because the silent-fallback alternative (a `JSONResultParser` that
secretly gets a JUnit XML file) is much harder to diagnose than a `TypeError`
at startup.