### PR TITLE
fix log stream airflow tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Change history
 
+- [0.5.3 — Live streaming of pytest output to the task log (stream_output)](#053---2026-06-24)
 - [0.5.2 — Sharding across workers (dynamic task mapping), parallel/dist execution, and test selection sugar (markers, keyword)](#052---2026-06-21)
 - [0.5.1 — Load env from a `.env` file (env_file) and verbose runner diagnostics](#051---2026-06-20)
 - [0.5.0 — Re-run only failed tests (rerun_failed, failed_only), multi-target, parser-owned report dir](#050---2026-06-16)
@@ -20,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.1.0 — Initial release: operator, runner, parser, core functionality](#010---2026-05-23)
 
 ## [Unreleased]
+
+## [0.5.3] - 2026-06-24
+
+### Added
+- `PytestOperator(stream_output=True)` (default) -- pytest output is logged to the
+  task log **line-by-line as the suite runs** instead of one blob at the end, so a
+  long run is no longer a blank screen. The child runs unbuffered (``-u``);
+  streamed lines share the output cap and the full output is still captured.
+  ``stream_output=False`` restores the single end-of-run blob (also lighter on the
+  logging backend for very chatty suites). Tip: pair with ``-v`` for clean
+  per-test lines.
+
+### Changed
+- `PytestRunner.run()` gained a keyword-only ``on_output`` sink
+  (``Callable[[str, str], None]``, called per ``(line, stream)``), forwarded by
+  the operator when streaming. A custom runner should accept it (or
+  ``**kwargs``); it may ignore it.
 
 ## [0.5.2] - 2026-06-21
 
@@ -642,7 +660,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.4.2...v0.5.0

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 - [Constructor options](#constructor-options)
 - [.env files](#env-files)
 - [Debugging a run (verbose diagnostics)](#debugging-a-run-verbose-diagnostics)
+- [Streaming pytest output (stream_output)](#streaming-pytest-output-stream_output)
 - [pytest config, plugins, and Allure](#pytest-config-plugins-and-allure)
 - [Selecting tests (markers / keyword)](#selecting-tests-markers--keyword)
 - [Parallel execution (parallel / dist)](#parallel-execution-parallel--dist)
@@ -381,6 +382,22 @@ PytestOperator(
 It logs the final `python -m pytest ...` command, the effective working directory, the **env delta against `os.environ`** (which keys this run adds vs overrides), and the report directory + cleanup policy. Credential-looking values are **masked** — keys matching `PASSWORD`/`TOKEN`/`SECRET`/`KEY`/`AUTH`/… and `AIRFLOW_CONN_*` (whose value is a connection URI with an embedded password) are printed as `***`, so secrets never reach the task log.
 
 > **Don't put secrets in `pytest_args`.** The masking covers **env values only**. The pytest *command* — including your `pytest_args` — is logged verbatim, so a secret passed as a CLI flag (e.g. `--token=…`) would appear in the task log in clear text. Pass secrets via `env` / `env_file` instead (CLI args are also visible to anyone who can run `ps` on the worker).
+
+## Streaming pytest output (`stream_output`)
+
+By default (`stream_output=True`) pytest's stdout/stderr is logged to the task log **line-by-line as the suite runs**, so a long run isn't a blank screen until it finishes:
+
+```python
+PytestOperator(
+    task_id="run_tests",
+    test_path="/opt/airflow/tests",
+    pytest_args=["-v"],   # one line per test streams cleanly; default progress dots are coarser over a pipe
+)
+```
+
+The child runs unbuffered (`-u`) so lines flush promptly; stdout streams at `INFO`, stderr at `WARNING`. The full output is still captured in the result, and streamed lines share the runner's output cap (`max_output_bytes`, default 10 MiB), so a runaway suite can't flood the log.
+
+Set `stream_output=False` to restore the old behaviour — one stdout/stderr blob logged once after the run. That's also **lighter on your logging backend**: one big record instead of thousands of small ones, which can matter for very chatty suites or per-record remote log handlers (Elasticsearch, Stackdriver, …).
 
 ## pytest config, plugins, and Allure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.5.2"
+version = "0.5.3"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/airflow_pytest_operator/models.py
+++ b/src/airflow_pytest_operator/models.py
@@ -14,8 +14,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
+
+# A live sink for child output lines. Called once per line as it is drained,
+# with the trailing newline stripped, as ``sink(line, stream)`` where ``stream``
+# is ``"stdout"`` or ``"stderr"``. Used to stream pytest output to the task log
+# in real time instead of one blob at the end.
+OutputSink: TypeAlias = Callable[[str, str], None]
 
 
 @dataclass(frozen=True)

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -108,6 +108,11 @@ class PytestOperator(BaseOperator):
         tests), ``"loadscope"`` / ``"loadfile"`` / ``"loadgroup"`` (pin a
         module-or-class / file / group to one worker), ``"worksteal"``,
         ``"each"``, ``"no"``. Requires ``parallel``. Default None.
+    :param stream_output: when True (default), pytest's stdout/stderr is logged
+        to the task log line-by-line **as it runs** (so a long suite isn't a
+        blank screen until it finishes), and the child runs unbuffered (``-u``).
+        The full output is still captured in the result either way. False
+        restores the old behaviour: one stdout/stderr blob logged after the run.
     :param store: injectable ``LastFailedStore`` for the ``failed_only`` set
         (default: ``VariableLastFailedStore``). Any object with
         ``read``/``write``/``delete`` works (structural typing). Unused unless
@@ -146,6 +151,7 @@ class PytestOperator(BaseOperator):
         rerun_failed: int = 0,
         parallel: int | str | None = None,
         dist: str | None = None,
+        stream_output: bool = True,
         runner: PytestRunner | None = None,
         parser: ResultParser | None = None,
         store: LastFailedStore | None = None,
@@ -254,6 +260,7 @@ class PytestOperator(BaseOperator):
         self.rerun_failed = rerun_failed
         self.parallel = parallel
         self.dist = dist
+        self.stream_output = stream_output
         self._runner = runner or SubprocessPytestRunner()
         self._parser = parser or JUnitResultParser()
         self._store: LastFailedStore = store or VariableLastFailedStore()
@@ -429,6 +436,11 @@ class PytestOperator(BaseOperator):
         child output, turns a missing report into a clear
         :class:`TestExecutionError`, parses the result, and logs the summary.
         """
+        # stream_output: hand the runner a live sink so pytest output reaches
+        # the task log line-by-line as it runs, instead of one blob at the end
+        # (the wait-on-a-blank-screen problem). The runner still returns the full
+        # captured output in ``artifacts`` either way.
+        on_output = self._emit_pytest_line if self.stream_output else None
         artifacts = self._runner.run(
             targets,
             pytest_args=pytest_args,
@@ -440,13 +452,17 @@ class PytestOperator(BaseOperator):
             # The parser decides the report flags/location; the runner just
             # splices them -- which keeps the runner format-agnostic.
             report_request=self._parser.report_request,
+            on_output=on_output,
         )
 
-        # Surface child output in the task log regardless of outcome.
-        if artifacts.stdout:
-            self.log.info("pytest stdout:\n%s", artifacts.stdout)
-        if artifacts.stderr:
-            self.log.warning("pytest stderr:\n%s", artifacts.stderr)
+        # Surface child output in the task log. When streaming, the lines were
+        # already logged live (above), so the end-of-run blob would just be a
+        # duplicate -- skip it. When not streaming, log the blob as before.
+        if not self.stream_output:
+            if artifacts.stdout:
+                self.log.info("pytest stdout:\n%s", artifacts.stdout)
+            if artifacts.stderr:
+                self.log.warning("pytest stderr:\n%s", artifacts.stderr)
 
         # No report -> pytest never wrote one (collection error, crash, OOM,
         # wrong path, missing report-plugin). An execution failure, not a test
@@ -480,6 +496,18 @@ class PytestOperator(BaseOperator):
         if result.failed_node_ids:
             self.log.error("Failed tests:\n  %s", "\n  ".join(result.failed_node_ids))
         return result
+
+    def _emit_pytest_line(self, line: str, stream: str) -> None:
+        """Live sink for child output -- routes each line to the task log.
+
+        Passed to the runner as ``on_output`` when ``stream_output`` is on.
+        stdout goes to info, stderr to warning (matching the old end-of-run
+        blob levels), so the output streams to the Airflow UI as it happens.
+        """
+        if stream == "stderr":
+            self.log.warning("%s", line)
+        else:
+            self.log.info("%s", line)
 
     # -- best-effort collaborator calls ---------------------------------
     #

--- a/src/airflow_pytest_operator/runners/base.py
+++ b/src/airflow_pytest_operator/runners/base.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 
-from ..models import ReportRequest, RunArtifacts
+from ..models import OutputSink, ReportRequest, RunArtifacts
 
 
 class PytestRunner(ABC):
@@ -43,6 +43,7 @@ class PytestRunner(ABC):
         env_file: str | None = None,
         env_file_overrides: bool = False,
         report_request: Callable[[str], ReportRequest],
+        on_output: OutputSink | None = None,
     ) -> RunArtifacts:
         """Run pytest and return where to find its outputs.
 
@@ -70,6 +71,15 @@ class PytestRunner(ABC):
         ``report_request`` is keyword-only and required -- there is no
         sensible default ("just run pytest with no report" produces
         artifacts no parser can consume).
+
+        ``on_output`` is an optional sink for *live* child output: when given,
+        the runner calls it once per line as the line is drained (newline
+        stripped), as ``on_output(line, stream)`` with ``stream`` being
+        ``"stdout"`` or ``"stderr"``. It lets the operator stream pytest output
+        to the task log in real time instead of one blob at the end. Keyword-only
+        with a ``None`` default, so a runner that does not support streaming may
+        ignore it (the full output is still returned in ``RunArtifacts`` either
+        way). The same output cap applies to streamed lines.
         """
         raise NotImplementedError
 

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -27,7 +27,7 @@ from collections.abc import Callable, Sequence
 from typing import Any
 
 from ..exceptions import TestExecutionError
-from ..models import ReportRequest, RunArtifacts
+from ..models import OutputSink, ReportRequest, RunArtifacts
 from .base import PytestRunner
 
 _IS_WINDOWS = os.name == "nt"
@@ -445,6 +445,7 @@ class SubprocessPytestRunner(PytestRunner):
         env_file: str | None = None,
         env_file_overrides: bool = False,
         report_request: Callable[[str], ReportRequest],
+        on_output: OutputSink | None = None,
     ) -> RunArtifacts:
         # Enforce the single-run contract atomically. A second concurrent
         # run() on the SAME instance would race on the per-run state stored
@@ -471,6 +472,7 @@ class SubprocessPytestRunner(PytestRunner):
                 env_file=env_file,
                 env_file_overrides=env_file_overrides,
                 report_request=report_request,
+                on_output=on_output,
             )
         finally:
             with self._lock:
@@ -485,6 +487,7 @@ class SubprocessPytestRunner(PytestRunner):
         env_file: str | None = None,
         env_file_overrides: bool = False,
         report_request: Callable[[str], ReportRequest],
+        on_output: OutputSink | None = None,
     ) -> RunArtifacts:
         if isinstance(test_path, str):
             raw_paths: list[str] = [test_path]
@@ -574,8 +577,15 @@ class SubprocessPytestRunner(PytestRunner):
         effective_cwd = self._resolve_cwd(test_paths)
         target_paths = self._resolve_target_paths(test_paths, effective_cwd)
 
+        # When streaming, run the interpreter unbuffered (-u) so the child
+        # flushes stdout/stderr per write instead of block-buffering them on a
+        # pipe -- otherwise readline() (and the live emit below) would not see a
+        # line until the child's buffer fills or it exits. No effect on the
+        # captured output, and skipped entirely when not streaming.
+        interpreter_flags = ["-u"] if on_output is not None else []
         cmd = [
             self._python,
+            *interpreter_flags,
             "-m",
             "pytest",
             *target_paths,
@@ -653,17 +663,46 @@ class SubprocessPytestRunner(PytestRunner):
         stderr_state: list[int] = [0, 0]
         max_bytes = self._max_output_bytes
 
-        def _drain(stream: Any, sink: list[str], state: list[int]) -> None:
+        def _drain(
+            stream: Any, sink: list[str], state: list[int], stream_name: str
+        ) -> None:
             # readline() is the right primitive here: it returns chunks as
             # they arrive (line-buffered), doesn't block waiting for EOF,
             # and exits cleanly when the pipe closes. read() would buffer
             # the entire stream first, which defeats the purpose for a
             # long-running suite.
+            emit_disabled = False
+
+            def _emit(kept: str) -> None:
+                # Stream the just-captured text live, mirroring exactly what was
+                # appended to ``sink`` so the live view and the final blob agree
+                # (and the same cap applies). Blank spacer lines are dropped so
+                # they don't spam the log.
+                nonlocal emit_disabled
+                if on_output is None or emit_disabled:
+                    return
+                line = kept.rstrip("\r\n")
+                if not line:
+                    return
+                try:
+                    on_output(line, stream_name)
+                except Exception as exc:  # noqa: BLE001 - a bad sink must never
+                    # stop draining (that would block the child on a full pipe):
+                    # log once, then stop emitting for this stream and keep
+                    # draining into ``sink``.
+                    emit_disabled = True
+                    _log.warning(
+                        "disabling live %s streaming after sink error: %s",
+                        stream_name,
+                        exc,
+                    )
+
             try:
                 for chunk in iter(stream.readline, ""):
                     if max_bytes is None:
                         sink.append(chunk)
                         state[0] += len(chunk)
+                        _emit(chunk)
                         continue
                     remaining = max_bytes - state[0]
                     if remaining <= 0:
@@ -675,13 +714,16 @@ class SubprocessPytestRunner(PytestRunner):
                         state[0] += len(chunk)
                         if state[0] >= max_bytes:
                             state[1] = 1
+                        _emit(chunk)
                     else:
                         # The chunk would cross the cap. Keep only what fits so
                         # the budget is a hard ceiling, not "cap + one chunk":
                         # a single very long line from a test must not blow it.
-                        sink.append(chunk[:remaining])
+                        kept = chunk[:remaining]
+                        sink.append(kept)
                         state[0] = max_bytes
                         state[1] = 1
+                        _emit(kept)
             except (ValueError, OSError) as e:
                 # The read side failed (pipe closed mid-read, decode error,
                 # ...). Distinct from a close() failure below so the log says
@@ -698,10 +740,14 @@ class SubprocessPytestRunner(PytestRunner):
         # daemon=True so a stuck drainer never blocks interpreter exit; in
         # practice they always exit because the child closes the pipe.
         stdout_thread = threading.Thread(
-            target=_drain, args=(proc.stdout, stdout_chunks, stdout_state), daemon=True
+            target=_drain,
+            args=(proc.stdout, stdout_chunks, stdout_state, "stdout"),
+            daemon=True,
         )
         stderr_thread = threading.Thread(
-            target=_drain, args=(proc.stderr, stderr_chunks, stderr_state), daemon=True
+            target=_drain,
+            args=(proc.stderr, stderr_chunks, stderr_state, "stderr"),
+            daemon=True,
         )
         stdout_thread.start()
         stderr_thread.start()

--- a/tests/operator/_op_helpers.py
+++ b/tests/operator/_op_helpers.py
@@ -28,6 +28,8 @@ class FakeRunner:
         self.calls = []
         self.cancelled = 0
         self.cleanup_calls = []
+        # (line, stream) pairs replayed through on_output to simulate streaming.
+        self.stream_lines: list[tuple[str, str]] = []
 
     def run(
         self,
@@ -38,8 +40,14 @@ class FakeRunner:
         env_file=None,
         env_file_overrides=False,
         report_request,
+        on_output=None,
     ):
         spec = report_request("/fake/report/dir")
+        # Simulate live streaming: if the operator handed us a sink and the test
+        # pre-seeded lines, feed them through so routing/levels can be asserted.
+        if on_output is not None:
+            for line, stream in self.stream_lines:
+                on_output(line, stream)
         self.calls.append(
             {
                 "test_path": test_path,
@@ -48,6 +56,7 @@ class FakeRunner:
                 "env_file": env_file,
                 "env_file_overrides": env_file_overrides,
                 "report_request": report_request,
+                "on_output": on_output,
                 "spec": spec,
             }
         )
@@ -265,6 +274,7 @@ class _RecordingCustomRunner:
         env_file=None,
         env_file_overrides=False,
         report_request,
+        on_output=None,
     ):
         report_request("/fake/dir")
         self.calls.append(

--- a/tests/operator/test_op_core.py
+++ b/tests/operator/test_op_core.py
@@ -269,7 +269,9 @@ def test_operator_does_not_mutate_injected_runner():
     assert not hasattr(injected, "_report_dir")  # runner no longer owns it
 
 
-def test_stdout_and_stderr_are_logged():
+def test_stdout_and_stderr_logged_as_blob_when_not_streaming():
+    # stream_output=False -> the old behaviour: child output is logged once as a
+    # blob after the run (stdout at info, stderr at warning).
     from unittest import mock
 
     runner = FakeRunner(
@@ -283,6 +285,7 @@ def test_stdout_and_stderr_are_logged():
     op = PytestOperator(
         task_id="t",
         test_path="tests/",
+        stream_output=False,
         runner=runner,
         parser=FakeParser(_result(passed=1)),
     )

--- a/tests/operator/test_op_streaming.py
+++ b/tests/operator/test_op_streaming.py
@@ -1,0 +1,150 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""stream_output: live per-line pytest output instead of one end-of-run blob.
+Shared fakes in _op_helpers."""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from _op_helpers import (
+    FakeParser,
+    FakeRunner,
+    SequenceParser,
+    _ctx,
+    _res,
+    _result,
+)
+
+from airflow_pytest_operator.models import RunArtifacts
+from airflow_pytest_operator.operators import PytestOperator
+
+
+def test_stream_output_default_is_true():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[stream:default] stream_output={op.stream_output!r}")
+    assert op.stream_output is True
+
+
+def test_streaming_passes_sink_to_runner():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    print(f"[stream:wire] on_output={runner.calls[0]['on_output']!r}")
+    assert runner.calls[0]["on_output"] is not None
+
+
+def test_no_streaming_passes_no_sink():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        stream_output=False,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    assert runner.calls[0]["on_output"] is None
+
+
+def test_streamed_lines_route_stdout_info_stderr_warning():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    runner.stream_lines = [("out-line", "stdout"), ("err-line", "stderr")]
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with (
+        mock.patch.object(op.log, "info") as info,
+        mock.patch.object(op.log, "warning") as warning,
+    ):
+        op.execute(_ctx())
+    info_msgs = " ".join(str(c) for c in info.call_args_list)
+    warn_msgs = " ".join(str(c) for c in warning.call_args_list)
+    print(
+        f"[stream:route] info={'out-line' in info_msgs} warn={'err-line' in warn_msgs}"
+    )
+    assert "out-line" in info_msgs
+    assert "err-line" in warn_msgs
+
+
+def test_streaming_skips_the_end_of_run_blob():
+    # With streaming on, lines are logged live -> the end-of-run blob would be a
+    # duplicate, so it must NOT be logged (here stream_lines is empty, so the
+    # blob's stdout text must not appear at all).
+    runner = FakeRunner(
+        RunArtifacts(
+            exit_code=0,
+            report_path="/x.xml",
+            stdout="blob-stdout-text",
+            stderr="blob-stderr-text",
+        )
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with (
+        mock.patch.object(op.log, "info") as info,
+        mock.patch.object(op.log, "warning") as warning,
+    ):
+        op.execute(_ctx())
+    logged = " ".join(str(c) for c in info.call_args_list + warning.call_args_list)
+    print(f"[stream:noblob] {logged[:200]!r}")
+    assert "pytest stdout:" not in logged
+    assert "blob-stdout-text" not in logged
+
+
+def test_emit_pytest_line_routes_levels():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    with (
+        mock.patch.object(op.log, "info") as info,
+        mock.patch.object(op.log, "warning") as warning,
+    ):
+        op._emit_pytest_line("hello", "stdout")
+        op._emit_pytest_line("oops", "stderr")
+    assert any("hello" in str(c) for c in info.call_args_list)
+    assert any("oops" in str(c) for c in warning.call_args_list)
+
+
+def test_streaming_applied_to_every_rerun_round():
+    # The sink is wired for the first full run AND each in-process rerun.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),  # first run: 1 failure
+            _res([], passed=1),  # rerun: recovered
+        ]
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        rerun_failed=1,
+        runner=runner,
+        parser=parser,
+    )
+    op.execute(_ctx())
+    print(f"[stream:reruns] calls={len(runner.calls)}")
+    assert len(runner.calls) == 2
+    assert all(call["on_output"] is not None for call in runner.calls)

--- a/tests/runner/test_run_streaming.py
+++ b/tests/runner/test_run_streaming.py
@@ -1,0 +1,129 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Live output streaming: the on_output sink, the -u flag, and cap sharing.
+Shared fakes in _run_helpers."""
+
+from __future__ import annotations
+
+from _run_helpers import _run, _suite
+
+from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+_LOGGER = "airflow_pytest_operator.runners.subprocess_runner"
+
+
+def test_run_streams_lines_to_sink(tmp_path):
+    path = _suite(
+        tmp_path,
+        """
+        def test_a(): assert True
+        def test_b(): assert True
+    """,
+    )
+    lines: list[tuple[str, str]] = []
+    art = _run(
+        SubprocessPytestRunner(),
+        path,
+        pytest_args=["-v"],  # one newline-terminated line per test -> streams
+        on_output=lambda line, stream: lines.append((stream, line)),
+    )
+    print(f"[stream] {len(lines)} live lines; first={lines[0] if lines else None!r}")
+    assert lines, "expected lines streamed through the sink"
+    assert all(stream in ("stdout", "stderr") for stream, _ in lines)
+    # Lines have no trailing newline, blank spacer lines are skipped, and the
+    # full output is still captured.
+    assert all(not line.endswith("\n") for _, line in lines)
+    assert all(line for _, line in lines), "blank lines should not be streamed"
+    assert art.stdout
+    streamed_stdout = "\n".join(line for stream, line in lines if stream == "stdout")
+    assert "test_a" in streamed_stdout or "test_a" in art.stdout
+
+
+def test_run_without_sink_does_not_stream_but_still_captures(tmp_path):
+    path = _suite(tmp_path, "def test_a(): assert True")
+    art = _run(SubprocessPytestRunner(), path)  # no on_output
+    print(f"[stream:none] exit={art.exit_code} captured_len={len(art.stdout)}")
+    assert art.exit_code == 0
+    assert art.stdout  # captured exactly as before -- back-compat
+
+
+def test_run_inserts_dash_u_when_streaming(tmp_path, caplog):
+    path = _suite(tmp_path, "def test_a(): assert True")
+    with caplog.at_level("INFO", logger=_LOGGER):
+        _run(
+            SubprocessPytestRunner(verbose=True),
+            path,
+            on_output=lambda line, stream: None,
+        )
+    cmds = [r.getMessage() for r in caplog.records if "command:" in r.getMessage()]
+    print(f"[stream:-u] {cmds}")
+    assert any(" -u -m pytest" in m for m in cmds)
+
+
+def test_run_omits_dash_u_without_streaming(tmp_path, caplog):
+    path = _suite(tmp_path, "def test_a(): assert True")
+    with caplog.at_level("INFO", logger=_LOGGER):
+        _run(SubprocessPytestRunner(verbose=True), path)  # no on_output
+    cmds = [r.getMessage() for r in caplog.records if "command:" in r.getMessage()]
+    assert cmds and all(" -u -m pytest" not in m for m in cmds)
+    assert any("-m pytest" in m for m in cmds)
+
+
+def test_streaming_respects_the_output_cap(tmp_path):
+    # A tiny cap bounds the captured blob AND the streamed text identically:
+    # the live emit shares the same byte budget as accumulation.
+    path = _suite(
+        tmp_path,
+        """
+        def test_a():
+            print("X" * 5000)
+            assert True
+    """,
+    )
+    streamed: list[str] = []
+    art = _run(
+        SubprocessPytestRunner(max_output_bytes=200),
+        path,
+        pytest_args=["-s"],  # don't let pytest capture the print
+        on_output=lambda line, stream: streamed.append(line),
+    )
+    total = sum(len(line) for line in streamed)
+    print(f"[stream:cap] streamed_chars={total} captured={len(art.stdout)}")
+    # The cap was hit (captured blob carries the truncation marker) ...
+    assert "truncated at 200" in art.stdout
+    # ... and the live-streamed text honours the same 200-char budget, and the
+    # truncation marker is only on the captured blob, never streamed.
+    assert total <= 200
+    assert all("truncated" not in line for line in streamed)
+
+
+def test_bad_sink_does_not_break_draining(tmp_path):
+    # A sink that raises must not wedge the drainer (which would block the child
+    # on a full pipe) -- the full output is still captured.
+    path = _suite(
+        tmp_path,
+        """
+        def test_a(): assert True
+        def test_b(): assert True
+    """,
+    )
+
+    def boom(line: str, stream: str) -> None:
+        raise RuntimeError("sink boom")
+
+    art = _run(SubprocessPytestRunner(), path, pytest_args=["-v"], on_output=boom)
+    print(f"[stream:badsink] exit={art.exit_code} captured_len={len(art.stdout)}")
+    assert art.exit_code == 0
+    assert art.stdout  # draining continued despite the raising sink


### PR DESCRIPTION
## [0.5.3] - 2026-06-24

### Added
- `PytestOperator(stream_output=True)` (default) -- pytest output is logged to the
  task log **line-by-line as the suite runs** instead of one blob at the end, so a
  long run is no longer a blank screen. The child runs unbuffered (``-u``);
  streamed lines share the output cap and the full output is still captured.
  ``stream_output=False`` restores the single end-of-run blob (also lighter on the
  logging backend for very chatty suites). Tip: pair with ``-v`` for clean
  per-test lines.

### Changed
- `PytestRunner.run()` gained a keyword-only ``on_output`` sink
  (``Callable[[str, str], None]``, called per ``(line, stream)``), forwarded by
  the operator when streaming. A custom runner should accept it (or
  ``**kwargs``); it may ignore it.