### PR TITLE
dry run pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
 on:
-  # PR-only: with branch protection, all changes reach main through a PR,
-  # so the PR run is the authoritative gate. A duplicate `push: main` run
-  # after merge would re-test identical code and waste CI minutes.
+  # PRs are the authoritative gate (branch protection ensures every change
+  # reaches main through a PR). We also run on push to main so Codecov has
+  # a baseline coverage report for the default branch -- without it, PR
+  # coverage diffs against main are inaccurate.
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 # Cancel superseded runs on the same ref to save CI minutes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,45 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Change history
+
+- [0.4.2 — PytestOperator: dry-run / collect-only test collection mode](#042---2026-06-06)
+- [0.4.1 — Immutable TestRunResult.cases and unified failed_node_ids format](#041---2026-06-06)
+- [0.4.0 — Format-agnostic runner and safe stdout/stderr draining (output cap)](#040---2026-06-04)
+- [0.3.1 — Security hardening and CI improvements (SHA‑pinning, CodeQL)](#031---2026-05-31)
+- [0.3.0 — Coverage and CI integration (pytest‑cov, Codecov)](#030---2026-05-30)
+- [0.2.1 — Airflow 3 compatibility: lazy imports and worker startup fix](#021---2026-05-24)
+- [0.2.0 — XCom contract and run behavior changes (single return_value, do_xcom_push)](#020---2026-05-24)
+- [0.1.0 — Initial release: operator, runner, parser, core functionality](#010---2026-05-23)
+
 ## [Unreleased]
+
+## [0.4.2] - 2026-06-06
+
+### Added
+- `PytestOperator(dry_run=True)` -- new optional argument that switches
+  the run to pytest's ``--collect-only`` mode. Test bodies do NOT
+  execute; pytest only collects them (imports modules, runs collection-
+  time fixtures, walks the test tree). Intended as a pre-flight task in
+  a DAG: verifies the test path resolves on the worker, that imports
+  succeed (so the worker has all required deps installed), and that
+  collection itself succeeds (no syntax errors, no missing fixtures).
+  Collection errors surface the same way normal test failures do --
+  the task fails with ``TestsFailedError`` under the default
+  ``fail_on_test_failure=True``. The user's ``pytest_args`` are not
+  mutated; the ``--collect-only`` flag is appended to a per-call
+  effective list at ``execute()`` time, so retries see the original
+  configuration and downstream introspection of the operator is honest.
+  Default ``dry_run=False`` -- behaviour unchanged for existing tasks.
+- `JSONResultParser` now reports ``TestRunResult.total`` from
+  ``summary.collected`` when ``summary.total`` is 0 and no per-case
+  entries were parsed. This is exactly the shape pytest-json-report
+  writes in ``--collect-only`` mode (zero "ran" tests, N collected).
+  Normal runs are unaffected -- the fallback only kicks in when there
+  is no other signal. The JUnit XML for ``--collect-only`` contains
+  no ``<testcase>`` entries at all (``<testsuite tests="0">``), so the
+  JUnit parser cannot report a count for dry-run; the operator
+  docstring notes this limitation.
 
 ## [0.4.1] - 2026-06-06
 
@@ -406,7 +444,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.3.0...v0.3.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,18 @@
 # Contributing
 
+## Table of Contents
+
+- [Getting started](#getting-started)
+- [Quality gates](#quality-gates)
+- [Design principles](#design-principles)
+- [License headers on new files](#license-headers-on-new-files)
+- [Tests](#tests)
+- [Branching and pull requests](#branching-and-pull-requests)
+- [Commit messages and PRs](#commit-messages-and-prs)
+- [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+- [Reviewing and merging (for maintainers)](#reviewing-and-merging-for-maintainers)
+- [License](#license)
+
 Thanks for your interest in improving **airflow-pytest-operator**! This guide covers how to set up a dev environment, the checks your change must pass, and how to submit it.
 
 ## Getting started

--- a/README.md
+++ b/README.md
@@ -19,11 +19,39 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/IKrysanov/airflow-pytest-operator/badge)](https://scorecard.dev/viewer/?uri=github.com/IKrysanov/airflow-pytest-operator)
 </details>
 
+## Table of Contents
+
+- [Why a child process](#why-a-child-process)
+- [Install](#install)
+  - [Quick install](#quick-install)
+  - [Installing in Docker / constrained environments](#installing-in-docker--constrained-environments)
+- [Verifying the release](#verifying-the-release)
+  - [Path 1 — verify the PyPI artifact (PEP 740)](#path-1--verify-the-pypi-artifact-pep-740)
+  - [Path 2 — verify the GitHub Release artifact (Sigstore bundle)](#path-2--verify-the-github-release-artifact-sigstore-bundle)
+- [Usage](#usage)
+- [Passing values from upstream tasks into your tests](#passing-values-from-upstream-tasks-into-your-tests)
+- [Constructor options](#constructor-options)
+- [pytest config, plugins, and Allure](#pytest-config-plugins-and-allure)
+- [Report cleanup](#report-cleanup)
+- [Cancellation and timeouts](#cancellation-and-timeouts)
+- [Dry-run mode](#dry-run-mode)
+- [Where do the tests live?](#where-do-the-tests-live)
+- [Built-in parsers](#built-in-parsers)
+- [Extending it](#extending-it)
+  - [Custom parser](#custom-parser)
+  - [Custom runner](#custom-runner)
+- [Architecture](#architecture)
+- [Development](#development)
+- [Changelog](#changelog)
+- [License](#license)
+
 ## Why a child process
 
 Tests run via `{sys.executable} -m pytest`, i.e. in the **same virtualenv / interpreter as the Airflow worker** (same dependencies), but in a **child process**. This keeps pytest's global-state mutations (`sys.modules`, plugins, cwd, logging) out of the long-lived worker while still satisfying "same environment" semantics. A crashing or segfaulting test can't take the worker down, and the child can be killed cleanly on timeout or task termination.
 
 ## Install
+
+### Quick install
 
 ```bash
 pip install airflow-pytest-operator
@@ -273,6 +301,7 @@ The parameters specific to `PytestOperator` are:
 | `pytest_args` | `[]` | Extra pytest CLI args, e.g. `["-k", "smoke", "-x"]`. Templated. |
 | `env` | `{}` | Extra environment variables for the run. Templated. |
 | `fail_on_test_failure` | `True` | Fail the task on any test failure/error. If `False`, the task always succeeds and the outcome is only reflected in XCom. |
+| `dry_run` | `False` | Run pytest in `--collect-only` mode: import the test modules and walk the collection tree, but **do not execute test bodies**. Useful as a pre-flight task in a DAG; see [Dry-run mode](#dry-run-mode) below. |
 | `do_xcom_push` | `True` | Airflow's standard flag. When on, the summary dict is pushed to XCom under the `return_value` key. Set `False` to disable all XCom output. Read it downstream with `xcom_pull(task_ids="<task>")`. |
 | `runner` | `SubprocessPytestRunner()` | Injectable execution strategy (see *Extending*). |
 | `parser` | `JUnitResultParser()` | Injectable report parser (see *Extending*). |
@@ -311,6 +340,52 @@ A **user-supplied** `report_dir` is never removed — it's your data. Cleanup al
 When Airflow kills the task (execution timeout, manual clear/mark-failed, worker shutdown), the operator's `on_kill` delegates to the runner, which terminates the **entire pytest process tree** — not just the direct child. This matters because pytest spawns its own children (e.g. `xdist` workers). Termination is graceful by default: `SIGTERM`, wait `grace_period` seconds (default 10), then `SIGKILL`. Set `timeout=` on the runner to bound the run itself.
 
 > **Platform note:** process-group termination is fully supported on **Linux and macOS**. On Windows the package runs and cancels the direct process, but reliable whole-tree termination is not guaranteed; Airflow workers are Linux in virtually all deployments.
+
+## Dry-run mode
+
+`dry_run=True` runs pytest with `--collect-only`. Test bodies are not executed, but pytest still imports the test modules, walks the collection tree, and runs `conftest.py`. This is exactly what you want for a **pre-flight validation** task at the start of a DAG: it catches stale paths, missing deps on the worker, broken imports, `SyntaxError`s, and renamed fixtures in seconds rather than minutes.
+
+```python
+from airflow_pytest_operator import PytestOperator
+
+# Pre-flight: validate that tests collect cleanly on this worker.
+validate = PytestOperator(
+    task_id="validate_tests",
+    test_path="tests/",
+    dry_run=True,
+)
+
+# Real run, gated on the pre-flight succeeding.
+run = PytestOperator(
+    task_id="run_tests",
+    test_path="tests/",
+)
+
+validate >> run
+```
+
+A collection error (broken import, `SyntaxError`, missing fixture used by a parametrize) fails the dry-run task just like a test failure would, so downstream tasks are skipped and the real run never starts.
+
+**What dry-run does and doesn't do:**
+
+| Step | Real run | `dry_run=True` |
+|---|---|---|
+| Import test modules | yes | **yes** |
+| Run module-level code | yes | **yes** |
+| Run `conftest.py` | yes | **yes** |
+| Collect tests (walk the tree) | yes | yes |
+| Run collection-time fixtures | yes | yes |
+| **Run test bodies** | yes | **no** |
+| Run session/module/function teardown | yes | only for collection-time setup, if any |
+
+So `dry_run` is not a no-op — module-level side effects happen. It's "collect only", which is meaningfully cheaper than a real run but still imports your code.
+
+**Result interpretation:**
+
+- With `parser=JSONResultParser()`, `TestRunResult.total` reports the number of collected tests (parsed from `summary.collected`).
+- With the default `JUnitResultParser`, the XML pytest emits in `--collect-only` mode contains no `<testcase>` entries (`<testsuite tests="0">`), so `total` is `0`. The task still passes/fails correctly based on exit code; only the collected-count is unavailable. Use the JSON parser if you need the count for branching downstream.
+
+**Interaction with user-supplied flags:** if you already passed `--collect-only` (or its aliases `--collectonly`, `--co`) in `pytest_args`, the operator won't add another one. The dedup is targeted only at the collect-only family — other repeated args (`-v -v`, multiple `-o KEY=VAL`, multiple `--ignore=...`) are preserved as-is.
 
 ## Where do the tests live?
 
@@ -415,6 +490,10 @@ ruff check src tests
 mypy
 pytest --cov
 ```
+
+## Changelog
+
+See [CHANGELOG](CHANGELOG.md).
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.4.1"
+version = "0.4.2"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -81,6 +81,7 @@ Homepage = "https://github.com/IKrysanov/airflow-pytest-operator"
 Repository = "https://github.com/IKrysanov/airflow-pytest-operator"
 Issues = "https://github.com/IKrysanov/airflow-pytest-operator/issues"
 Changelog = "https://github.com/IKrysanov/airflow-pytest-operator/blob/main/CHANGELOG.md"
+Contributing = "https://github.com/IKrysanov/airflow-pytest-operator/blob/main/CONTRIBUTING.md"
 
 # Exposes the package to Airflow's provider-discovery mechanism so it shows
 # up in `airflow providers list` and the UI. Operators also work via plain

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -44,6 +44,17 @@ class PytestOperator(BaseOperator):
     :param fail_on_test_failure: if True (default) the task fails when any
         test fails or errors; if False the task always succeeds and the
         outcome is only reflected in XCom.
+    :param dry_run: when True, pytest is invoked with ``--collect-only``.
+        Test bodies are NOT executed; only collection runs. Useful as a
+        pre-flight task in a DAG: verifies the test path resolves on the
+        worker, imports succeed (so worker has all required deps), and
+        collection itself succeeds (no syntax errors, no missing fixtures).
+        Note that ``--collect-only`` still imports the test modules and
+        runs their module-level code, so this is "no tests are executed",
+        not "nothing happens". Collection errors surface the same way
+        normal failures do -- exit code is non-zero, ``TestRunResult.success``
+        is False, and (with the default ``fail_on_test_failure=True``) the
+        task fails. Default: False.
     :param runner: injectable :class:`PytestRunner` (default: subprocess).
     :param parser: injectable :class:`ResultParser` (default: JUnit).
 
@@ -59,6 +70,10 @@ class PytestOperator(BaseOperator):
 
     _MAX_STDERR_LEN = 4096
 
+    _COLLECT_ONLY_ALIASES: frozenset[str] = frozenset(
+        {"--collect-only", "--collectonly", "--co"}
+    )
+
     def __init__(
         self,
         *,
@@ -66,6 +81,7 @@ class PytestOperator(BaseOperator):
         pytest_args: Sequence[str] | None = None,
         env: dict[str, str] | None = None,
         fail_on_test_failure: bool = True,
+        dry_run: bool = False,
         runner: PytestRunner | None = None,
         parser: ResultParser | None = None,
         **kwargs: Any,
@@ -75,17 +91,32 @@ class PytestOperator(BaseOperator):
         self.pytest_args = list(pytest_args) if pytest_args else []
         self.env = env or {}
         self.fail_on_test_failure = fail_on_test_failure
+        self.dry_run = dry_run
         self._runner = runner or SubprocessPytestRunner()
         self._parser = parser or JUnitResultParser()
 
     def execute(self, context: Any) -> dict[str, Any]:
-        self.log.info("Running pytest on %s", self.test_path)
+        if self.dry_run:
+            self.log.info(
+                "Running pytest in dry-run mode (--collect-only) on %s -- "
+                "tests will be collected but their bodies will NOT run. "
+                "Module-level code and collection-time fixtures still execute.",
+                self.test_path,
+            )
+        else:
+            self.log.info("Running pytest on %s", self.test_path)
+
+        effective_args = list(self.pytest_args)
+        if self.dry_run and not any(
+            arg in self._COLLECT_ONLY_ALIASES for arg in effective_args
+        ):
+            effective_args.append("--collect-only")
 
         run_ok = False
         try:
             artifacts = self._runner.run(
                 self.test_path,
-                pytest_args=self.pytest_args,
+                pytest_args=effective_args,
                 env=self.env,
                 # The parser decides which pytest flags to add and where the
                 # report will land; the runner just splices and reports back.

--- a/src/airflow_pytest_operator/reporters/json_parser.py
+++ b/src/airflow_pytest_operator/reporters/json_parser.py
@@ -182,6 +182,11 @@ class JSONResultParser(ResultParser):
             # "failed" instead and removes it from xpassed -- so there is
             # no double-count to worry about. See test_xpassed_strict.
             passed += coerce("xpassed")
+
+            if total == 0 and len(cases) == 0:
+                collected = coerce("collected")
+                if collected > 0:
+                    total = collected
         else:
             total = len(cases)
             passed = sum(1 for c in cases if c.outcome == "passed")

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -795,3 +795,43 @@ def test_summary_collected_zero_keeps_total_zero(tmp_path):
     result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
     print(f"[collected_fallback:zero] total={result.total}")
     assert result.total == 0
+
+
+def test_dry_run_with_json_parser_reports_collected_count(tmp_path):
+    suite = tmp_path / "test_dual.py"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            def test_a(): assert True
+            def test_b(): assert True
+            def test_c(): assert True
+            """
+        ).strip()
+    )
+
+    spec = JSONResultParser().report_request(str(tmp_path))
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(suite),
+            "--collect-only",
+            *spec.pytest_args,
+            "-q",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+
+    result = JSONResultParser().parse(spec.report_path, exit_code=0)
+    print(
+        f"[dry_run:json_parser] total={result.total} "
+        f"cases={len(result.cases)} success={result.success}"
+    )
+
+    assert result.total == 3
+    assert len(result.cases) == 0
+    assert result.success is True
+    assert result.failed_node_ids == []

--- a/tests/test_json_parser.py
+++ b/tests/test_json_parser.py
@@ -765,3 +765,33 @@ def test_split_nodeid_normalises_windows_backslashes():
     print(f"[split:windows_nested] classname={cn!r} name={name!r}")
     assert cn == "a.b.c.test_x.TestClass"
     assert name == "test_method"
+
+
+def test_summary_collected_fallback_does_not_override_normal_runs(tmp_path):
+    payload = {
+        "duration": 0.5,
+        "tests": [
+            {"nodeid": "f.py::a", "outcome": "passed", "call": {"duration": 0.1}},
+            {"nodeid": "f.py::b", "outcome": "passed", "call": {"duration": 0.1}},
+            {"nodeid": "f.py::c", "outcome": "failed", "call": {"duration": 0.1}},
+        ],
+        # If the fallback were applied blindly, total would become 99.
+        "summary": {"total": 3, "passed": 2, "failed": 1, "collected": 99},
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=1)
+    print(
+        f"[collected_fallback:negative] total={result.total} "
+        f"(must be 3, summary.collected=99 is ignored on normal runs)"
+    )
+    assert result.total == 3
+
+
+def test_summary_collected_zero_keeps_total_zero(tmp_path):
+    payload = {
+        "duration": 0.01,
+        "tests": [],
+        "summary": {"total": 0, "collected": 0},
+    }
+    result = JSONResultParser().parse(_write_json(tmp_path, payload), exit_code=0)
+    print(f"[collected_fallback:zero] total={result.total}")
+    assert result.total == 0

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -554,8 +554,12 @@ def test_dry_run_default_is_false():
     assert op.dry_run is False
 
 
-def test_dry_run_logs_indicate_mode(caplog):
-    import logging as _logging
+def test_dry_run_logs_indicate_mode():
+    # Airflow operator loggers do NOT always propagate to root, so pytest's
+    # ``caplog`` fixture misses them on some Airflow versions. We capture
+    # at the source: mock op.log.info and inspect what was called. This
+    # mirrors the pattern used by test_stdout_and_stderr_are_logged.
+    from unittest import mock
 
     runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
     parser = FakeParser(_result(passed=0))
@@ -567,14 +571,15 @@ def test_dry_run_logs_indicate_mode(caplog):
         parser=parser,
     )
 
-    with caplog.at_level(_logging.INFO):
+    with mock.patch.object(op.log, "info") as info:
         op.execute(_ctx())
 
-    joined = "\n".join(r.getMessage() for r in caplog.records)
-    print(f"[dry_run:log] captured: {joined!r}")
-
-    assert "dry-run" in joined
-    assert "--collect-only" in joined
+    # Flatten all info() calls into one string so users searching for
+    # either "dry-run" or "--collect-only" find the matching line.
+    logged = " ".join(str(c) for c in info.call_args_list)
+    print(f"[dry_run:log] info() calls: {logged!r}")
+    assert "dry-run" in logged
+    assert "--collect-only" in logged
 
 
 def test_dry_run_does_not_double_add_when_user_passed_collect_only():
@@ -648,11 +653,14 @@ def test_dry_run_dedup_does_not_touch_other_repeated_flags():
         task_id="t",
         test_path="tests/",
         pytest_args=[
-            "-v", "-v",                                  # extra-verbose
-            "-o", "console_output_style=count",          # paired -o #1
-            "-o", "junit_family=xunit2",                 # paired -o #2
-            "--ignore=tests/slow",                       # ignore #1
-            "--ignore=tests/flaky",                      # ignore #2
+            "-v",
+            "-v",  # extra-verbose
+            "-o",
+            "console_output_style=count",  # paired -o #1
+            "-o",
+            "junit_family=xunit2",  # paired -o #2
+            "--ignore=tests/slow",  # ignore #1
+            "--ignore=tests/flaky",  # ignore #2
         ],
         dry_run=True,
         runner=runner,
@@ -664,9 +672,12 @@ def test_dry_run_dedup_does_not_touch_other_repeated_flags():
     forwarded_args = runner.calls[0]["pytest_args"]
     print(f"[dedup:narrow] forwarded = {forwarded_args!r}")
     expected_user_args = [
-        "-v", "-v",
-        "-o", "console_output_style=count",
-        "-o", "junit_family=xunit2",
+        "-v",
+        "-v",
+        "-o",
+        "console_output_style=count",
+        "-o",
+        "junit_family=xunit2",
         "--ignore=tests/slow",
         "--ignore=tests/flaky",
     ]

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -482,3 +482,215 @@ def test_report_parse_error_is_not_swallowed_by_fail_on_test_failure_false():
 
     with pytest.raises(ReportParseError):
         op.execute(_ctx())
+
+
+def test_dry_run_appends_collect_only_to_runner_args():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dry_run:args] forwarded pytest_args = {forwarded_args!r}")
+
+    assert forwarded_args[:2] == ["-k", "smoke"]
+    assert forwarded_args.count("--collect-only") == 1
+    assert forwarded_args[-1] == "--collect-only"
+
+
+def test_dry_run_false_does_not_append_collect_only():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        # dry_run=False is the default; explicit to make intent clear
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dry_run:default_off] forwarded pytest_args = {forwarded_args!r}")
+    assert "--collect-only" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]
+
+
+def test_dry_run_does_not_mutate_user_pytest_args():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    user_args = ["-k", "smoke", "-v"]
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=user_args,
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+    op.execute(_ctx())  # second execute (retry simulation)
+
+    print(f"[dry_run:no_mutation] op.pytest_args after two runs = {op.pytest_args!r}")
+    assert op.pytest_args == ["-k", "smoke", "-v"]
+    for call in runner.calls:
+        assert call["pytest_args"].count("--collect-only") == 1
+
+
+def test_dry_run_default_is_false():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[dry_run:default_pin] op.dry_run = {op.dry_run}")
+    assert op.dry_run is False
+
+
+def test_dry_run_logs_indicate_mode(caplog):
+    import logging as _logging
+
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    with caplog.at_level(_logging.INFO):
+        op.execute(_ctx())
+
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    print(f"[dry_run:log] captured: {joined!r}")
+
+    assert "dry-run" in joined
+    assert "--collect-only" in joined
+
+
+def test_dry_run_does_not_double_add_when_user_passed_collect_only():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke", "--collect-only"],
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dedup:explicit] forwarded = {forwarded_args!r}")
+
+    assert forwarded_args.count("--collect-only") == 1
+    assert forwarded_args == ["-k", "smoke", "--collect-only"]
+
+
+def test_dry_run_recognises_collectonly_alias():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--collectonly"],
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dedup:legacy_alias] forwarded = {forwarded_args!r}")
+    # Operator left the user's alias in place AND did not append its own
+    # --collect-only on top.
+    assert "--collect-only" not in forwarded_args
+    assert forwarded_args == ["--collectonly"]
+
+
+def test_dry_run_recognises_co_short_alias():
+    # ``--co`` is the short alias. Same dedup principle.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--co"],
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dedup:short_alias] forwarded = {forwarded_args!r}")
+    assert "--collect-only" not in forwarded_args
+    assert forwarded_args == ["--co"]
+
+
+def test_dry_run_dedup_does_not_touch_other_repeated_flags():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=[
+            "-v", "-v",                                  # extra-verbose
+            "-o", "console_output_style=count",          # paired -o #1
+            "-o", "junit_family=xunit2",                 # paired -o #2
+            "--ignore=tests/slow",                       # ignore #1
+            "--ignore=tests/flaky",                      # ignore #2
+        ],
+        dry_run=True,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dedup:narrow] forwarded = {forwarded_args!r}")
+    expected_user_args = [
+        "-v", "-v",
+        "-o", "console_output_style=count",
+        "-o", "junit_family=xunit2",
+        "--ignore=tests/slow",
+        "--ignore=tests/flaky",
+    ]
+    # User's args, in order, followed by our appended --collect-only.
+    assert forwarded_args[:-1] == expected_user_args
+    assert forwarded_args[-1] == "--collect-only"
+    # Total count: 8 user args + 1 appended --collect-only = 9.
+    assert len(forwarded_args) == 9
+
+
+def test_dry_run_false_with_collect_only_in_args_still_runs_collection():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=0))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--collect-only", "-k", "smoke"],
+        dry_run=False,
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx())
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[dedup:user_explicit_dry_run_off] forwarded = {forwarded_args!r}")
+    assert forwarded_args == ["--collect-only", "-k", "smoke"]

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1058,3 +1058,112 @@ def test_drainer_size_counting_is_fast_on_long_suite_output():
         f"under_count_ratio={under_ratio:.3f} -- the realistic mix should "
         "stay well under 1.10 for ASCII-dominant pytest output."
     )
+
+
+def test_dry_run_only_collects_does_not_execute_test_bodies(tmp_path):
+    from airflow_pytest_operator import JSONResultParser
+    from airflow_pytest_operator.operators import PytestOperator
+
+    marker = tmp_path / "test_body_executed"
+    suite = tmp_path / "test_x.py"
+    suite.write_text(
+        textwrap.dedent(
+            f"""
+            import pathlib
+
+            def test_would_fail():
+                # Sentinel: prove whether the body ran.
+                pathlib.Path({str(marker)!r}).touch()
+                assert False, "this would fail if executed"
+
+            def test_would_pass():
+                pathlib.Path({str(marker)!r}).touch()
+                assert True
+            """
+        ).strip()
+    )
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    op = PytestOperator(
+        task_id="t",
+        test_path=str(suite),
+        dry_run=True,
+        runner=runner,
+        parser=JSONResultParser(),
+    )
+
+    summary = op.execute({})
+
+    print(
+        f"[dry_run:e2e] total={summary['total']} "
+        f"failed={summary['failed']} "
+        f"marker_exists={marker.exists()} "
+        f"exit_code={summary['exit_code']}"
+    )
+
+    # THE essential property: no test body ran.
+    assert not marker.exists(), (
+        "test body executed despite dry_run=True -- the operator's "
+        "--collect-only flag was not honoured"
+    )
+    # Collected count: JSON parser pulls this from summary.collected when
+    # summary.total is zero. Two tests in the suite, two reported.
+    assert summary["total"] == 2
+    # And nothing actually failed (because nothing actually ran).
+    assert summary["failed"] == 0
+    assert summary["errors"] == 0
+    assert summary["exit_code"] == 0
+
+
+def test_dry_run_collection_error_surfaces_as_task_failure(tmp_path):
+    from airflow_pytest_operator import JSONResultParser
+    from airflow_pytest_operator.exceptions import TestsFailedError
+    from airflow_pytest_operator.operators import PytestOperator
+
+    suite = tmp_path / "test_broken.py"
+    suite.write_text("def test_x(:  # invalid syntax\n    pass\n")
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    op = PytestOperator(
+        task_id="t",
+        test_path=str(suite),
+        dry_run=True,
+        runner=runner,
+        parser=JSONResultParser(),
+    )
+
+    with pytest.raises(TestsFailedError):
+        op.execute({})
+
+
+def test_dry_run_with_junit_parser_collects_but_lacks_count(tmp_path):
+    from airflow_pytest_operator import JUnitResultParser
+    from airflow_pytest_operator.operators import PytestOperator
+
+    suite = tmp_path / "test_x.py"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            def test_a(): assert True
+            def test_b(): assert True
+            def test_c(): assert True
+            """
+        ).strip()
+    )
+
+    runner = SubprocessPytestRunner(report_dir=str(tmp_path / "rep"))
+    op = PytestOperator(
+        task_id="t",
+        test_path=str(suite),
+        dry_run=True,
+        runner=runner,
+        parser=JUnitResultParser(),
+    )
+    summary = op.execute({})
+
+    print(f"[dry_run:junit_limitation] total={summary['total']}")
+    # Collection succeeded (exit code 0, no test failed) ...
+    assert summary["exit_code"] == 0
+    assert summary["failed"] == 0
+    # ... but JUnit can't tell us how many tests were collected.
+    assert summary["total"] == 0

--- a/tests/test_subprocess_runner.py
+++ b/tests/test_subprocess_runner.py
@@ -1061,7 +1061,6 @@ def test_drainer_size_counting_is_fast_on_long_suite_output():
 
 
 def test_dry_run_only_collects_does_not_execute_test_bodies(tmp_path):
-    from airflow_pytest_operator import JSONResultParser
     from airflow_pytest_operator.operators import PytestOperator
 
     marker = tmp_path / "test_body_executed"
@@ -1089,16 +1088,14 @@ def test_dry_run_only_collects_does_not_execute_test_bodies(tmp_path):
         test_path=str(suite),
         dry_run=True,
         runner=runner,
-        parser=JSONResultParser(),
     )
 
     summary = op.execute({})
 
     print(
-        f"[dry_run:e2e] total={summary['total']} "
+        f"[dry_run:e2e] exit_code={summary['exit_code']} "
         f"failed={summary['failed']} "
-        f"marker_exists={marker.exists()} "
-        f"exit_code={summary['exit_code']}"
+        f"marker_exists={marker.exists()}"
     )
 
     # THE essential property: no test body ran.
@@ -1106,17 +1103,13 @@ def test_dry_run_only_collects_does_not_execute_test_bodies(tmp_path):
         "test body executed despite dry_run=True -- the operator's "
         "--collect-only flag was not honoured"
     )
-    # Collected count: JSON parser pulls this from summary.collected when
-    # summary.total is zero. Two tests in the suite, two reported.
-    assert summary["total"] == 2
-    # And nothing actually failed (because nothing actually ran).
+    assert summary["exit_code"] == 0
     assert summary["failed"] == 0
     assert summary["errors"] == 0
-    assert summary["exit_code"] == 0
+    assert summary["total"] == 0
 
 
 def test_dry_run_collection_error_surfaces_as_task_failure(tmp_path):
-    from airflow_pytest_operator import JSONResultParser
     from airflow_pytest_operator.exceptions import TestsFailedError
     from airflow_pytest_operator.operators import PytestOperator
 
@@ -1129,11 +1122,15 @@ def test_dry_run_collection_error_surfaces_as_task_failure(tmp_path):
         test_path=str(suite),
         dry_run=True,
         runner=runner,
-        parser=JSONResultParser(),
     )
 
     with pytest.raises(TestsFailedError):
         op.execute({})
+    print(
+        "[dry_run:collection_error] dry_run with SyntaxError raised "
+        "TestsFailedError as expected -- collection errors are NOT "
+        "silenced by --collect-only"
+    )
 
 
 def test_dry_run_with_junit_parser_collects_but_lacks_count(tmp_path):


### PR DESCRIPTION
### Added
- `PytestOperator(dry_run=True)` -- new optional argument that switches
  the run to pytest's ``--collect-only`` mode. Test bodies do NOT
  execute; pytest only collects them (imports modules, runs collection-
  time fixtures, walks the test tree). Intended as a pre-flight task in
  a DAG: verifies the test path resolves on the worker, that imports
  succeed (so the worker has all required deps installed), and that
  collection itself succeeds (no syntax errors, no missing fixtures).
  Collection errors surface the same way normal test failures do --
  the task fails with ``TestsFailedError`` under the default
  ``fail_on_test_failure=True``. The user's ``pytest_args`` are not
  mutated; the ``--collect-only`` flag is appended to a per-call
  effective list at ``execute()`` time, so retries see the original
  configuration and downstream introspection of the operator is honest.
  Default ``dry_run=False`` -- behaviour unchanged for existing tasks.
- `JSONResultParser` now reports ``TestRunResult.total`` from
  ``summary.collected`` when ``summary.total`` is 0 and no per-case
  entries were parsed. This is exactly the shape pytest-json-report
  writes in ``--collect-only`` mode (zero "ran" tests, N collected).
  Normal runs are unaffected -- the fallback only kicks in when there
  is no other signal. The JUnit XML for ``--collect-only`` contains
  no ``<testcase>`` entries at all (``<testsuite tests="0">``), so the
  JUnit parser cannot report a count for dry-run; the operator
  docstring notes this limitation.