### PR TITLE
Add test_retry_strategy="failed_only" for --lf retries (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On a pytest **timeout**, the raised `TestExecutionError` now carries the
   captured `stdout` / `stderr` as attributes (not just in the worker log), so
   operators and UIs can surface *why* a run hung programmatically.
+- `PytestOperator(test_retry_strategy="failed_only")` -- new optional
+  argument controlling how Airflow task *retries* re-run the suite. With
+  the default ``"all"`` the whole suite re-runs on every retry (behaviour
+  unchanged). With ``"failed_only"`` the operator appends pytest's ``--lf``
+  (``--last-failed``) on retry attempts (``try_number > 1``), so only the
+  tests that failed on the previous attempt run again -- a large saving on
+  big suites where only a few tests fail. The first attempt always runs the
+  full suite. ``--lf`` is backed by pytest's ``.pytest_cache``, so the
+  narrowing only happens when that cache from the previous attempt is still
+  readable on the worker; otherwise pytest safely falls back to the full
+  suite. The user's ``pytest_args`` are not mutated -- the flag is appended
+  to a per-call effective list at ``execute()`` time and is not double-added
+  if ``--lf``/``--last-failed`` is already present. An invalid value raises
+  ``ValueError``. Default ``"all"`` -- behaviour unchanged for existing tasks.
 
 ### Changed
 - **Breaking (pre-release):** `SubprocessPytestRunner` no longer takes a

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 - [Report location & cleanup](#report-location--cleanup)
 - [Cancellation and timeouts](#cancellation-and-timeouts)
 - [Dry-run mode](#dry-run-mode)
+- [Retry strategy (failed-only reruns)](#retry-strategy-failed-only-reruns)
 - [Where do the tests live?](#where-do-the-tests-live)
 - [Built-in parsers](#built-in-parsers)
 - [Extending it](#extending-it)
@@ -315,6 +316,7 @@ The parameters specific to `PytestOperator` are:
 | `env` | `{}` | Extra environment variables for the run. Templated. |
 | `fail_on_test_failure` | `True` | Fail the task on any test failure/error. If `False`, the task always succeeds and the outcome is only reflected in XCom. |
 | `dry_run` | `False` | Run pytest in `--collect-only` mode: import the test modules and walk the collection tree, but **do not execute test bodies**. Useful as a pre-flight task in a DAG; see [Dry-run mode](#dry-run-mode) below. |
+| `test_retry_strategy` | `"all"` | How Airflow task **retries** re-run the suite. `"all"` re-runs everything; `"failed_only"` appends pytest's `--lf` on retries so only previously failed tests run again. See [Retry strategy](#retry-strategy-failed-only-reruns) below. |
 | `do_xcom_push` | `True` | Airflow's standard flag. When on, the summary dict is pushed to XCom under the `return_value` key. Set `False` to disable all XCom output. Read it downstream with `xcom_pull(task_ids="<task>")`. |
 | `runner` | `SubprocessPytestRunner()` | Injectable execution strategy (see *Extending*). |
 | `parser` | `JUnitResultParser()` | Injectable report parser (see *Extending*). |
@@ -413,6 +415,32 @@ So `dry_run` is not a no-op — module-level side effects happen. It's "collect 
 - With the default `JUnitResultParser`, the XML pytest emits in `--collect-only` mode contains no `<testcase>` entries (`<testsuite tests="0">`), so `total` is `0`. The task still passes/fails correctly based on exit code; only the collected-count is unavailable. Use the JSON parser if you need the count for branching downstream.
 
 **Interaction with user-supplied flags:** if you already passed `--collect-only` (or its aliases `--collectonly`, `--co`) in `pytest_args`, the operator won't add another one. The dedup is targeted only at the collect-only family — other repeated args (`-v -v`, multiple `-o KEY=VAL`, multiple `--ignore=...`) are preserved as-is.
+
+## Retry strategy (failed-only reruns)
+
+By default, when an Airflow task retries, the **entire** pytest suite runs again. For a large suite where only a couple of tests failed, that wastes a lot of time. Set `test_retry_strategy="failed_only"` to make retries re-run **only the tests that failed on the previous attempt**, using pytest's `--lf` (`--last-failed`):
+
+```python
+from airflow_pytest_operator import PytestOperator
+
+run = PytestOperator(
+    task_id="run_tests",
+    test_path="tests/",
+    retries=2,                          # Airflow's standard retry count
+    test_retry_strategy="failed_only",  # retries re-run only what failed
+)
+```
+
+How it works:
+
+- **First attempt** (`try_number == 1`) always runs the full suite.
+- **Each retry** (`try_number > 1`) appends `--lf`, so pytest re-runs only the previously failed tests.
+- `--lf` reads pytest's `.pytest_cache`. The narrowing therefore only kicks in when that cache from the previous attempt is still readable on the worker. If it isn't (e.g. the retry lands on a different worker with no shared filesystem, or the cache dir is ephemeral), pytest **safely falls back to running the whole suite** — you never silently skip tests.
+- The operator does not mutate your `pytest_args`; `--lf` is added to a per-call list at execute time, and it won't be added twice if you already passed `--lf`/`--last-failed` yourself.
+
+> **Tip:** for the cache to survive across retries, the test folder (where `.pytest_cache` is written) should live on storage that persists between attempts on the same worker. On distributed executors without shared storage, treat `failed_only` as a best-effort optimisation that gracefully degrades to a full run.
+
+The default `test_retry_strategy="all"` keeps the original behaviour (full suite on every retry).
 
 ## Where do the tests live?
 

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -56,6 +56,19 @@ class PytestOperator(BaseOperator):
         normal failures do -- exit code is non-zero, ``TestRunResult.success``
         is False, and (with the default ``fail_on_test_failure=True``) the
         task fails. Default: False.
+    :param test_retry_strategy: how Airflow task *retries* re-run the
+        suite. ``"all"`` (default) re-runs the whole suite on every retry --
+        unchanged behaviour. ``"failed_only"`` appends pytest's ``--lf``
+        (``--last-failed``) on retry attempts (``try_number > 1``), so only
+        the tests that failed on the previous attempt run again; this can
+        cut retry time dramatically on large suites where only a few tests
+        failed. The first attempt always runs the full suite. ``--lf`` is
+        backed by pytest's cache (``.pytest_cache``), so it only narrows the
+        run when that cache from the previous attempt is still readable on
+        the worker; otherwise pytest safely falls back to running everything.
+        The user's ``pytest_args`` are not mutated -- the flag is appended to
+        a per-call effective list at ``execute()`` time, and is not added if
+        ``--lf``/``--last-failed`` is already present. Default: ``"all"``.
     :param runner: injectable :class:`PytestRunner` (default: subprocess).
     :param parser: injectable :class:`ResultParser` (default: JUnit). The
         parser owns the report location: set ``report_dir`` on it, e.g.
@@ -80,6 +93,10 @@ class PytestOperator(BaseOperator):
         {"--collect-only", "--collectonly", "--co"}
     )
 
+    _RETRY_STRATEGIES: frozenset[str] = frozenset({"all", "failed_only"})
+
+    _LAST_FAILED_ALIASES: frozenset[str] = frozenset({"--lf", "--last-failed"})
+
     def __init__(
         self,
         *,
@@ -88,16 +105,23 @@ class PytestOperator(BaseOperator):
         env: dict[str, str] | None = None,
         fail_on_test_failure: bool = True,
         dry_run: bool = False,
+        test_retry_strategy: str = "all",
         runner: PytestRunner | None = None,
         parser: ResultParser | None = None,
         **kwargs: Any,
     ) -> None:
+        if test_retry_strategy not in self._RETRY_STRATEGIES:
+            raise ValueError(
+                "test_retry_strategy must be one of 'all', 'failed_only'; "
+                f"got {test_retry_strategy!r}"
+            )
         super().__init__(**kwargs)
         self.test_path = test_path
         self.pytest_args = list(pytest_args) if pytest_args else []
         self.env = env or {}
         self.fail_on_test_failure = fail_on_test_failure
         self.dry_run = dry_run
+        self.test_retry_strategy = test_retry_strategy
         self._runner = runner or SubprocessPytestRunner()
         self._parser = parser or JUnitResultParser()
 
@@ -117,6 +141,22 @@ class PytestOperator(BaseOperator):
             arg in self._COLLECT_ONLY_ALIASES for arg in effective_args
         ):
             effective_args.append("--collect-only")
+
+        # On Airflow retries, optionally narrow the run to only the tests
+        # that failed on the previous attempt (pytest --lf). The first
+        # attempt always runs the full suite; we don't double-add the flag
+        # if the user already passed it. Like --collect-only above, this is
+        # spliced into a per-call effective list, so self.pytest_args (and
+        # thus downstream introspection / the next retry) stays unmutated.
+        if self.test_retry_strategy == "failed_only" and self._is_retry(context):
+            if not any(arg in self._LAST_FAILED_ALIASES for arg in effective_args):
+                effective_args.append("--lf")
+                self.log.info(
+                    "Retry attempt detected with test_retry_strategy='failed_only' "
+                    "-- appending --lf so pytest re-runs only the tests that failed "
+                    "on the previous attempt (falls back to the full suite if the "
+                    "pytest cache is unavailable on this worker)."
+                )
 
         run_ok = False
         try:
@@ -191,6 +231,20 @@ class PytestOperator(BaseOperator):
                 self._runner.cleanup(success=run_ok)
             except Exception:  # pragma: no cover - best-effort teardown
                 self.log.exception("Error while cleaning up report directory")
+
+    @staticmethod
+    def _is_retry(context: Any) -> bool:
+        """True when Airflow is re-running this task (a retry attempt).
+
+        Airflow exposes the attempt number on the task instance as
+        ``try_number``: 1 on the first attempt, 2+ on each retry. We read it
+        defensively (``getattr`` with a default of 1) so a missing or
+        unusual context degrades to "first attempt" -- i.e. the full suite
+        runs -- rather than raising during execute().
+        """
+        ti = context.get("ti") if hasattr(context, "get") else None
+        try_number = getattr(ti, "try_number", 1)
+        return isinstance(try_number, int) and try_number > 1
 
     def on_kill(self) -> None:
         """Abort the test run when Airflow terminates the task.

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -81,8 +81,12 @@ class FakeParser:
 
 
 class FakeTI:
-    def __init__(self):
+    def __init__(self, try_number=1):
         self.pushed = {}
+        # Airflow exposes the attempt number here: 1 on the first run, 2+
+        # on retries. The operator reads it to decide whether to narrow a
+        # 'failed_only' retry to --lf.
+        self.try_number = try_number
 
     def xcom_push(self, key, value):
         self.pushed[key] = value
@@ -101,8 +105,8 @@ def _result(*, failed=0, errors=0, passed=1):
     )
 
 
-def _ctx():
-    return {"ti": FakeTI()}
+def _ctx(try_number=1):
+    return {"ti": FakeTI(try_number=try_number)}
 
 
 def test_passing_run_returns_summary_for_xcom():
@@ -738,3 +742,193 @@ def test_dry_run_false_with_collect_only_in_args_still_runs_collection():
     forwarded_args = runner.calls[0]["pytest_args"]
     print(f"[dedup:user_explicit_dry_run_off] forwarded = {forwarded_args!r}")
     assert forwarded_args == ["--collect-only", "-k", "smoke"]
+
+
+# ---------------------------------------------------------------------------
+# test_retry_strategy="failed_only" -- re-run only failed tests on retry (--lf)
+# ---------------------------------------------------------------------------
+
+
+def test_test_retry_strategy_default_is_all():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[retry:default_pin] op.test_retry_strategy = {op.test_retry_strategy!r}")
+    assert op.test_retry_strategy == "all"
+
+
+def test_invalid_test_retry_strategy_raises_value_error():
+    with pytest.raises(ValueError, match="test_retry_strategy"):
+        PytestOperator(task_id="t", test_path="tests/", test_retry_strategy="bogus")
+
+
+def test_failed_only_appends_lf_on_retry():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    # try_number=2 -> this is the first retry.
+    op.execute(_ctx(try_number=2))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:lf_on_retry] forwarded = {forwarded_args!r}")
+    assert forwarded_args[:2] == ["-k", "smoke"]
+    assert forwarded_args.count("--lf") == 1
+    assert forwarded_args[-1] == "--lf"
+
+
+def test_failed_only_does_not_append_lf_on_first_attempt():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    # try_number=1 -> first attempt, full suite must run.
+    op.execute(_ctx(try_number=1))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:no_lf_first_attempt] forwarded = {forwarded_args!r}")
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]
+
+
+def test_strategy_all_never_appends_lf_even_on_retry():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        # "all" is the default; explicit here to pin the contract.
+        test_retry_strategy="all",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=3))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:all_no_lf] forwarded = {forwarded_args!r}")
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]
+
+
+def test_failed_only_does_not_double_add_lf_if_user_passed_it():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke", "--lf"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=2))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:dedup_lf] forwarded = {forwarded_args!r}")
+    assert forwarded_args.count("--lf") == 1
+    assert forwarded_args == ["-k", "smoke", "--lf"]
+
+
+def test_failed_only_recognises_last_failed_long_alias():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--last-failed"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=2))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:dedup_long_alias] forwarded = {forwarded_args!r}")
+    # Operator left the user's long alias in place AND did not add --lf on top.
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["--last-failed"]
+
+
+def test_failed_only_does_not_mutate_user_pytest_args_across_retries():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    user_args = ["-k", "smoke"]
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=user_args,
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=1))  # first attempt: no --lf
+    op.execute(_ctx(try_number=2))  # retry: --lf appended to a fresh list
+
+    print(f"[retry:no_mutation] op.pytest_args after two runs = {op.pytest_args!r}")
+    # The stored config is never mutated -- still the original user args.
+    assert op.pytest_args == ["-k", "smoke"]
+    # First call: no --lf; second call: exactly one --lf at the end.
+    assert "--lf" not in runner.calls[0]["pytest_args"]
+    assert runner.calls[1]["pytest_args"].count("--lf") == 1
+    assert runner.calls[1]["pytest_args"][-1] == "--lf"
+
+
+def test_failed_only_logs_on_retry():
+    from unittest import mock
+
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    with mock.patch.object(op.log, "info") as info:
+        op.execute(_ctx(try_number=2))
+
+    logged = " ".join(str(c) for c in info.call_args_list)
+    print(f"[retry:log] info() calls: {logged!r}")
+    assert "--lf" in logged
+    assert "failed_only" in logged
+
+
+def test_failed_only_missing_ti_in_context_degrades_to_full_suite():
+    """A context without a usable 'ti' must not crash execute(); it should
+    behave as the first attempt (full suite, no --lf)."""
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute({})  # no "ti" key at all
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:no_ti] forwarded = {forwarded_args!r}")
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]


### PR DESCRIPTION
Closes #12.
Adds an optional `test_retry_strategy` parameter to `PytestOperator`:
- "all" (default) — re-run the whole suite on every Airflow retry (unchanged behaviour).
- "failed_only" — on retries (try_number > 1) append pytest's `--lf` so only
  the previously-failed tests run again. The first attempt always runs the full
  suite; falls back to the full suite if the pytest cache is unavailable.
Follows the existing `dry_run` pattern: the flag is spliced into a per-call
effective args list, `pytest_args` is never mutated, and `--lf`/`--last-failed`
is not double-added if the user already passed it.
Tested:
- Unit tests (10 new) — all green (282 total).
- Live on Airflow 3.2.1 (Docker): a 100-test suite with 5 failures re-ran only
  the 5 failed tests on retry (100 → 5).