### PR TITLE
Reliable "retry only failed": best-effort --lf + run-all→run-failed pattern (#12)Feat/failed only retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dotted ``failed_node_ids`` (from XCom) back into pytest CLI selectors, for a
   "retry only failed" DAG pattern. Idempotent; leaves malformed/slash-form
   input untouched.
+- `failed_selectors(summary, *, class_prefix="Test")` -- convenience wrapper
+  over ``node_id_to_pytest_args`` that reads ``failed_node_ids`` out of a
+  ``PytestOperator`` XCom summary and returns the pytest selectors, yielding
+  ``[]`` for a missing/empty summary so the run-all -> run-failed branch can
+  short-circuit cleanly.
 - Task-log lines for the report directory, run outcome, and cleanup /
   cancellation decisions, so the report location and lifecycle are visible.
 - On a pytest **timeout**, the raised `TestExecutionError` now carries the
@@ -50,6 +55,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to a per-call effective list at ``execute()`` time and is not double-added
   if ``--lf``/``--last-failed`` is already present. An invalid value raises
   ``ValueError``. Default ``"all"`` -- behaviour unchanged for existing tasks.
+  ``--lf`` is best-effort: it relies on the worker's ``.pytest_cache`` (it
+  degrades to a full run on a fresh worker, e.g. a retry that lands on a
+  different K8s/Celery pod, and can race between parallel tasks that share a
+  pytest rootdir). For a cache-independent guarantee on any executor, use the
+  ``run_all`` -> ``run_failed`` DAG pattern below.
+- **Robust "retry only failed" recipe** documented: a ``run_all`` ->
+  ``run_failed`` DAG pattern that carries ``failed_node_ids`` through XCom and
+  reruns only the failed tests via ``node_id_to_pytest_args``. Unlike ``--lf``
+  it does not depend on the worker's ``.pytest_cache``, so it works on any
+  executor and survives a worker/pod dying between tasks. See
+  ``examples/retry_failed_dag_pattern.py`` and the README "Retry strategy".
 
 ### Changed
 - **Breaking (pre-release):** `SubprocessPytestRunner` no longer takes a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On a pytest **timeout**, the raised `TestExecutionError` now carries the
   captured `stdout` / `stderr` as attributes (not just in the worker log), so
   operators and UIs can surface *why* a run hung programmatically.
+- `PytestOperator(test_retry_strategy="failed_only")` -- new optional
+  argument controlling how Airflow task *retries* re-run the suite. With
+  the default ``"all"`` the whole suite re-runs on every retry (behaviour
+  unchanged). With ``"failed_only"`` the operator appends pytest's ``--lf``
+  (``--last-failed``) on retry attempts (``try_number > 1``), so only the
+  tests that failed on the previous attempt run again -- a large saving on
+  big suites where only a few tests fail. The first attempt always runs the
+  full suite. ``--lf`` is backed by pytest's ``.pytest_cache``, so the
+  narrowing only happens when that cache from the previous attempt is still
+  readable on the worker; otherwise pytest safely falls back to the full
+  suite. The user's ``pytest_args`` are not mutated -- the flag is appended
+  to a per-call effective list at ``execute()`` time and is not double-added
+  if ``--lf``/``--last-failed`` is already present. An invalid value raises
+  ``ValueError``. Default ``"all"`` -- behaviour unchanged for existing tasks.
 
 ### Changed
 - **Breaking (pre-release):** `SubprocessPytestRunner` no longer takes a

--- a/README.md
+++ b/README.md
@@ -418,7 +418,11 @@ So `dry_run` is not a no-op — module-level side effects happen. It's "collect 
 
 ## Retry strategy (failed-only reruns)
 
-By default, when an Airflow task retries, the **entire** pytest suite runs again. For a large suite where only a couple of tests failed, that wastes a lot of time. Set `test_retry_strategy="failed_only"` to make retries re-run **only the tests that failed on the previous attempt**, using pytest's `--lf` (`--last-failed`):
+By default, when an Airflow task retries, the **entire** pytest suite runs again. For a large suite where only a couple of tests failed, that wastes time. There are two ways to re-run only the failures — pick one based on your executor.
+
+### Best-effort: `test_retry_strategy="failed_only"` (operator-level `--lf`)
+
+Set `test_retry_strategy="failed_only"` to make Airflow retries re-run **only the tests that failed on the previous attempt**, using pytest's `--lf` (`--last-failed`):
 
 ```python
 from airflow_pytest_operator import PytestOperator
@@ -435,12 +439,62 @@ How it works:
 
 - **First attempt** (`try_number == 1`) always runs the full suite.
 - **Each retry** (`try_number > 1`) appends `--lf`, so pytest re-runs only the previously failed tests.
-- `--lf` reads pytest's `.pytest_cache`. The narrowing therefore only kicks in when that cache from the previous attempt is still readable on the worker. If it isn't (e.g. the retry lands on a different worker with no shared filesystem, or the cache dir is ephemeral), pytest **safely falls back to running the whole suite** — you never silently skip tests.
 - The operator does not mutate your `pytest_args`; `--lf` is added to a per-call list at execute time, and it won't be added twice if you already passed `--lf`/`--last-failed` yourself.
 
-> **Tip:** for the cache to survive across retries, the test folder (where `.pytest_cache` is written) should live on storage that persists between attempts on the same worker. On distributed executors without shared storage, treat `failed_only` as a best-effort optimisation that gracefully degrades to a full run.
+**Limitations — why this is best-effort.** `--lf` reads pytest's `.pytest_cache`, which lives on the **worker's filesystem**. The narrowing only happens when that cache survives between attempts:
 
-The default `test_retry_strategy="all"` keeps the original behaviour (full suite on every retry).
+- On **distributed executors** (Kubernetes, Celery) without shared storage, a retry can land on a different worker/pod that has no cache — pytest then **safely falls back to running the whole suite** (you never silently skip tests, but you also save nothing).
+- **Parallel** `PytestOperator` tasks that share a pytest `rootdir` write to the *same* `.pytest_cache` and can overwrite each other's "last failed" record.
+
+So `failed_only` is a zero-config win for single-worker / shared-volume setups that degrades gracefully everywhere else. The default `test_retry_strategy="all"` keeps the original behaviour (full suite on every retry). For a guarantee that survives **any** executor, use the pattern below.
+
+### Robust: run-all → run-failed (any executor)
+
+For a result that does **not** depend on the worker cache, split the work across two tasks and carry the failed test ids through **XCom** (Airflow's metadata DB). Because the second task reads a *different* task's XCom, Airflow never clears it (it only clears a task's own XCom on that task's own retry) — so this works on any executor and survives a worker/pod dying between tasks:
+
+```python
+from airflow.decorators import task
+from airflow_pytest_operator import PytestOperator, failed_selectors
+from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+with DAG(...) as dag:
+    # 1) Run everything; don't fail the task, so the summary (with
+    #    failed_node_ids) is pushed to XCom for the next task.
+    run_all = PytestOperator(
+        task_id="run_all",
+        test_path="/opt/airflow/tests",
+        fail_on_test_failure=False,
+    )
+
+    # 2) Skip the rerun when nothing failed.
+    @task.short_circuit
+    def has_failures(summary: dict) -> bool:
+        return bool(failed_selectors(summary))
+
+    # 3) Turn the XCom summary into pytest selectors for the failed tests.
+    @task
+    def to_selectors(summary: dict) -> list[str]:
+        return failed_selectors(summary)
+
+    summary = run_all.output
+    selectors = to_selectors(summary)
+
+    # 4) Re-run ONLY the failed tests. cwd is the pytest rootdir (where
+    #    pytest.ini / pyproject lives) so the relative selectors resolve.
+    #    Give this task its own retries for several rounds if you like — they
+    #    stay reliable because the ids live in run_all's XCom, not a cache.
+    run_failed = PytestOperator(
+        task_id="run_failed",
+        test_path=selectors,
+        fail_on_test_failure=True,
+        retries=2,
+        runner=SubprocessPytestRunner(cwd="/opt/airflow"),
+    )
+
+    run_all >> has_failures(summary) >> selectors >> run_failed
+```
+
+`failed_selectors(summary)` is a small helper over `node_id_to_pytest_args`: it reads `failed_node_ids` out of the XCom summary and returns the pytest selectors, yielding `[]` when nothing failed (so the short-circuit stays clean). A full, runnable version is in [`examples/retry_failed_dag_pattern.py`](examples/retry_failed_dag_pattern.py).
 
 ## Where do the tests live?
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 - [Report location & cleanup](#report-location--cleanup)
 - [Cancellation and timeouts](#cancellation-and-timeouts)
 - [Dry-run mode](#dry-run-mode)
+- [Retry strategy (failed-only reruns)](#retry-strategy-failed-only-reruns)
 - [Where do the tests live?](#where-do-the-tests-live)
 - [Built-in parsers](#built-in-parsers)
 - [Extending it](#extending-it)
@@ -315,6 +316,7 @@ The parameters specific to `PytestOperator` are:
 | `env` | `{}` | Extra environment variables for the run. Templated. |
 | `fail_on_test_failure` | `True` | Fail the task on any test failure/error. If `False`, the task always succeeds and the outcome is only reflected in XCom. |
 | `dry_run` | `False` | Run pytest in `--collect-only` mode: import the test modules and walk the collection tree, but **do not execute test bodies**. Useful as a pre-flight task in a DAG; see [Dry-run mode](#dry-run-mode) below. |
+| `test_retry_strategy` | `"all"` | How Airflow task **retries** re-run the suite. `"all"` re-runs everything; `"failed_only"` appends pytest's `--lf` on retries so only previously failed tests run again. See [Retry strategy](#retry-strategy-failed-only-reruns) below. |
 | `do_xcom_push` | `True` | Airflow's standard flag. When on, the summary dict is pushed to XCom under the `return_value` key. Set `False` to disable all XCom output. Read it downstream with `xcom_pull(task_ids="<task>")`. |
 | `runner` | `SubprocessPytestRunner()` | Injectable execution strategy (see *Extending*). |
 | `parser` | `JUnitResultParser()` | Injectable report parser (see *Extending*). |
@@ -413,6 +415,32 @@ So `dry_run` is not a no-op — module-level side effects happen. It's "collect 
 - With the default `JUnitResultParser`, the XML pytest emits in `--collect-only` mode contains no `<testcase>` entries (`<testsuite tests="0">`), so `total` is `0`. The task still passes/fails correctly based on exit code; only the collected-count is unavailable. Use the JSON parser if you need the count for branching downstream.
 
 **Interaction with user-supplied flags:** if you already passed `--collect-only` (or its aliases `--collectonly`, `--co`) in `pytest_args`, the operator won't add another one. The dedup is targeted only at the collect-only family — other repeated args (`-v -v`, multiple `-o KEY=VAL`, multiple `--ignore=...`) are preserved as-is.
+
+## Retry strategy (failed-only reruns)
+
+By default, when an Airflow task retries, the **entire** pytest suite runs again. For a large suite where only a couple of tests failed, that wastes a lot of time. Set `test_retry_strategy="failed_only"` to make retries re-run **only the tests that failed on the previous attempt**, using pytest's `--lf` (`--last-failed`):
+
+```python
+from airflow_pytest_operator import PytestOperator
+
+run = PytestOperator(
+    task_id="run_tests",
+    test_path="tests/",
+    retries=2,                          # Airflow's standard retry count
+    test_retry_strategy="failed_only",  # retries re-run only what failed
+)
+```
+
+How it works:
+
+- **First attempt** (`try_number == 1`) always runs the full suite.
+- **Each retry** (`try_number > 1`) appends `--lf`, so pytest re-runs only the previously failed tests.
+- `--lf` reads pytest's `.pytest_cache`. The narrowing therefore only kicks in when that cache from the previous attempt is still readable on the worker. If it isn't (e.g. the retry lands on a different worker with no shared filesystem, or the cache dir is ephemeral), pytest **safely falls back to running the whole suite** — you never silently skip tests.
+- The operator does not mutate your `pytest_args`; `--lf` is added to a per-call list at execute time, and it won't be added twice if you already passed `--lf`/`--last-failed` yourself.
+
+> **Tip:** for the cache to survive across retries, the test folder (where `.pytest_cache` is written) should live on storage that persists between attempts on the same worker. On distributed executors without shared storage, treat `failed_only` as a best-effort optimisation that gracefully degrades to a full run.
+
+The default `test_retry_strategy="all"` keeps the original behaviour (full suite on every retry).
 
 ## Where do the tests live?
 

--- a/examples/retry_failed_dag_pattern.py
+++ b/examples/retry_failed_dag_pattern.py
@@ -1,0 +1,89 @@
+"""Example DAG: robust "retry only failed" across any executor.
+
+Instead of pytest's worker-local ``.pytest_cache`` (the operator-level
+``test_retry_strategy="failed_only"`` / ``--lf`` option, which is best-effort
+and degrades to a full run on a fresh worker), this pattern carries the failed
+test ids through Airflow XCom (the metadata DB) from a first "run all" task to a
+second "run failed" task.
+
+Because the second task reads a *different* task's XCom, Airflow never clears it
+(it only clears a task's own XCom on that task's own retry). So the rerun is
+reliable on Kubernetes/Celery, survives a worker or pod dying between tasks, and
+does not race with parallel tasks over a shared cache.
+
+    run_all (all tests; never fails the task; records failures in XCom)
+      -> has_failures? (short-circuit: stop if nothing failed)
+      -> to_selectors  (dotted failed_node_ids -> pytest CLI selectors)
+      -> run_failed    (only the previously-failed tests; fails the pipeline)
+"""
+
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pendulum
+from airflow import DAG
+from airflow.decorators import task
+
+from airflow_pytest_operator import PytestOperator, failed_selectors
+from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+# The pytest rootdir (where pytest.ini / pyproject.toml lives). The second task
+# runs from here so the relative selectors from failed_selectors resolve.
+ROOTDIR = "/opt/airflow"
+TESTS = "/opt/airflow/tests"
+
+with DAG(
+    dag_id="retry_failed_dag_pattern",
+    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
+    schedule=None,
+    catchup=False,
+    tags=["testing", "retry", "failed_only"],
+) as dag:
+    # 1) Run the whole suite. fail_on_test_failure=False so the task SUCCEEDS
+    #    and pushes its summary (including failed_node_ids) to XCom.
+    run_all = PytestOperator(
+        task_id="run_all",
+        test_path=TESTS,
+        pytest_args=["-q"],
+        fail_on_test_failure=False,
+    )
+
+    # 2) Stop the branch if there is nothing to re-run.
+    @task.short_circuit
+    def has_failures(summary: dict) -> bool:
+        return bool(failed_selectors(summary))
+
+    # 3) Turn the XCom summary into pytest selectors for the failed tests.
+    @task
+    def to_selectors(summary: dict) -> list[str]:
+        return failed_selectors(summary)
+
+    summary = run_all.output
+    selectors = to_selectors(summary)
+
+    # 4) Re-run ONLY the previously-failed tests, and fail the pipeline if they
+    #    still fail. Give this task its own retries for several rounds if you
+    #    like -- they stay reliable because the ids live in run_all's XCom.
+    run_failed = PytestOperator(
+        task_id="run_failed",
+        test_path=selectors,
+        pytest_args=["-q"],
+        fail_on_test_failure=True,
+        retries=2,
+        runner=SubprocessPytestRunner(cwd=ROOTDIR),
+    )
+
+    run_all >> has_failures(summary) >> selectors >> run_failed

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -12,6 +12,8 @@ Public API:
     node_id_to_pytest_args — convert dotted failed_node_ids back to
                              pytest CLI selectors (for retry-failed-only
                              workflows)
+    failed_selectors       — XCom summary -> pytest selectors for the failed
+                             tests (the run-all -> run-failed DAG pattern)
 """
 
 # Copyright 2026 the airflow-pytest-operator contributors
@@ -43,7 +45,7 @@ from .provider_info import __version__ as __version__
 from .provider_info import get_provider_info as get_provider_info
 from .reporters import JSONResultParser, JUnitResultParser, ResultParser
 from .runners import PytestRunner, SubprocessPytestRunner
-from .utils import node_id_to_pytest_args
+from .utils import failed_selectors, node_id_to_pytest_args
 
 if TYPE_CHECKING:
     # PytestOperator is exposed lazily via __getattr__ (see below) so that
@@ -70,6 +72,7 @@ __all__ = [
     "TestsFailedError",
     "get_provider_info",
     "node_id_to_pytest_args",
+    "failed_selectors",
 ]
 
 

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -56,6 +56,19 @@ class PytestOperator(BaseOperator):
         normal failures do -- exit code is non-zero, ``TestRunResult.success``
         is False, and (with the default ``fail_on_test_failure=True``) the
         task fails. Default: False.
+    :param test_retry_strategy: how Airflow task *retries* re-run the
+        suite. ``"all"`` (default) re-runs the whole suite on every retry --
+        unchanged behaviour. ``"failed_only"`` appends pytest's ``--lf``
+        (``--last-failed``) on retry attempts (``try_number > 1``), so only
+        the tests that failed on the previous attempt run again; this can
+        cut retry time dramatically on large suites where only a few tests
+        failed. The first attempt always runs the full suite. ``--lf`` is
+        backed by pytest's cache (``.pytest_cache``), so it only narrows the
+        run when that cache from the previous attempt is still readable on
+        the worker; otherwise pytest safely falls back to running everything.
+        The user's ``pytest_args`` are not mutated -- the flag is appended to
+        a per-call effective list at ``execute()`` time, and is not added if
+        ``--lf``/``--last-failed`` is already present. Default: ``"all"``.
     :param runner: injectable :class:`PytestRunner` (default: subprocess).
     :param parser: injectable :class:`ResultParser` (default: JUnit). The
         parser owns the report location: set ``report_dir`` on it, e.g.
@@ -80,6 +93,10 @@ class PytestOperator(BaseOperator):
         {"--collect-only", "--collectonly", "--co"}
     )
 
+    _RETRY_STRATEGIES: frozenset[str] = frozenset({"all", "failed_only"})
+
+    _LAST_FAILED_ALIASES: frozenset[str] = frozenset({"--lf", "--last-failed"})
+
     def __init__(
         self,
         *,
@@ -88,16 +105,23 @@ class PytestOperator(BaseOperator):
         env: dict[str, str] | None = None,
         fail_on_test_failure: bool = True,
         dry_run: bool = False,
+        test_retry_strategy: str = "all",
         runner: PytestRunner | None = None,
         parser: ResultParser | None = None,
         **kwargs: Any,
     ) -> None:
+        if test_retry_strategy not in self._RETRY_STRATEGIES:
+            raise ValueError(
+                "test_retry_strategy must be one of 'all', 'failed_only'; "
+                f"got {test_retry_strategy!r}"
+            )
         super().__init__(**kwargs)
         self.test_path = test_path
         self.pytest_args = list(pytest_args) if pytest_args else []
         self.env = env or {}
         self.fail_on_test_failure = fail_on_test_failure
         self.dry_run = dry_run
+        self.test_retry_strategy = test_retry_strategy
         self._runner = runner or SubprocessPytestRunner()
         self._parser = parser or JUnitResultParser()
 
@@ -117,6 +141,22 @@ class PytestOperator(BaseOperator):
             arg in self._COLLECT_ONLY_ALIASES for arg in effective_args
         ):
             effective_args.append("--collect-only")
+
+        # On Airflow retries, optionally narrow the run to only the tests
+        # that failed on the previous attempt (pytest --lf). The first
+        # attempt always runs the full suite; we don't double-add the flag
+        # if the user already passed it. Like --collect-only above, this is
+        # spliced into a per-call effective list, so self.pytest_args (and
+        # thus downstream introspection / the next retry) stays unmutated.
+        if self.test_retry_strategy == "failed_only" and self._is_retry(context):
+            if not any(arg in self._LAST_FAILED_ALIASES for arg in effective_args):
+                effective_args.append("--lf")
+                self.log.info(
+                    "Retry attempt detected with test_retry_strategy='failed_only' "
+                    "-- appending --lf so pytest re-runs only the tests that failed "
+                    "on the previous attempt (falls back to the full suite if the "
+                    "pytest cache is unavailable on this worker)."
+                )
 
         run_ok = False
         try:
@@ -191,6 +231,20 @@ class PytestOperator(BaseOperator):
                 self._runner.cleanup(success=run_ok)
             except Exception:  # pragma: no cover - best-effort teardown
                 self.log.exception("Error while cleaning up report directory")
+
+    @staticmethod
+    def _is_retry(context: Any) -> bool:
+        """True when Airflow is re-running this task (a retry attempt).
+
+        Airflow exposes the attempt number on the task instance as
+        ``try_number``: 1 on the first attempt, 2+ on each retry. We read it
+        defensively (``getattr`` with a default of 1) so a missing or
+        unusual context degrades to "first attempt" -- i.e. the full suite
+        runs -- rather than raising during execute().
+        """
+        ti = context.get("ti") if hasattr(context, "get") else None
+        try_number = getattr(ti, "try_number", 1)
+        return isinstance(try_number, int) and try_number > 1
 
     def on_kill(self) -> None:
         """Abort the test run when Airflow terminates the task.

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -69,6 +69,14 @@ class PytestOperator(BaseOperator):
         The user's ``pytest_args`` are not mutated -- the flag is appended to
         a per-call effective list at ``execute()`` time, and is not added if
         ``--lf``/``--last-failed`` is already present. Default: ``"all"``.
+        Note this is **best-effort**: ``--lf`` depends on the worker's
+        ``.pytest_cache`` (it degrades to a full run on a fresh worker, e.g. a
+        retry that lands on a different K8s/Celery pod, and can race between
+        parallel tasks that share a pytest rootdir). For a cache-independent
+        guarantee on any executor, carry ``failed_node_ids`` between two tasks
+        via XCom and convert them with
+        :func:`~airflow_pytest_operator.node_id_to_pytest_args` (the
+        run-all -> run-failed pattern in the README).
     :param runner: injectable :class:`PytestRunner` (default: subprocess).
     :param parser: injectable :class:`ResultParser` (default: JUnit). The
         parser owns the report location: set ``report_dir`` on it, e.g.

--- a/src/airflow_pytest_operator/utils/__init__.py
+++ b/src/airflow_pytest_operator/utils/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 
-from .node_id import node_id_to_pytest_args
+from .node_id import failed_selectors, node_id_to_pytest_args
 
-__all__ = ["node_id_to_pytest_args"]
+__all__ = ["failed_selectors", "node_id_to_pytest_args"]

--- a/src/airflow_pytest_operator/utils/node_id.py
+++ b/src/airflow_pytest_operator/utils/node_id.py
@@ -29,7 +29,8 @@ feed them back into a fresh pytest invocation.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
 
 
 def node_id_to_pytest_args(
@@ -59,6 +60,33 @@ def node_id_to_pytest_args(
     else:
         prefixes = tuple(class_prefix)
     return [_convert_one(nid, prefixes) for nid in node_ids]
+
+
+def failed_selectors(
+    summary: Mapping[str, Any] | None,
+    *,
+    class_prefix: str | Sequence[str] = "Test",
+) -> list[str]:
+    """Pytest CLI selectors for the failed tests in a result summary.
+
+    A convenience wrapper over :func:`node_id_to_pytest_args` for the
+    "run all -> rerun only failed" DAG pattern (see the README). Pull a
+    :class:`~airflow_pytest_operator.PytestOperator`'s XCom summary -- the dict
+    produced by :meth:`TestRunResult.to_xcom`, which carries ``failed_node_ids``
+    in dotted form -- and feed the result straight into a second operator's
+    ``test_path``.
+
+    :param summary: the XCom summary dict, or ``None``. A missing dict, a
+        missing ``failed_node_ids`` key, or an empty list all yield ``[]`` so
+        the caller can cleanly short-circuit when nothing failed.
+    :param class_prefix: forwarded to :func:`node_id_to_pytest_args`.
+    :returns: slash-form pytest selectors for the failed tests, in order.
+        Empty when there were no failures.
+    """
+    if not summary:
+        return []
+    node_ids = summary.get("failed_node_ids") or []
+    return node_id_to_pytest_args(node_ids, class_prefix=class_prefix)
 
 
 def _convert_one(node_id: str, prefixes: tuple[str, ...]) -> str:

--- a/tests/test_node_id_utils.py
+++ b/tests/test_node_id_utils.py
@@ -26,7 +26,7 @@ example covers a representative case so a future reader can
 
 from __future__ import annotations
 
-from airflow_pytest_operator import node_id_to_pytest_args
+from airflow_pytest_operator import failed_selectors, node_id_to_pytest_args
 
 # ---------------------------------------------------------------------------
 # Conversion table: dotted -> slash. Each test covers one shape.
@@ -372,3 +372,70 @@ def test_round_trip_actually_re_runs_only_failed_tests_via_real_pytest(
     )
     assert result_2.failed == 3
     assert result_2.passed == 0
+
+
+# ---------------------------------------------------------------------------
+# failed_selectors: XCom summary dict -> pytest selectors (run-all -> run-failed)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_selectors_converts_failed_ids():
+    summary = {
+        "failed_node_ids": ["tests.test_x::test_y", "tests.test_z::test_w"],
+    }
+    sels = failed_selectors(summary)
+    print(f"[failed_selectors:basic] {sels!r}")
+    assert sels == ["tests/test_x.py::test_y", "tests/test_z.py::test_w"]
+
+
+def test_failed_selectors_empty_when_no_failures():
+    # An all-green run: the key is present but the list is empty.
+    assert failed_selectors({"failed_node_ids": []}) == []
+
+
+def test_failed_selectors_missing_key_returns_empty():
+    # A summary without the key (e.g. a different/older shape) must not raise.
+    assert failed_selectors({"passed": 3, "failed": 0}) == []
+
+
+def test_failed_selectors_none_summary_returns_empty():
+    # xcom_pull can return None (e.g. nothing pushed yet) -- handle it.
+    assert failed_selectors(None) == []
+
+
+def test_failed_selectors_none_failed_ids_returns_empty():
+    # Defensive: key present but explicitly None.
+    assert failed_selectors({"failed_node_ids": None}) == []
+
+
+def test_failed_selectors_forwards_class_prefix():
+    summary = {"failed_node_ids": ["tests.test_x.Suite::test_y"]}
+    # class_prefix="Suite" makes the trailing segment a class, not a path part.
+    sels = failed_selectors(summary, class_prefix="Suite")
+    print(f"[failed_selectors:prefix] {sels!r}")
+    assert sels == ["tests/test_x.py::Suite::test_y"]
+
+
+def test_failed_selectors_real_summary_round_trips_from_to_xcom():
+    # Use a real TestRunResult.to_xcom() so the test pins the actual contract
+    # between the operator's XCom and this helper.
+    from airflow_pytest_operator.models import CaseResult, TestRunResult
+
+    result = TestRunResult(
+        total=2,
+        passed=1,
+        failed=1,
+        skipped=0,
+        errors=0,
+        duration=0.1,
+        exit_code=1,
+        cases=(
+            CaseResult(name="test_ok", classname="tests.test_api", time=0.1,
+                       outcome="passed"),
+            CaseResult(name="test_bad", classname="tests.test_api", time=0.1,
+                       outcome="failed"),
+        ),
+    )
+    summary = result.to_xcom()
+    print(f"[failed_selectors:from_to_xcom] summary={summary['failed_node_ids']!r}")
+    assert failed_selectors(summary) == ["tests/test_api.py::test_bad"]

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -81,8 +81,12 @@ class FakeParser:
 
 
 class FakeTI:
-    def __init__(self):
+    def __init__(self, try_number=1):
         self.pushed = {}
+        # Airflow exposes the attempt number here: 1 on the first run, 2+
+        # on retries. The operator reads it to decide whether to narrow a
+        # 'failed_only' retry to --lf.
+        self.try_number = try_number
 
     def xcom_push(self, key, value):
         self.pushed[key] = value
@@ -101,8 +105,8 @@ def _result(*, failed=0, errors=0, passed=1):
     )
 
 
-def _ctx():
-    return {"ti": FakeTI()}
+def _ctx(try_number=1):
+    return {"ti": FakeTI(try_number=try_number)}
 
 
 def test_passing_run_returns_summary_for_xcom():
@@ -738,3 +742,193 @@ def test_dry_run_false_with_collect_only_in_args_still_runs_collection():
     forwarded_args = runner.calls[0]["pytest_args"]
     print(f"[dedup:user_explicit_dry_run_off] forwarded = {forwarded_args!r}")
     assert forwarded_args == ["--collect-only", "-k", "smoke"]
+
+
+# ---------------------------------------------------------------------------
+# test_retry_strategy="failed_only" -- re-run only failed tests on retry (--lf)
+# ---------------------------------------------------------------------------
+
+
+def test_test_retry_strategy_default_is_all():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[retry:default_pin] op.test_retry_strategy = {op.test_retry_strategy!r}")
+    assert op.test_retry_strategy == "all"
+
+
+def test_invalid_test_retry_strategy_raises_value_error():
+    with pytest.raises(ValueError, match="test_retry_strategy"):
+        PytestOperator(task_id="t", test_path="tests/", test_retry_strategy="bogus")
+
+
+def test_failed_only_appends_lf_on_retry():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    # try_number=2 -> this is the first retry.
+    op.execute(_ctx(try_number=2))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:lf_on_retry] forwarded = {forwarded_args!r}")
+    assert forwarded_args[:2] == ["-k", "smoke"]
+    assert forwarded_args.count("--lf") == 1
+    assert forwarded_args[-1] == "--lf"
+
+
+def test_failed_only_does_not_append_lf_on_first_attempt():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    # try_number=1 -> first attempt, full suite must run.
+    op.execute(_ctx(try_number=1))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:no_lf_first_attempt] forwarded = {forwarded_args!r}")
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]
+
+
+def test_strategy_all_never_appends_lf_even_on_retry():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        # "all" is the default; explicit here to pin the contract.
+        test_retry_strategy="all",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=3))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:all_no_lf] forwarded = {forwarded_args!r}")
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]
+
+
+def test_failed_only_does_not_double_add_lf_if_user_passed_it():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke", "--lf"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=2))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:dedup_lf] forwarded = {forwarded_args!r}")
+    assert forwarded_args.count("--lf") == 1
+    assert forwarded_args == ["-k", "smoke", "--lf"]
+
+
+def test_failed_only_recognises_last_failed_long_alias():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--last-failed"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=2))
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:dedup_long_alias] forwarded = {forwarded_args!r}")
+    # Operator left the user's long alias in place AND did not add --lf on top.
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["--last-failed"]
+
+
+def test_failed_only_does_not_mutate_user_pytest_args_across_retries():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    user_args = ["-k", "smoke"]
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=user_args,
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute(_ctx(try_number=1))  # first attempt: no --lf
+    op.execute(_ctx(try_number=2))  # retry: --lf appended to a fresh list
+
+    print(f"[retry:no_mutation] op.pytest_args after two runs = {op.pytest_args!r}")
+    # The stored config is never mutated -- still the original user args.
+    assert op.pytest_args == ["-k", "smoke"]
+    # First call: no --lf; second call: exactly one --lf at the end.
+    assert "--lf" not in runner.calls[0]["pytest_args"]
+    assert runner.calls[1]["pytest_args"].count("--lf") == 1
+    assert runner.calls[1]["pytest_args"][-1] == "--lf"
+
+
+def test_failed_only_logs_on_retry():
+    from unittest import mock
+
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    with mock.patch.object(op.log, "info") as info:
+        op.execute(_ctx(try_number=2))
+
+    logged = " ".join(str(c) for c in info.call_args_list)
+    print(f"[retry:log] info() calls: {logged!r}")
+    assert "--lf" in logged
+    assert "failed_only" in logged
+
+
+def test_failed_only_missing_ti_in_context_degrades_to_full_suite():
+    """A context without a usable 'ti' must not crash execute(); it should
+    behave as the first attempt (full suite, no --lf)."""
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        test_retry_strategy="failed_only",
+        runner=runner,
+        parser=parser,
+    )
+
+    op.execute({})  # no "ti" key at all
+
+    forwarded_args = runner.calls[0]["pytest_args"]
+    print(f"[retry:no_ti] forwarded = {forwarded_args!r}")
+    assert "--lf" not in forwarded_args
+    assert forwarded_args == ["-k", "smoke"]


### PR DESCRIPTION
Supersedes #24 (closed). Reworked in response to @IKrysanov's review.

I tested the suggested XCom approach on live Airflow 3.2.1: a task's XCom is
cleared at the start of every attempt (verified at the DB level — the row
written on try 1 is deleted before try 2 reads it), so xcom_pull(task_ids=
self.task_id) returns None on a retry. The two-tier "XCom then --lf" would
therefore always fall through to --lf.

So this PR:
- keeps test_retry_strategy="failed_only" (--lf) but documents it honestly as
  best-effort (degrades to a full run on a fresh K8s/Celery worker; can race
  between parallel tasks sharing a rootdir);
- adds the reliable, cross-executor path as the run-all → run-failed DAG
  pattern, using the existing node_id_to_pytest_args (the right place: a
  *different* task's XCom is not cleared);
- adds a small pure helper failed_selectors(summary) (+ unit tests) and a
  runnable examples/retry_failed_dag_pattern.py.

Verified live on Airflow 3.2.1: a 100-test suite with 5 failures re-ran only
the 5 failed tests via failed_selectors (100 → 5).