### PR TITLE
Feature/coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Change history
 
+- [0.6.0 — Coverage gate (cov_fail_under), typed XCom summary (RunSummary), and py.typed](#060---2026-07-01)
 - [0.5.4 — Measure coverage on the run and push the fraction to XCom (coverage)](#054---2026-06-30)
 - [0.5.3 — Live streaming of pytest output to the task log (stream_output)](#053---2026-06-24)
 - [0.5.2 — Sharding across workers (dynamic task mapping), parallel/dist execution, and test selection sugar (markers, keyword)](#052---2026-06-21)
@@ -23,26 +24,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-01
+
 ### Added
-- `PytestOperator(cov_fail_under=...)` -- a coverage **gate**: a fraction in
-  ``[0, 1]`` (e.g. ``0.80``) compared against the measured ``coverage``. Setting
-  it enables coverage measurement automatically (no need to also pass
-  ``coverage=True``); after the run, a fraction below the threshold fails the
-  task with the new ``CoverageThresholdError`` (a clear, dedicated error rather
-  than pytest-cov's bare exit code), and on pass the summary gains
-  ``coverage_passed=True``. Test failures take precedence (a red suite raises
-  first when ``fail_on_test_failure``); **fail-closed** when coverage cannot be
-  measured; skipped in ``dry_run`` and deferred to an explicit ``--no-cov``.
-  Validated at construction (non-number -> ``TypeError``; outside ``[0, 1]`` ->
-  ``ValueError`` with a "use 0.8 for 80%" hint). ``CoverageThresholdError`` is
-  exported from the package root. Default None (no gate).
+- `PytestOperator(cov_fail_under=...)` -- a coverage **gate** (a fraction in
+  ``[0, 1]``). Enables coverage measurement automatically and fails the task with
+  the new ``CoverageThresholdError`` below the threshold; test failures take
+  precedence, and it is fail-closed if coverage can't be measured. On pass the
+  summary gains ``coverage_passed=True``. Exported from the package root.
+- `RunSummary` -- a ``TypedDict`` for the XCom summary, exported from the package
+  root, so ``xcom_pull`` results can be typed. ``execute`` / ``to_xcom`` now
+  return it (a plain ``dict`` at runtime; type-only, no behaviour change).
+- `py.typed` marker (PEP 561), so downstream type-checkers see the package's
+  public hints -- including ``RunSummary``.
+- `examples/coverage_gate.py` -- a DAG showing the native gate and the
+  measure-then-read-``coverage``-from-XCom pattern.
 
 ### Changed
-- Internal: extracted the constructor's argument validation to
-  ``operators/_validation.py`` (pure check functions) and the whole pytest-cov
-  concern -- splice / read-back / gate -- to a ``CoverageController`` in
-  ``operators/_coverage.py``, keeping ``pytest_operator.py`` focused on
-  orchestration (it shrank ~40%). No public API or behaviour change.
+- A coverage run without ``pytest-cov`` installed now fails with an actionable
+  error naming the ``[coverage]`` extra, instead of a generic "no report".
+- Internal: extracted argument validation to ``operators/_validation.py`` and the
+  pytest-cov concern to a ``CoverageController`` (``operators/_coverage.py``),
+  keeping ``pytest_operator.py`` orchestration-only (~40% smaller). No API change.
 
 ## [0.5.4] - 2026-06-30
 
@@ -695,7 +698,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.4...v0.6.0
 [0.5.4]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.1...v0.5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Change history
 
+- [0.5.4 — Measure coverage on the run and push the fraction to XCom (coverage)](#054---2026-06-30)
 - [0.5.3 — Live streaming of pytest output to the task log (stream_output)](#053---2026-06-24)
 - [0.5.2 — Sharding across workers (dynamic task mapping), parallel/dist execution, and test selection sugar (markers, keyword)](#052---2026-06-21)
 - [0.5.1 — Load env from a `.env` file (env_file) and verbose runner diagnostics](#051---2026-06-20)
@@ -21,6 +22,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.1.0 — Initial release: operator, runner, parser, core functionality](#010---2026-05-23)
 
 ## [Unreleased]
+
+### Added
+- `PytestOperator(cov_fail_under=...)` -- a coverage **gate**: a fraction in
+  ``[0, 1]`` (e.g. ``0.80``) compared against the measured ``coverage``. Setting
+  it enables coverage measurement automatically (no need to also pass
+  ``coverage=True``); after the run, a fraction below the threshold fails the
+  task with the new ``CoverageThresholdError`` (a clear, dedicated error rather
+  than pytest-cov's bare exit code), and on pass the summary gains
+  ``coverage_passed=True``. Test failures take precedence (a red suite raises
+  first when ``fail_on_test_failure``); **fail-closed** when coverage cannot be
+  measured; skipped in ``dry_run`` and deferred to an explicit ``--no-cov``.
+  Validated at construction (non-number -> ``TypeError``; outside ``[0, 1]`` ->
+  ``ValueError`` with a "use 0.8 for 80%" hint). ``CoverageThresholdError`` is
+  exported from the package root. Default None (no gate).
+
+### Changed
+- Internal: extracted the constructor's argument validation to
+  ``operators/_validation.py`` (pure check functions) and the whole pytest-cov
+  concern -- splice / read-back / gate -- to a ``CoverageController`` in
+  ``operators/_coverage.py``, keeping ``pytest_operator.py`` focused on
+  orchestration (it shrank ~40%). No public API or behaviour change.
+
+## [0.5.4] - 2026-06-30
+
+### Added
+- `PytestOperator(coverage=True)` -- measure coverage via ``pytest-cov`` on the
+  first full run: splices ``--cov --cov-report=term-missing`` (table to the task
+  log) and pushes the overall coverage **fraction** to XCom under the new
+  ``coverage`` key -- a float in ``[0, 1]`` (e.g. ``0.85``), or ``None`` if no
+  total was parsed; absent when coverage was not measured. First run only (not
+  the ``rerun_failed`` rounds), skipped in ``dry_run``, and defers to an explicit
+  ``--cov``/``--no-cov`` in ``pytest_args``. Configure source / formats /
+  ``fail_under`` via ``[tool.coverage.*]``; needs the new ``[coverage]`` extra;
+  defaults ``False``. See the README "Coverage" section.
 
 ## [0.5.3] - 2026-06-24
 
@@ -660,7 +695,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Change history
 
 - [0.6.0 — Coverage gate (cov_fail_under), typed XCom summary (RunSummary), and py.typed](#060---2026-07-01)
-- [0.5.4 — Measure coverage on the run and push the fraction to XCom (coverage)](#054---2026-06-30)
 - [0.5.3 — Live streaming of pytest output to the task log (stream_output)](#053---2026-06-24)
 - [0.5.2 — Sharding across workers (dynamic task mapping), parallel/dist execution, and test selection sugar (markers, keyword)](#052---2026-06-21)
 - [0.5.1 — Load env from a `.env` file (env_file) and verbose runner diagnostics](#051---2026-06-20)
@@ -27,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2026-07-01
 
 ### Added
+- `PytestOperator(coverage=True)` -- measure coverage via ``pytest-cov`` on the
+  first full run: splices ``--cov --cov-report=term-missing`` (table to the task
+  log) and pushes the overall coverage **fraction** to XCom under the new
+  ``coverage`` key -- a float in ``[0, 1]`` (e.g. ``0.85``), or ``None`` if no
+  total was parsed; absent when coverage was not measured. First run only (not
+  the ``rerun_failed`` rounds), skipped in ``dry_run``, and defers to an explicit
+  ``--cov``/``--no-cov`` in ``pytest_args``. Configure source / formats /
+  ``fail_under`` via ``[tool.coverage.*]``; needs the new ``[coverage]`` extra;
+  defaults ``False``. See the README "Coverage" section.
 - `PytestOperator(cov_fail_under=...)` -- a coverage **gate** (a fraction in
   ``[0, 1]``). Enables coverage measurement automatically and fails the task with
   the new ``CoverageThresholdError`` below the threshold; test failures take
@@ -46,19 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Internal: extracted argument validation to ``operators/_validation.py`` and the
   pytest-cov concern to a ``CoverageController`` (``operators/_coverage.py``),
   keeping ``pytest_operator.py`` orchestration-only (~40% smaller). No API change.
-
-## [0.5.4] - 2026-06-30
-
-### Added
-- `PytestOperator(coverage=True)` -- measure coverage via ``pytest-cov`` on the
-  first full run: splices ``--cov --cov-report=term-missing`` (table to the task
-  log) and pushes the overall coverage **fraction** to XCom under the new
-  ``coverage`` key -- a float in ``[0, 1]`` (e.g. ``0.85``), or ``None`` if no
-  total was parsed; absent when coverage was not measured. First run only (not
-  the ``rerun_failed`` rounds), skipped in ``dry_run``, and defers to an explicit
-  ``--cov``/``--no-cov`` in ``pytest_args``. Configure source / formats /
-  ``fail_under`` via ``[tool.coverage.*]``; needs the new ``[coverage]`` extra;
-  defaults ``False``. See the README "Coverage" section.
 
 ## [0.5.3] - 2026-06-24
 
@@ -699,8 +694,7 @@ Initial release.
   licensed.
 
 [Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.6.0...HEAD
-[0.6.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.4...v0.6.0
-[0.5.4]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...v0.5.4
+[0.6.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 - [pytest config, plugins, and Allure](#pytest-config-plugins-and-allure)
 - [Selecting tests (markers / keyword)](#selecting-tests-markers--keyword)
 - [Parallel execution (parallel / dist)](#parallel-execution-parallel--dist)
+- [Coverage (coverage)](#coverage-coverage)
 - [Sharding across workers (dynamic task mapping)](#sharding-across-workers-dynamic-task-mapping)
 - [Report location & cleanup](#report-location--cleanup)
 - [Cancellation and timeouts](#cancellation-and-timeouts)
@@ -221,6 +222,8 @@ The summary pushed to XCom (standard `return_value` key) looks like:
 }
 ```
 
+With `coverage=True` the summary additionally carries a `coverage` key — the overall coverage fraction in `[0, 1]`, or `None`; it is **absent** when coverage was not measured, so the shape above is unchanged by default. See [Coverage](#coverage-coverage).
+
 `failed_node_ids` uses a dotted, parser-independent form. To feed them back
 into a pytest run (a "retry only failed" task), convert them to CLI selectors
 with `node_id_to_pytest_args`:
@@ -336,6 +339,8 @@ The parameters specific to `PytestOperator` are:
 | `rerun_failed` | `0` | **In-process** re-runs of only the failed tests, within one task. `N>0` runs the full suite then re-runs the still-failing tests up to `N` more times — no cache, no Airflow retry, robust on any executor. See [Retry strategy](#retry-strategy-failed-only-reruns). |
 | `parallel` | `None` | Run the suite in parallel on the worker via `pytest-xdist` (`-n`). An int is the worker count; `"auto"`/`"logical"` map to xdist's CPU/logical-core counts. Applied to the first full run only (in-process `rerun_failed` rounds stay serial); ignored in `dry_run`; defers to an explicit `-n` in `pytest_args`. Needs the `[xdist]` extra on the worker. See [Parallel execution](#parallel-execution-parallel--dist). |
 | `dist` | `None` | `pytest-xdist` scheduler mode (`--dist`): `"load"` (default behaviour, spread individual tests), `"loadscope"`/`"loadfile"`/`"loadgroup"` (pin a module-or-class/file/`xdist_group` to one worker), `"worksteal"`, `"each"`, `"no"`. Requires `parallel` to be set. See [Parallel execution](#parallel-execution-parallel--dist). |
+| `coverage` | `False` | Measure coverage via `pytest-cov` on the first full run and push the overall fraction to XCom under the `coverage` key. Needs the `[coverage]` extra on the worker. See [Coverage](#coverage-coverage). |
+| `cov_fail_under` | `None` | Coverage **gate**: a fraction in `[0, 1]` (e.g. `0.80`). Enables coverage automatically and fails the task with `CoverageThresholdError` when below the threshold (test failures take precedence; fail-closed if unmeasurable). See [Coverage](#coverage-coverage). |
 | `do_xcom_push` | `True` | Airflow's standard flag. When on, the summary dict is pushed to XCom under the `return_value` key. Set `False` to disable all XCom output. Read it downstream with `xcom_pull(task_ids="<task>")`. |
 | `runner` | `SubprocessPytestRunner()` | Injectable execution strategy (see *Extending*). |
 | `parser` | `JUnitResultParser()` | Injectable report parser (see *Extending*). |
@@ -449,6 +454,42 @@ You could always pass `pytest_args=["-n", "4"]` by hand — these parameters add
 **`dist` and the "everything ran on `gw0`" gotcha.** With `parallel` set, xdist's default scheduler is `load`, which spreads *individual tests* across workers. The `loadscope` / `loadfile` / `loadgroup` modes instead keep a whole **scope** — a module/class, a file, or an `xdist_group` — on one worker, so tests that share setup aren't split apart. The flip side: a suite whose tests **all live in one module/class** has a single scope, so under `loadscope`/`loadgroup` the entire run lands on `gw0` while the other workers sit idle. That is the mode working as designed, not a bug. To check what actually happened, read the xdist header in the task log: `4 workers [N items]` means four workers spawned (so any `gw0`-only run is a *distribution* effect — likely the scope above or a tiny/fast suite gw0 drained first), whereas `1 worker` means `-n` didn't take effect. Set `verbose=True` on the runner to log the fully-resolved pytest command.
 
 > **Two axes of parallelism.** `parallel` scales *within* one worker (one Airflow task, N pytest processes). To spread a large suite *across* workers/pods, shard it with dynamic task mapping (below) — and each shard can still set `parallel` to use its own cores.
+
+## Coverage (`coverage`)
+
+Measure code coverage with [`pytest-cov`](https://pypi.org/project/pytest-cov/). Install the extra on the worker and set `coverage=True`:
+
+```python
+PytestOperator(
+    task_id="tests",
+    test_path="tests/",
+    coverage=True,         # -> --cov --cov-report=term-missing on the first full run
+)
+# pip install "airflow-pytest-operator[coverage]" on the worker
+```
+
+This logs the coverage **table** to the task log and pushes the **overall line-coverage fraction** to XCom under the summary's `coverage` key — a float in `[0, 1]` (e.g. `0.85`), read from the table's `TOTAL` row, or `None` if no total could be parsed. The key is **absent** when coverage was not measured, so the default XCom shape is unchanged. Gate a downstream task on it:
+
+```python
+def coverage_gate(**ctx):
+    cov = (ctx["ti"].xcom_pull(task_ids="tests") or {}).get("coverage")
+    if cov is not None and cov < 0.80:
+        raise ValueError(f"coverage {cov:.0%} below the 80% gate")
+```
+
+Or gate **natively**, without a separate task — set `cov_fail_under` (a fraction in `[0, 1]`):
+
+```python
+PytestOperator(task_id="tests", test_path="tests/", cov_fail_under=0.80)
+```
+
+This enables coverage measurement automatically (no need to also pass `coverage=True`) and **fails the task** with a clear `CoverageThresholdError` when the run is below the threshold; on pass the summary gains `coverage_passed=True`. Test failures take precedence (a red suite raises first), and it is **fail-closed** — a gate that can't be evaluated (no coverage total parsed) is an error, not a silent pass. Skipped in `dry_run`, deferred to an explicit `--no-cov`. A value outside `[0, 1]` is rejected — use `0.8`, not `80`. (This is the operator-level gate with a clear task-failure message; coverage.py's own `fail_under` below is the pytest-level equivalent.)
+
+**Rules.** Applied to the first full run only (the in-process `rerun_failed` rounds run uncovered); skipped in `dry_run`; and deferred when `pytest_args` already drives `--cov`/`--no-cov` (a user-supplied `--cov` still surfaces a fraction if the run prints a terminal `TOTAL` row).
+
+**Configuration** is coverage.py's own — set `source`, `omit`, report `precision`, and `fail_under` in `[tool.coverage.*]` (`pyproject.toml`) or `.coveragerc`; see the [coverage.py docs](https://coverage.readthedocs.io/en/latest/config.html). A configured `precision` is honoured (the XCom value is the number shown in the log), and `fail_under` makes the pytest run itself exit non-zero — failing the task independently of the XCom gate above.
+
+> **What it measures.** `coverage.py` instruments the Python that runs **in the pytest worker process** — your code under `source`/`--cov`. For a **system/integration test that calls an external service** (REST, gRPC, a DB), it counts only the *local* client code, never the remote system's code (a different process/host). Such a test reports **low coverage of your package** by design — that is expected, not a regression. Point `[tool.coverage.run] source` at unit-testable packages, and don't hold a system-test task to the same threshold as a unit-test task. (To cover a remote Python service you must run coverage inside *that* process — see [subprocess measurement](https://coverage.readthedocs.io/en/latest/subprocess.html).)
 
 ## Sharding across workers (dynamic task mapping)
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ The summary pushed to XCom (standard `return_value` key) looks like:
 
 With `coverage=True` the summary additionally carries a `coverage` key — the overall coverage fraction in `[0, 1]`, or `None`; it is **absent** when coverage was not measured, so the shape above is unchanged by default. See [Coverage](#coverage-coverage).
 
+The summary's shape is exported as a `TypedDict`, `RunSummary`, so you can type a downstream `xcom_pull` result (`from airflow_pytest_operator import RunSummary`). The block above is always present; `coverage`, `coverage_passed`, and the rerun keys (`rerun_rounds`, `recovered_node_ids`, `still_failing_node_ids`) are optional — read them with `.get(...)`. It is a plain `dict` at runtime.
+
 `failed_node_ids` uses a dotted, parser-independent form. To feed them back
 into a pytest run (a "retry only failed" task), convert them to CLI selectors
 with `node_id_to_pytest_args`:
@@ -326,7 +328,7 @@ The parameters specific to `PytestOperator` are:
 | Option | Default | Description |
 |---|---|---|
 | `test_path` | — | Target(s) passed to pytest: a file, directory, or node-id selector — or a sequence of them. Templated. |
-| `pytest_args` | `[]` | Extra pytest CLI args, e.g. `["-k", "smoke", "-x"]`. Templated. |
+| `pytest_args` | `[]` | Extra pytest CLI args, e.g. `["-k", "smoke", "-x"]`. Templated. See the [pytest reference](#pytest-config-plugins-and-allure) for what you can pass. |
 | `markers` | `None` | Marker expression passed to pytest as `-m` (e.g. `"smoke and not slow"`). Discoverability sugar over `pytest_args`; templated; defers to an explicit `-m` in `pytest_args`; a value that renders empty is skipped. See [Selecting tests](#selecting-tests-markers--keyword). |
 | `keyword` | `None` | Keyword expression passed to pytest as `-k` (e.g. `"login or logout"`). Same sugar/precedence/templating rules as `markers`. See [Selecting tests](#selecting-tests-markers--keyword). |
 | `env` | `{}` | Extra environment variables for the run. Templated. |
@@ -408,6 +410,11 @@ Set `stream_output=False` to restore the old behaviour — one stdout/stderr blo
 ## pytest config, plugins, and Allure
 
 The operator runs real `python -m pytest`, so pytest discovers its own configuration (`pytest.ini`, `pyproject.toml`, `tox.ini`, `setup.cfg`) and `rootdir` exactly as on the command line. **Plugins and their options are picked up from your test folder's config automatically** — Allure, `pytest-xdist`, `pytest-cov`, markers, `addopts`, and so on. The operator only adds `--junitxml` (for its own parsing); everything else is yours.
+
+> **pytest reference.** Everything you pass via `pytest_args` or a config file is plain pytest — its own docs are the quickest reference:
+> - [How to invoke pytest (CLI)](https://docs.pytest.org/en/stable/how-to/usage.html) · [full flag reference](https://docs.pytest.org/en/stable/reference/reference.html#command-line-flags) · [configuration files](https://docs.pytest.org/en/stable/reference/customize.html)
+> - [Markers (`-m`)](https://docs.pytest.org/en/stable/how-to/mark.html) · [Keyword selection (`-k`)](https://docs.pytest.org/en/stable/how-to/usage.html#specifying-which-tests-to-run) · [the cache (`--lf`, `--cache-clear`, `-p no:cacheprovider`)](https://docs.pytest.org/en/stable/how-to/cache.html)
+> - Plugins: [pytest-cov](https://pytest-cov.readthedocs.io/) · [pytest-xdist](https://pytest-xdist.readthedocs.io/) · [coverage.py config](https://coverage.readthedocs.io/en/latest/config.html)
 
 To make relative paths in `addopts` (e.g. `--alluredir=allure-results`) resolve next to your tests rather than the worker's working directory, the runner sets its working directory to the test folder by default: a directory target becomes the cwd, a file's parent becomes the cwd, and with multiple targets the closest shared parent is used. Node-id selectors (`path::test`) are anchored on their path portion — so this also applies to a `failed_only` retry, whose targets are all node-ids — and only a target with no resolvable path on disk falls back to the inherited cwd. Pass an explicit `cwd=` to override. Report paths stay absolute, so this never misplaces them.
 

--- a/examples/coverage_gate.py
+++ b/examples/coverage_gate.py
@@ -1,0 +1,92 @@
+"""Example DAG: measure test coverage and gate a pipeline on it.
+
+``coverage=True`` measures line coverage with pytest-cov on the first full run,
+logs the coverage table to the task log, and pushes the overall fraction to XCom
+under the ``coverage`` key (a float in ``[0, 1]``, or ``None`` when it could not
+be read). Install the extra on every worker that runs these tasks:
+
+    pip install "airflow-pytest-operator[coverage]"
+
+Two ways to gate on it:
+
+1. NATIVE gate -- set ``cov_fail_under`` (a fraction in ``[0, 1]``). The operator
+   fails the TASK with a clear ``CoverageThresholdError`` when the run is below
+   the threshold, and on pass the XCom summary gains ``coverage_passed=True``.
+   Simplest option: no extra task, the pipeline stops on low coverage. Test
+   failures still take precedence, and it is fail-closed if coverage cannot be
+   measured.
+
+2. XCom read -- measure with ``coverage=True`` (no gate) and let a downstream
+   task read ``coverage`` from XCom and decide (branch, alert, record a trend).
+   Use this when you want the number without necessarily failing the run.
+
+The XCom summary is a :class:`~airflow_pytest_operator.RunSummary` (a
+``TypedDict``): ``coverage`` is optional and is ``None`` when unavailable, so
+always guard before comparing.
+
+See the README "Coverage" section for what coverage does and does NOT measure --
+notably, a REST/system test only covers your local client code, so a low number
+there is expected, not a regression.
+"""
+
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pendulum
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+from airflow_pytest_operator import PytestOperator, RunSummary
+
+with DAG(
+    dag_id="pytest_coverage_gate",
+    start_date=pendulum.datetime(2024, 1, 1, tz="UTC"),
+    schedule=None,
+    catchup=False,
+    tags=["testing", "coverage", "quality-gate"],
+) as dag:
+    # --- Option 1: native gate. The task itself fails below 80% coverage. ---
+    PytestOperator(
+        task_id="tests_with_gate",
+        test_path="/opt/airflow/tests",
+        # A fraction in [0, 1]; use 0.8 for 80%, not 80. Enables coverage
+        # measurement automatically (no need to also pass coverage=True).
+        cov_fail_under=0.80,
+    )
+
+    # --- Option 2: measure only, then decide downstream from XCom. ---
+    measure = PytestOperator(
+        task_id="tests_measured",
+        test_path="/opt/airflow/tests",
+        coverage=True,  # measure, but never fail the task on coverage
+    )
+
+    def _report_coverage(**context: object) -> None:
+        ti = context["ti"]
+        # xcom_pull returns the RunSummary dict (or None if the task was skipped).
+        summary: RunSummary | None = ti.xcom_pull(task_ids="tests_measured")  # type: ignore[attr-defined]
+        cov = summary.get("coverage") if summary else None
+        if cov is None:
+            print("coverage: unavailable (no terminal total parsed)")
+        else:
+            print(f"coverage: {cov:.0%} -- {'OK' if cov >= 0.80 else 'BELOW 80%'}")
+
+    report = PythonOperator(
+        task_id="report_coverage",
+        python_callable=_report_coverage,
+    )
+
+    measure >> report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.5.4"
+version = "0.6.0"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.5.3"
+version = "0.5.4"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -67,6 +67,13 @@ json-report = ["pytest-json-report>=1.5"]
 # plugin extras, this only needs to be installed where pytest runs (the
 # worker), not necessarily on the operator side.
 xdist = ["pytest>=7.0", "pytest-xdist>=3.0"]
+# pytest-cov for the operator's ``coverage=True`` parameter, which splices
+# ``--cov`` / ``--cov-report=term-missing`` into the first full run. There is
+# no first-party coverage measurement in pytest; this opt-in extra installs
+# pytest-cov on workers that need it. Like the other plugin extras, only
+# needed where pytest runs (the worker). Configure source / report formats /
+# fail-under in ``[tool.coverage.run]`` / ``[tool.coverage.report]``.
+coverage = ["pytest>=7.0", "pytest-cov>=4.0"]
 # Enables the operator's ``env_file=`` argument, which parses a ``.env`` with
 # ``dotenv_values`` (a read-only parse -- it never mutates the worker's
 # ``os.environ``). Only needed on the operator side, and only if you use

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING
 
 from .exceptions import (
     AirflowPytestError,
+    CoverageThresholdError,
     ReportParseError,
     TestExecutionError,
     TestsFailedError,
@@ -65,6 +66,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "__version__",
     "PytestOperator",
     "PytestRunner",
     "SubprocessPytestRunner",
@@ -79,6 +81,7 @@ __all__ = [
     "TestExecutionError",
     "ReportParseError",
     "TestsFailedError",
+    "CoverageThresholdError",
     "get_provider_info",
     "node_id_to_pytest_args",
     "parse_collect_only_output",

--- a/src/airflow_pytest_operator/__init__.py
+++ b/src/airflow_pytest_operator/__init__.py
@@ -1,25 +1,3 @@
-"""Run pytest suites as Airflow tasks.
-
-Public API:
-    PytestOperator         — the operator to use in DAGs
-    PytestRunner           — runner interface (extend for docker/k8s)
-    SubprocessPytestRunner — default runner
-    ResultParser           — parser interface
-    JUnitResultParser      — default parser (JUnit XML)
-    JSONResultParser       — parser for pytest-json-report output
-    ReportRequest          — parser-declared pytest invocation spec
-    TestRunResult          — structured result model
-    node_id_to_pytest_args — convert dotted failed_node_ids back to
-                             pytest CLI selectors (for retry-failed-only
-                             workflows)
-    LastFailedStore        — structural (Protocol) interface for a custom
-                             ``failed_only`` cross-retry store
-    VariableLastFailedStore — Airflow-Variable store backing the single-operator
-                             ``test_retry_strategy="failed_only"`` retry mode
-    last_failed_var_key    — derive the Variable key a task instance uses for
-                             its failed set (for inspection / cleanup)
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +23,7 @@ from .exceptions import (
     TestExecutionError,
     TestsFailedError,
 )
-from .models import CaseResult, ReportRequest, RunArtifacts, TestRunResult
+from .models import CaseResult, ReportRequest, RunArtifacts, RunSummary, TestRunResult
 from .provider_info import __version__ as __version__
 from .provider_info import get_provider_info as get_provider_info
 from .reporters import JSONResultParser, JUnitResultParser, ResultParser
@@ -76,6 +54,7 @@ __all__ = [
     "ReportRequest",
     "TestRunResult",
     "RunArtifacts",
+    "RunSummary",
     "CaseResult",
     "AirflowPytestError",
     "TestExecutionError",

--- a/src/airflow_pytest_operator/compat/airflow.py
+++ b/src/airflow_pytest_operator/compat/airflow.py
@@ -1,14 +1,3 @@
-"""Airflow version compatibility shim.
-
-This is the *only* module in the package that imports Airflow directly.
-Everything else imports ``BaseOperator`` from here. Centralizing the
-version-specific imports means that supporting a new Airflow release is
-a one-file change (Open/Closed at the package level).
-
-Airflow 2.x and 3.x differ in the import path of ``BaseOperator`` and a
-few helpers. We resolve them once, lazily, and expose a stable surface.
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/airflow_pytest_operator/exceptions.py
+++ b/src/airflow_pytest_operator/exceptions.py
@@ -76,3 +76,29 @@ class TestsFailedError(AirflowPytestError):
             f"{result.failed} failed, {result.errors} errors "
             f"out of {result.total} tests"
         )
+
+
+class CoverageThresholdError(AirflowPytestError):
+    """Coverage fell below (or could not be measured for) the ``cov_fail_under`` gate.
+
+    Raised by :class:`PytestOperator` when ``cov_fail_under`` is set and the
+    run's overall coverage fraction is below it -- or could not be read at all
+    (fail-closed). Carries the measured ``coverage`` (a fraction in ``[0, 1]``,
+    or ``None`` when no total could be parsed) and the ``threshold`` so handlers
+    can inspect both.
+    """
+
+    def __init__(self, coverage: float | None, threshold: float) -> None:
+        self.coverage = coverage
+        self.threshold = threshold
+        if coverage is None:
+            super().__init__(
+                f"coverage gate cov_fail_under={threshold} could not be "
+                "evaluated: no coverage total was read from the run (ensure a "
+                "terminal coverage report -- term / term-missing)"
+            )
+        else:
+            super().__init__(
+                f"coverage {coverage:.2%} is below the cov_fail_under "
+                f"threshold of {threshold:.2%}"
+            )

--- a/src/airflow_pytest_operator/exceptions.py
+++ b/src/airflow_pytest_operator/exceptions.py
@@ -1,11 +1,3 @@
-"""Exception hierarchy for the operator.
-
-A small, focused hierarchy lets callers (and Airflow's retry logic)
-distinguish *test failures* from *infrastructure failures*. That
-distinction matters: a failing test usually shouldn't be retried,
-but a missing pytest binary or unreadable report might be.
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/airflow_pytest_operator/models.py
+++ b/src/airflow_pytest_operator/models.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, TypeAlias
+from typing import TypeAlias, TypedDict
 
 # A live sink for child output lines. Called once per line as it is drained,
 # with the trailing newline stripped, as ``sink(line, stream)`` where ``stream``
@@ -105,6 +105,42 @@ class RunArtifacts:
     working_dir: str | None = None
 
 
+class _RequiredSummary(TypedDict):
+    """The keys always present in the XCom summary (from a parsed report)."""
+
+    total: int
+    passed: int
+    failed: int
+    skipped: int
+    errors: int
+    duration: float
+    exit_code: int
+    success: bool
+    failed_node_ids: list[str]
+
+
+class RunSummary(_RequiredSummary, total=False):
+    """The summary dict ``PytestOperator.execute`` returns / pushes to XCom.
+
+    The inherited block above is always present. The keys below appear only when
+    the relevant feature ran, so downstream code must treat them as optional
+    (use ``.get(...)``):
+
+    * ``coverage`` / ``coverage_passed`` -- with ``coverage`` / ``cov_fail_under``;
+    * ``rerun_rounds`` / ``recovered_node_ids`` / ``still_failing_node_ids`` --
+      with ``rerun_failed`` (when a rerun actually happened).
+
+    It is a plain ``dict`` at runtime (a ``TypedDict``); the type just documents
+    the contract and gives downstream ``xcom_pull`` results autocomplete.
+    """
+
+    coverage: float | None
+    coverage_passed: bool
+    rerun_rounds: int
+    recovered_node_ids: list[str]
+    still_failing_node_ids: list[str]
+
+
 @dataclass(frozen=True)
 class TestRunResult:
     """Aggregated result of one pytest run, mapped from a parsed report."""
@@ -130,7 +166,7 @@ class TestRunResult:
     def failed_node_ids(self) -> list[str]:
         return [c.node_id for c in self.cases if c.outcome in ("failed", "error")]
 
-    def to_xcom(self) -> dict[str, Any]:
+    def to_xcom(self) -> RunSummary:
         """A compact, JSON-serializable dict suitable for XCom."""
         return {
             "total": self.total,

--- a/src/airflow_pytest_operator/operators/_constants.py
+++ b/src/airflow_pytest_operator/operators/_constants.py
@@ -1,11 +1,3 @@
-"""Internal vocabulary for :class:`PytestOperator`.
-
-Module-private constants (the accepted option values and the pytest CLI flags
-the operator knows about) plus one small pure helper, kept out of
-``pytest_operator.py`` so that file stays focused on orchestration. Nothing here
-is part of the public API.
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,6 +47,11 @@ NUMPROCESSES_FLAGS: tuple[str, ...] = ("-n", "--numprocesses")
 DIST_FLAGS: tuple[str, ...] = ("--dist",)
 MARKER_FLAGS: tuple[str, ...] = ("-m",)
 KEYWORD_FLAGS: tuple[str, ...] = ("-k",)
+# pytest-cov flags the operator's ``coverage`` parameter maps onto. Any of
+# these in ``pytest_args`` means the user is already driving coverage
+# (including the explicit opt-out ``--no-cov``); the operator defers and
+# splices nothing.
+COV_FLAGS: tuple[str, ...] = ("--cov", "--no-cov")
 
 
 def has_flag(args: Sequence[str], names: tuple[str, ...]) -> bool:

--- a/src/airflow_pytest_operator/operators/_coverage.py
+++ b/src/airflow_pytest_operator/operators/_coverage.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from __future__ import annotations
 
 import re
@@ -99,13 +98,29 @@ class CoverageController:
             return None
         return float(matches[-1]) / 100.0
 
+    @staticmethod
+    def looks_like_missing_plugin(stderr: str | None) -> bool:
+        """True if ``stderr`` shows pytest rejecting ``--cov`` (pytest-cov absent).
+
+        Without pytest-cov installed, pytest aborts a coverage run with
+        ``error: unrecognized arguments: --cov ...`` and writes no report. The
+        operator uses this to turn that confusing "no report" failure into an
+        actionable "install the ``[coverage]`` extra" message.
+        """
+        if not stderr:
+            return False
+        return "unrecognized arguments" in stderr and "--cov" in stderr
+
     def evaluate_gate(self, coverage: float | None) -> None:
         """Enforce ``cov_fail_under``; raise on failure, return on pass.
 
-        Fail-closed: an unmeasurable run (``coverage is None``) under an active
-        gate is a failure, not a silent pass. The caller invokes this only when
-        coverage was active and :attr:`gate_enabled` is True.
+        A no-op when no gate is configured. Fail-closed otherwise: an
+        unmeasurable run (``coverage is None``) under an active gate is a
+        failure, not a silent pass. The operator only calls this when coverage
+        was active, but the ``None`` guard keeps the method safe to call
+        unconditionally (and independent of ``python -O`` assert stripping).
         """
-        assert self.cov_fail_under is not None  # gate_enabled checked by caller
+        if self.cov_fail_under is None:
+            return  # no gate configured -- nothing to enforce
         if coverage is None or coverage < self.cov_fail_under:
             raise CoverageThresholdError(coverage, self.cov_fail_under)

--- a/src/airflow_pytest_operator/operators/_coverage.py
+++ b/src/airflow_pytest_operator/operators/_coverage.py
@@ -1,0 +1,111 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import annotations
+
+import re
+
+from ..exceptions import CoverageThresholdError
+from ._constants import COV_FLAGS, has_flag
+
+_COVERAGE_TOTAL_RE = re.compile(r"^TOTAL\s+.*?(\d+(?:\.\d+)?)%", re.MULTILINE)
+
+
+class CoverageController:
+    """Splice/measure/gate coverage for one operator instance.
+
+    Holds the two operator parameters that drive coverage and exposes small,
+    mostly-pure operations the operator calls in order: :meth:`augment_args`
+    (decide the flags), :meth:`extract` (read the fraction), and
+    :meth:`evaluate_gate` (enforce ``cov_fail_under``).
+    """
+
+    def __init__(self, *, coverage: bool, cov_fail_under: float | None) -> None:
+        self.coverage = coverage
+        self.cov_fail_under = cov_fail_under
+
+    @property
+    def requested(self) -> bool:
+        """True when coverage was asked for -- by the flag or by the gate."""
+        return self.coverage or self.cov_fail_under is not None
+
+    @property
+    def gate_enabled(self) -> bool:
+        """True when a ``cov_fail_under`` gate is configured."""
+        return self.cov_fail_under is not None
+
+    def augment_args(
+        self, effective_args: list[str], *, dry_run: bool
+    ) -> tuple[bool, bool]:
+        """Splice ``--cov``/report flags into ``effective_args`` *in place*.
+
+        Adds ``--cov --cov-report=term-missing`` on the first full run when
+        coverage is requested and the user is not already driving it. Skipped in
+        dry-run. Returns ``(active, deferred)``:
+
+        - ``active``   -- a coverage ``TOTAL`` row will be produced (``--cov`` is
+          in effect and not opted out with ``--no-cov``), so a fraction can be
+          read and the gate evaluated;
+        - ``deferred`` -- the user already set ``--cov``/``--no-cov`` in
+          ``pytest_args``, so nothing was spliced (the operator logs a warning).
+        """
+        deferred = False
+        if not dry_run and self.requested:
+            if has_flag(effective_args, COV_FLAGS):
+                deferred = True
+            else:
+                effective_args.extend(["--cov", "--cov-report=term-missing"])
+        active = (
+            not dry_run
+            and has_flag(effective_args, ("--cov",))
+            and not has_flag(effective_args, ("--no-cov",))
+        )
+        return active, deferred
+
+    @staticmethod
+    def extract(stdout: str) -> float | None:
+        """Overall line-coverage fraction parsed from pytest-cov's term report.
+
+        Scans ``stdout`` for the ``TOTAL`` row of the coverage table (printed by
+        ``--cov-report=term`` / ``term-missing``) and returns it as a fraction in
+        ``[0, 1]`` -- a ``TOTAL ... 85%`` row yields ``0.85``. The match anchors
+        on the row's trailing percentage, so the extra columns ``--cov-branch``
+        adds do not confuse it, and a configured ``[tool.coverage.report]
+        precision`` (e.g. ``85.25%`` -> ``0.8525``) is honoured since we read the
+        very number shown in the log. Returns ``None`` when no coverage table is
+        present (pytest-cov absent, a ``--cov-report`` without a terminal report,
+        or no data collected), so the caller records "requested but unavailable"
+        rather than a wrong ``0``.
+
+        Takes the *last* matching row, not the first: pytest-cov prints its table
+        in the terminal summary at the very end, so a test that happened to emit a
+        ``TOTAL ... NN%``-looking line of its own earlier in stdout cannot shadow
+        the real coverage total.
+        """
+        matches = _COVERAGE_TOTAL_RE.findall(stdout)
+        if not matches:
+            return None
+        return float(matches[-1]) / 100.0
+
+    def evaluate_gate(self, coverage: float | None) -> None:
+        """Enforce ``cov_fail_under``; raise on failure, return on pass.
+
+        Fail-closed: an unmeasurable run (``coverage is None``) under an active
+        gate is a failure, not a silent pass. The caller invokes this only when
+        coverage was active and :attr:`gate_enabled` is True.
+        """
+        assert self.cov_fail_under is not None  # gate_enabled checked by caller
+        if coverage is None or coverage < self.cov_fail_under:
+            raise CoverageThresholdError(coverage, self.cov_fail_under)

--- a/src/airflow_pytest_operator/operators/_validation.py
+++ b/src/airflow_pytest_operator/operators/_validation.py
@@ -1,0 +1,154 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..stores import LastFailedStore
+from ._constants import DIST_MODES, PARALLEL_KEYWORDS, RETRY_STRATEGIES
+
+
+def validate_test_retry_strategy(test_retry_strategy: str) -> None:
+    if test_retry_strategy not in RETRY_STRATEGIES:
+        raise ValueError(
+            "test_retry_strategy must be one of 'all', 'failed_only'; "
+            f"got {test_retry_strategy!r}"
+        )
+
+
+def validate_markers_keyword(markers: str | None, keyword: str | None) -> None:
+    # Only the type is checked here; an empty/blank value is left to execute()
+    # (a template may render to "" and be skipped).
+    for _name, _value in (("markers", markers), ("keyword", keyword)):
+        if _value is not None and not isinstance(_value, str):
+            raise TypeError(
+                f"{_name} must be a str (a pytest -m/-k expression) or None; "
+                f"got {type(_value).__name__}"
+            )
+
+
+def validate_rerun_failed(rerun_failed: int) -> None:
+    # bool is an int subclass -- reject it explicitly (it's not a count).
+    if isinstance(rerun_failed, bool) or not isinstance(rerun_failed, int):
+        raise TypeError(
+            f"rerun_failed must be an int (not bool); got {type(rerun_failed).__name__}"
+        )
+    if rerun_failed < 0:
+        raise ValueError(
+            f"rerun_failed must be a non-negative integer; got {rerun_failed!r}"
+        )
+
+
+def validate_parallel_dist(parallel: int | str | None, dist: str | None) -> None:
+    # parallel: xdist worker count. None = serial; int must be >= 1;
+    # "auto"/"logical" are xdist keywords. bool rejected explicitly.
+    if parallel is not None:
+        if isinstance(parallel, bool):
+            raise TypeError(
+                "parallel must be an int or 'auto'/'logical' (not bool); "
+                f"got {type(parallel).__name__}"
+            )
+        if isinstance(parallel, int):
+            if parallel < 1:
+                raise ValueError(
+                    f"parallel must be >= 1 (or None to disable); got {parallel!r}"
+                )
+        elif isinstance(parallel, str):
+            if parallel not in PARALLEL_KEYWORDS:
+                raise ValueError(
+                    "parallel string must be one of 'auto', 'logical'; "
+                    f"got {parallel!r}"
+                )
+        else:
+            raise TypeError(
+                "parallel must be an int, 'auto'/'logical', or None; "
+                f"got {type(parallel).__name__}"
+            )
+    # dist: xdist scheduler mode. Require parallel -- --dist is inert without
+    # -n, so reject it alone rather than silently no-op.
+    if dist is not None:
+        if dist not in DIST_MODES:
+            raise ValueError(
+                f"dist must be one of {', '.join(sorted(DIST_MODES))}; got {dist!r}"
+            )
+        if parallel is None:
+            raise ValueError(
+                "dist requires parallel to be set (a worker count or "
+                "'auto'/'logical'); --dist has no effect without -n."
+            )
+
+
+def validate_coverage(coverage: bool) -> None:
+    # coverage is a bool toggle for the pytest-cov splice. Reject a non-bool
+    # (no truthy ints) so a stray ``coverage=1`` does not silently enable it.
+    if not isinstance(coverage, bool):
+        raise TypeError(
+            "coverage must be a bool (True to enable pytest-cov coverage "
+            f"measurement, False to disable); got {type(coverage).__name__}"
+        )
+
+
+def validate_cov_fail_under(cov_fail_under: float | None) -> None:
+    # cov_fail_under: optional coverage gate, a fraction in [0, 1] compared
+    # against the same value pushed to XCom under ``coverage``. Reject bool (a
+    # stray True is not a threshold) and a percentage-style value (>1) with a
+    # pointed hint -- "fail under 80" is a very natural mistake.
+    if cov_fail_under is None:
+        return
+    if isinstance(cov_fail_under, bool) or not isinstance(cov_fail_under, (int, float)):
+        raise TypeError(
+            "cov_fail_under must be a float in [0, 1] (a coverage "
+            f"fraction) or None; got {type(cov_fail_under).__name__}"
+        )
+    if not 0.0 <= cov_fail_under <= 1.0:
+        raise ValueError(
+            "cov_fail_under is a fraction in [0, 1]; use 0.8 for 80%. "
+            f"Got {cov_fail_under!r}"
+        )
+
+
+def validate_store(store: Any) -> None:
+    # Fail fast on a bad store: the runtime_checkable protocol rejects anything
+    # missing read/write/delete (structural -- methods only).
+    if store is not None and not isinstance(store, LastFailedStore):
+        raise TypeError(
+            "store must implement the LastFailedStore protocol -- an object "
+            "with read(key), write(key, ids) and delete(key) methods, e.g. "
+            "the default VariableLastFailedStore(). "
+            f"Got {type(store).__name__}."
+        )
+
+
+def validate_env(env: Any) -> None:
+    # env keys/values become child env vars and must be strings: a non-str
+    # (e.g. a bare True) otherwise fails deep in os.fsencode. Reject here,
+    # naming the offending key.
+    if env is None:
+        return
+    if not isinstance(env, dict):
+        raise TypeError(
+            f"env must be a dict[str, str] or None; got {type(env).__name__}"
+        )
+    for key, value in env.items():
+        if not isinstance(key, str):
+            raise TypeError(
+                f"env keys must be str (env vars are strings); "
+                f"got {type(key).__name__} ({key!r})"
+            )
+        if not isinstance(value, str):
+            raise TypeError(
+                f"env[{key!r}] must be a str (env vars are strings); "
+                f"got {type(value).__name__}"
+            )

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -19,7 +19,7 @@ from typing import Any, Literal
 
 from ..compat import BaseOperator
 from ..exceptions import TestExecutionError, TestsFailedError
-from ..models import TestRunResult
+from ..models import RunSummary, TestRunResult
 from ..reporters import JUnitResultParser, ResultParser
 from ..runners import PytestRunner, SubprocessPytestRunner
 from ..stores import (
@@ -188,7 +188,7 @@ class PytestOperator(BaseOperator):
         self._parser = parser or JUnitResultParser()
         self._store: LastFailedStore = store or VariableLastFailedStore()
 
-    def execute(self, context: Any) -> dict[str, Any]:
+    def execute(self, context: Any) -> RunSummary:
         if self.dry_run:
             self.log.info(
                 "Running pytest in dry-run mode (--collect-only) on %s -- "
@@ -290,7 +290,9 @@ class PytestOperator(BaseOperator):
             result, coverage_percent = self._run_and_parse(
                 targets, effective_args, measure_coverage=cov_active
             )
-            summary = dict(result.to_xcom())
+            # to_xcom() returns a fresh RunSummary dict each call, so we mutate it
+            # directly (adding coverage / rerun keys below) -- no copy needed.
+            summary = result.to_xcom()
             # Surface the fraction only when coverage was active -- keeps the XCom
             # shape unchanged otherwise. From the first run; not re-derived.
             if cov_active:
@@ -424,6 +426,19 @@ class PytestOperator(BaseOperator):
             stderr_text = artifacts.stderr or "<empty>"
             if len(stderr_text) > MAX_STDERR_LEN:
                 stderr_text = stderr_text[:MAX_STDERR_LEN] + "...(truncated)"
+
+            # Common, confusing case: coverage was requested but pytest-cov is
+            # not installed on the worker, so pytest rejected --cov and wrote no
+            # report. Surface an actionable hint instead of the generic message.
+            if measure_coverage and self._coverage.looks_like_missing_plugin(
+                artifacts.stderr
+            ):
+                raise TestExecutionError(
+                    "coverage was requested but pytest-cov is not installed on "
+                    "the worker (pytest rejected --cov). Install the extra: "
+                    "pip install 'airflow-pytest-operator[coverage]'. "
+                    f"Captured stderr:\n{stderr_text}"
+                )
 
             raise TestExecutionError(
                 f"pytest produced no report for {type(self._parser).__name__} "

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -1,15 +1,3 @@
-"""The Airflow operator.
-
-This class is intentionally *thin*. Its only responsibilities are:
-  1. orchestrate runner -> parser,
-  2. integrate with Airflow (templating, XCom, logging, fail policy).
-
-It contains no subprocess logic and no XML parsing. Both collaborators
-are injected (Dependency Inversion): defaults are provided for ergonomic
-use in DAGs, but tests can pass fakes, and advanced users can swap in a
-Docker/K8s runner or a JSON parser without subclassing.
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,14 +32,22 @@ from ..utils import node_id_to_pytest_args
 from ._constants import (
     COLLECT_ONLY_ALIASES,
     DIST_FLAGS,
-    DIST_MODES,
     KEYWORD_FLAGS,
     MARKER_FLAGS,
     MAX_STDERR_LEN,
     NUMPROCESSES_FLAGS,
-    PARALLEL_KEYWORDS,
-    RETRY_STRATEGIES,
     has_flag,
+)
+from ._coverage import CoverageController
+from ._validation import (
+    validate_cov_fail_under,
+    validate_coverage,
+    validate_env,
+    validate_markers_keyword,
+    validate_parallel_dist,
+    validate_rerun_failed,
+    validate_store,
+    validate_test_retry_strategy,
 )
 
 
@@ -59,72 +55,61 @@ class PytestOperator(BaseOperator):
     """Run a pytest suite as an Airflow task.
 
     Orchestrates an injectable runner -> parser and handles the Airflow side
-    (templating, XCom, fail policy, retries). The structured summary returned
-    by ``execute`` is pushed to XCom under ``return_value`` unless Airflow's
-    ``do_xcom_push=False`` is set. See the README for full behaviour and
-    examples.
+    (templating, XCom, fail policy, retries). ``execute`` returns a summary dict
+    pushed to XCom under ``return_value`` (unless ``do_xcom_push=False``). See the
+    README for full behaviour and examples.
 
-    :param test_path: pytest target(s) -- a file, directory, or node-id, or a
+    :param test_path: pytest target(s) -- file, directory, or node-id, or a
         sequence of them (templated).
     :param pytest_args: extra pytest CLI args, e.g. ``["-x", "-q"]`` (templated).
-    :param markers: ``-m`` marker expression, e.g. ``"smoke and not slow"``
-        (templated). Sugar over ``pytest_args``; defers to an explicit ``-m``
-        there and is skipped if it renders empty. Default None.
-    :param keyword: ``-k`` keyword expression, e.g. ``"login or logout"``
-        (templated). Same rules as ``markers``. Default None.
+    :param markers: ``-m`` marker expression (templated). Sugar over
+        ``pytest_args``; defers to an explicit ``-m`` and skipped if empty.
+    :param keyword: ``-k`` keyword expression (templated). Same rules as
+        ``markers``.
     :param env: extra environment variables for the run (templated).
-    :param env_file: path to a ``.env`` merged into the test subprocess
-        (templated). The operator only forwards the path; the runner reads and
-        merges it with precedence ``os.environ`` < ``env_file`` < ``env``.
-        ``AIRFLOW*`` keys are skipped unless ``env_file_overrides=True``. Needs
-        the ``[dotenv]`` extra; a missing file/dependency fails the run.
-        Default None.
-    :param env_file_overrides: let ``env_file`` set ``AIRFLOW*`` keys. Default
-        False (the explicit ``env`` is never restricted).
+    :param env_file: path to a ``.env`` merged into the child (templated;
+        precedence ``os.environ`` < ``env_file`` < ``env``). ``AIRFLOW*`` keys
+        skipped unless ``env_file_overrides``. Needs the ``[dotenv]`` extra.
+    :param env_file_overrides: let ``env_file`` set ``AIRFLOW*`` keys (default
+        False; the explicit ``env`` is never restricted).
     :param fail_on_test_failure: fail the task on any test failure/error. If
         False, the task always succeeds and the outcome lives only in XCom.
-        Default True.
-    :param dry_run: invoke pytest with ``--collect-only`` -- import and collect,
-        but run no test bodies (module-level code still runs). A collection
-        error still fails the task. Useful as a DAG pre-flight. Default False.
-    :param test_retry_strategy: how Airflow *retries* re-run the suite. ``"all"``
-        (default) re-runs everything; ``"failed_only"`` re-runs only the previous
-        attempt's failures, carried across retries in an Airflow Variable
-        (consumed on read, written only when a further retry will read it).
-        Best-effort: falls back to the full suite if unavailable; ignored in
-        ``dry_run``.
-    :param rerun_failed: extra **in-process** rounds re-running only the failed
-        tests within one task execution (no pytest cache, no Airflow retry).
-        ``0`` (default) disables it. On rerun the XCom summary adds
-        ``rerun_rounds``, ``recovered_node_ids`` and ``still_failing_node_ids``;
-        the task fails only if tests still fail after all rounds. Ignored in
-        ``dry_run``. Non-negative int.
-    :param parallel: pytest-xdist worker count -- an int, or ``"auto"`` /
-        ``"logical"``; maps to ``-n``. Applied to the first full run only (not
-        the ``rerun_failed`` rounds), ignored in ``dry_run``, and deferred to an
-        explicit ``-n`` in ``pytest_args``. Needs the ``[xdist]`` extra on the
-        worker. Default None (serial).
-    :param dist: pytest-xdist ``--dist`` mode -- ``"load"`` (default; spread
-        tests), ``"loadscope"`` / ``"loadfile"`` / ``"loadgroup"`` (pin a
-        module-or-class / file / group to one worker), ``"worksteal"``,
-        ``"each"``, ``"no"``. Requires ``parallel``. Default None.
-    :param stream_output: when True (default), pytest's stdout/stderr is logged
-        to the task log line-by-line **as it runs** (so a long suite isn't a
-        blank screen until it finishes), and the child runs unbuffered (``-u``).
-        The full output is still captured in the result either way. False
-        restores the old behaviour: one stdout/stderr blob logged after the run.
-    :param store: injectable ``LastFailedStore`` for the ``failed_only`` set
-        (default: ``VariableLastFailedStore``). Any object with
-        ``read``/``write``/``delete`` works (structural typing). Unused unless
+    :param dry_run: invoke pytest with ``--collect-only`` (collect, run no test
+        bodies). A collection error still fails the task. Default False.
+    :param test_retry_strategy: how Airflow retries re-run the suite -- ``"all"``
+        (default) or ``"failed_only"`` (only the prior attempt's failures, carried
+        in an Airflow Variable). Best-effort; ignored in ``dry_run``.
+    :param rerun_failed: extra in-process rounds re-running only the failed tests
+        (no pytest cache, no Airflow retry). ``0`` disables. Adds ``rerun_rounds``
+        / ``recovered_node_ids`` / ``still_failing_node_ids`` to the summary.
+        Ignored in ``dry_run``. Non-negative int.
+    :param parallel: pytest-xdist worker count -- int, or ``"auto"``/``"logical"``
+        (maps to ``-n``). First full run only; ignored in ``dry_run``; defers to
+        an explicit ``-n``. Needs the ``[xdist]`` extra. Default None (serial).
+    :param dist: pytest-xdist ``--dist`` mode (``"load"``, ``"loadscope"``,
+        ``"loadfile"``, ``"loadgroup"``, ``"worksteal"``, ``"each"``, ``"no"``).
+        Requires ``parallel``. Default None.
+    :param stream_output: when True (default), child stdout/stderr is logged
+        line-by-line as it runs (unbuffered ``-u``); False logs one blob at the
+        end. The full output is captured either way.
+    :param coverage: when True, measure coverage via pytest-cov on the first full
+        run and push the overall fraction to XCom under ``coverage`` (a float in
+        ``[0, 1]``, or ``None``). Defers to a user ``--cov``/``--no-cov``, skipped
+        in ``dry_run``, not applied to reruns. Needs the ``[coverage]`` extra.
+        See the README. Default False.
+    :param cov_fail_under: optional coverage gate -- a fraction in ``[0, 1]``
+        compared against the measured ``coverage``. Enables measurement
+        automatically and fails the task with :class:`CoverageThresholdError`
+        below the threshold (test failures take precedence; fail-closed if
+        unmeasurable). See the README. Default None (no gate).
+    :param store: injectable ``LastFailedStore`` for ``failed_only`` (default
+        ``VariableLastFailedStore``). Unused unless
         ``test_retry_strategy="failed_only"``.
     :param runner: injectable :class:`PytestRunner` (default: subprocess).
-    :param parser: injectable :class:`ResultParser` (default: JUnit); it owns
-        the report location via its ``report_dir``.
+    :param parser: injectable :class:`ResultParser` (default: JUnit).
     """
 
-    # Airflow Jinja-templates these attributes before execute() runs. The
-    # internal option vocabulary and the ``has_flag`` helper live in
-    # ``_constants.py`` to keep this module focused on orchestration.
+    # Airflow Jinja-templates these attributes before execute() runs.
     template_fields: Sequence[str] = (
         "test_path",
         "pytest_args",
@@ -152,100 +137,25 @@ class PytestOperator(BaseOperator):
         parallel: int | str | None = None,
         dist: str | None = None,
         stream_output: bool = True,
+        coverage: bool = False,
+        cov_fail_under: float | None = None,
         runner: PytestRunner | None = None,
         parser: ResultParser | None = None,
         store: LastFailedStore | None = None,
         **kwargs: Any,
     ) -> None:
-        # Convention throughout: wrong *type* -> TypeError, valid type/wrong
-        # *value* -> ValueError.
-        if test_retry_strategy not in RETRY_STRATEGIES:
-            raise ValueError(
-                "test_retry_strategy must be one of 'all', 'failed_only'; "
-                f"got {test_retry_strategy!r}"
-            )
-        # markers/keyword: only the type is checked here; an empty/blank value
-        # is left to execute() (a template may render to "" and be skipped).
-        for _name, _value in (("markers", markers), ("keyword", keyword)):
-            if _value is not None and not isinstance(_value, str):
-                raise TypeError(
-                    f"{_name} must be a str (a pytest -m/-k expression) or None; "
-                    f"got {type(_value).__name__}"
-                )
-        # bool is an int subclass -- reject it explicitly (it's not a count).
-        if isinstance(rerun_failed, bool) or not isinstance(rerun_failed, int):
-            raise TypeError(
-                "rerun_failed must be an int (not bool); "
-                f"got {type(rerun_failed).__name__}"
-            )
-        if rerun_failed < 0:
-            raise ValueError(
-                f"rerun_failed must be a non-negative integer; got {rerun_failed!r}"
-            )
-        # parallel: xdist worker count. None = serial; int must be >= 1;
-        # "auto"/"logical" are xdist keywords. bool rejected explicitly.
-        if parallel is not None:
-            if isinstance(parallel, bool):
-                raise TypeError(
-                    "parallel must be an int or 'auto'/'logical' (not bool); "
-                    f"got {type(parallel).__name__}"
-                )
-            if isinstance(parallel, int):
-                if parallel < 1:
-                    raise ValueError(
-                        f"parallel must be >= 1 (or None to disable); got {parallel!r}"
-                    )
-            elif isinstance(parallel, str):
-                if parallel not in PARALLEL_KEYWORDS:
-                    raise ValueError(
-                        "parallel string must be one of 'auto', 'logical'; "
-                        f"got {parallel!r}"
-                    )
-            else:
-                raise TypeError(
-                    "parallel must be an int, 'auto'/'logical', or None; "
-                    f"got {type(parallel).__name__}"
-                )
-        # dist: xdist scheduler mode. Require parallel -- --dist is inert
-        # without -n, so reject it alone rather than silently no-op.
-        if dist is not None:
-            if dist not in DIST_MODES:
-                raise ValueError(
-                    f"dist must be one of {', '.join(sorted(DIST_MODES))}; got {dist!r}"
-                )
-            if parallel is None:
-                raise ValueError(
-                    "dist requires parallel to be set (a worker count or "
-                    "'auto'/'logical'); --dist has no effect without -n."
-                )
-        # Fail fast on a bad store: the runtime_checkable protocol rejects
-        # anything missing read/write/delete (structural -- methods only).
-        if store is not None and not isinstance(store, LastFailedStore):
-            raise TypeError(
-                "store must implement the LastFailedStore protocol -- an object "
-                "with read(key), write(key, ids) and delete(key) methods, e.g. "
-                "the default VariableLastFailedStore(). "
-                f"Got {type(store).__name__}."
-            )
-        # env keys/values become child env vars and must be strings: a non-str
-        # (e.g. a bare True) otherwise fails deep in os.fsencode. Reject here,
-        # naming the offending key.
-        if env is not None:
-            if not isinstance(env, dict):
-                raise TypeError(
-                    f"env must be a dict[str, str] or None; got {type(env).__name__}"
-                )
-            for key, value in env.items():
-                if not isinstance(key, str):
-                    raise TypeError(
-                        f"env keys must be str (env vars are strings); "
-                        f"got {type(key).__name__} ({key!r})"
-                    )
-                if not isinstance(value, str):
-                    raise TypeError(
-                        f"env[{key!r}] must be a str (env vars are strings); "
-                        f"got {type(value).__name__}"
-                    )
+        # Validate constructor arguments (extracted to _validation.py).
+        # Convention: wrong *type* -> TypeError, valid type / wrong *value* ->
+        # ValueError. Each call raises with a message naming the bad argument.
+        validate_test_retry_strategy(test_retry_strategy)
+        validate_markers_keyword(markers, keyword)
+        validate_rerun_failed(rerun_failed)
+        validate_parallel_dist(parallel, dist)
+        validate_coverage(coverage)
+        validate_cov_fail_under(cov_fail_under)
+        validate_store(store)
+        validate_env(env)
+
         super().__init__(**kwargs)
         self.test_path = test_path
         self.pytest_args = list(pytest_args) if pytest_args else []
@@ -261,6 +171,19 @@ class PytestOperator(BaseOperator):
         self.parallel = parallel
         self.dist = dist
         self.stream_output = stream_output
+        self.coverage = coverage
+        # Store as float so the gate comparison and message formatting are
+        # uniform (an int like 1 or 0 is a valid fraction).
+        self.cov_fail_under = (
+            float(cov_fail_under) if cov_fail_under is not None else None
+        )
+        # The coverage concern (splice flags, read the fraction, gate) lives in
+        # its own controller so the operator only logs + builds the XCom summary.
+        # Built from the stored attributes (normalized) so the controller always
+        # mirrors the operator's canonical state.
+        self._coverage = CoverageController(
+            coverage=self.coverage, cov_fail_under=self.cov_fail_under
+        )
         self._runner = runner or SubprocessPytestRunner()
         self._parser = parser or JUnitResultParser()
         self._store: LastFailedStore = store or VariableLastFailedStore()
@@ -282,10 +205,8 @@ class PytestOperator(BaseOperator):
         ):
             effective_args.append("--collect-only")
 
-        # markers / keyword: sugar for pytest's -m / -k, spliced into the first
-        # full run (and dry-run collection). An empty/blank value is skipped;
-        # defer to the same flag already in pytest_args. Not applied to the
-        # rerun_failed rounds (they target explicit node-ids).
+        # markers / keyword: sugar for -m / -k on the first full run. Skipped if
+        # empty; defers to the same flag already in pytest_args.
         for name, value, flags in (
             ("markers", self.markers, MARKER_FLAGS),
             ("keyword", self.keyword, KEYWORD_FLAGS),
@@ -303,9 +224,23 @@ class PytestOperator(BaseOperator):
             else:
                 effective_args += [flags[0], value]
 
-        # pytest-xdist: -n / --dist on the first full run only (rerun_failed
-        # rounds stay serial; skipped in dry-run). If the user already drives
-        # -n/--numprocesses, they own parallelism -- defer and skip --dist too.
+        # pytest-cov: the controller owns the splice/active/defer decision.
+        # ``cov_active`` -> a coverage total will be produced; ``cov_deferred``
+        # -> the user already drives --cov/--no-cov, so we warn.
+        cov_active, cov_deferred = self._coverage.augment_args(
+            effective_args, dry_run=self.dry_run
+        )
+        if cov_deferred:
+            self.log.warning(
+                "coverage measurement (coverage=%r / cov_fail_under=%r) ignored: "
+                "pytest_args already sets --cov / --no-cov; deferring to your "
+                "explicit arg.",
+                self.coverage,
+                self.cov_fail_under,
+            )
+
+        # pytest-xdist: -n / --dist on the first full run only (skipped in
+        # dry-run). Defer to a user-supplied -n/--numprocesses (and skip --dist).
         if not self.dry_run and self.parallel is not None:
             if has_flag(effective_args, NUMPROCESSES_FLAGS):
                 self.log.warning(
@@ -316,9 +251,7 @@ class PytestOperator(BaseOperator):
                 )
             else:
                 effective_args += ["-n", str(self.parallel)]
-                # Skip --dist if the user already set it: deference is keyed on
-                # -n above, so a lone --dist would otherwise be duplicated
-                # (xdist keeps the last, dropping theirs).
+                # Defer to a user-supplied --dist (xdist keeps the last one).
                 if self.dist is not None:
                     if has_flag(effective_args, DIST_FLAGS):
                         self.log.warning(
@@ -329,12 +262,10 @@ class PytestOperator(BaseOperator):
                     else:
                         effective_args += ["--dist", self.dist]
 
-        # failed_only: narrow to the tests that failed on the previous attempt,
-        # carried across Airflow retries in a Variable. We narrow whenever the
-        # store holds a set (not gated on try_number), else run the full suite.
-        # Consume-on-read: delete the Variable as soon as we read it, before the
-        # (possibly crashing) run, so a dead worker can't orphan it; a fresh copy
-        # is written at the end only if a retry will read it. No-op in dry-run.
+        # failed_only: narrow to the prior attempt's failures, carried in a
+        # Variable. Consume-on-read (delete before the run) so a dead worker
+        # can't orphan it; a fresh copy is written at the end only if a retry
+        # will read it. No-op in dry-run.
         var_key: str | None = None
         targets: str | Sequence[str] = self.test_path
         if self.test_retry_strategy == "failed_only" and not self.dry_run:
@@ -354,17 +285,33 @@ class PytestOperator(BaseOperator):
 
         run_ok = False
         try:
-            # First pass: snapshot its summary right away -- that's the honest
-            # picture pushed to XCom even if the reruns below recover failures.
-            # ``result`` tracks the latest run; ``summary`` holds the snapshot.
-            result = self._run_and_parse(targets, effective_args)
+            # First pass: snapshot the summary now -- the honest picture pushed
+            # to XCom even if the reruns below recover failures.
+            result, coverage_percent = self._run_and_parse(
+                targets, effective_args, measure_coverage=cov_active
+            )
             summary = dict(result.to_xcom())
+            # Surface the fraction only when coverage was active -- keeps the XCom
+            # shape unchanged otherwise. From the first run; not re-derived.
+            if cov_active:
+                summary["coverage"] = coverage_percent
+                if coverage_percent is None:
+                    self.log.warning(
+                        "coverage was requested but no TOTAL row was found in "
+                        "pytest's output -- pushing coverage=None. Make sure "
+                        "--cov-report includes a terminal report (term / "
+                        "term-missing) and that the run produced coverage data."
+                    )
+                else:
+                    self.log.info(
+                        "Overall coverage %.2f pushed to XCom under 'coverage'.",
+                        coverage_percent,
+                    )
             still_failing = list(result.failed_node_ids)
             rerun_rounds = 0
 
-            # In-process reruns of ONLY the failed tests -- no pytest cache, no
-            # Airflow retry, so robust on any executor. Skipped in dry-run and
-            # when nothing failed.
+            # In-process reruns of only the failed tests -- no pytest cache, no
+            # Airflow retry. Skipped in dry-run and when nothing failed.
             if not self.dry_run and self.rerun_failed > 0 and still_failing:
                 for _ in range(self.rerun_failed):
                     if not still_failing:
@@ -379,11 +326,10 @@ class PytestOperator(BaseOperator):
                         self.rerun_failed,
                         len(selectors),
                     )
-                    result = self._run_and_parse(selectors, list(self.pytest_args))
+                    result, _ = self._run_and_parse(selectors, list(self.pytest_args))
                     still_failing = list(result.failed_node_ids)
 
-            # Only when reruns happened, add the post-rerun view to the snapshot
-            # so the final outcome is unambiguous.
+            # Add the post-rerun view to the snapshot when reruns happened.
             run_ok = result.success
             if rerun_rounds:
                 recovered = [
@@ -402,12 +348,9 @@ class PytestOperator(BaseOperator):
                     len(still_failing),
                 )
 
-            # failed_only: hand the still-failing set to the next attempt, but
-            # ONLY when one will read it -- this attempt failed, fails the task
-            # (fail_on_test_failure), and isn't the final attempt. Otherwise we
-            # write nothing, so no terminal attempt orphans a Variable. Written
-            # before the raise below so the failing attempt hands failures
-            # forward; is_final_attempt gets self.log to surface its warning.
+            # failed_only: hand the still-failing set forward, but only when a
+            # next attempt will read it (this attempt fails the task and isn't
+            # the final one) -- so no terminal attempt orphans a Variable.
             if (
                 var_key is not None
                 and still_failing
@@ -419,38 +362,49 @@ class PytestOperator(BaseOperator):
             if self.fail_on_test_failure and not run_ok:
                 raise TestsFailedError(result)
 
+            # Coverage gate: the controller raises below the threshold
+            # (fail-closed if unmeasurable). After the test-failure raise above,
+            # so a red suite reports that first.
+            if cov_active and self._coverage.gate_enabled:
+                self._coverage.evaluate_gate(coverage_percent)
+                summary["coverage_passed"] = True
+                self.log.info(
+                    "Coverage gate passed: %.2f >= cov_fail_under=%.2f.",
+                    coverage_percent,
+                    self.cov_fail_under,
+                )
+
             return summary
         finally:
-            # Always clean up; the runner decides what to remove from its policy
-            # and the success flag. Wrapped so a cleanup error never masks the
-            # real outcome. The failed_only Variable is untouched here on purpose
-            # (consumed on read, written only for a retry that reads it).
+            # Always clean up (wrapped so a cleanup error never masks the real
+            # outcome). The failed_only Variable is untouched here on purpose.
             self._safe_cleanup(success=run_ok)
 
     def _run_and_parse(
-        self, targets: str | Sequence[str], pytest_args: Sequence[str]
-    ) -> TestRunResult:
+        self,
+        targets: str | Sequence[str],
+        pytest_args: Sequence[str],
+        *,
+        measure_coverage: bool = False,
+    ) -> tuple[TestRunResult, float | None]:
         """Run pytest once against ``targets`` and parse the report.
 
-        Shared by the first full run and each in-process rerun. Surfaces
-        child output, turns a missing report into a clear
-        :class:`TestExecutionError`, parses the result, and logs the summary.
+        Shared by the first full run and each in-process rerun. Returns the
+        parsed :class:`TestRunResult` plus the coverage fraction (a float in
+        ``[0, 1]`` when ``measure_coverage`` is set and a ``TOTAL`` row is found,
+        else ``None``). A missing report raises :class:`TestExecutionError`.
         """
-        # stream_output: hand the runner a live sink so pytest output reaches
-        # the task log line-by-line as it runs, instead of one blob at the end
-        # (the wait-on-a-blank-screen problem). The runner still returns the full
-        # captured output in ``artifacts`` either way.
+        # stream_output: a live sink so pytest output reaches the task log
+        # line-by-line; the full output is still returned in ``artifacts``.
         on_output = self._emit_pytest_line if self.stream_output else None
         artifacts = self._runner.run(
             targets,
             pytest_args=pytest_args,
             env=self.env,
-            # env_file forwarded as a path; the runner reads/merges it (the
-            # operator does no filesystem work).
+            # env_file is a path; the runner reads/merges it (no fs work here).
             env_file=self.env_file,
             env_file_overrides=self.env_file_overrides,
-            # The parser decides the report flags/location; the runner just
-            # splices them -- which keeps the runner format-agnostic.
+            # The parser owns the report flags/location; the runner just splices.
             report_request=self._parser.report_request,
             on_output=on_output,
         )
@@ -464,9 +418,8 @@ class PytestOperator(BaseOperator):
             if artifacts.stderr:
                 self.log.warning("pytest stderr:\n%s", artifacts.stderr)
 
-        # No report -> pytest never wrote one (collection error, crash, OOM,
-        # wrong path, missing report-plugin). An execution failure, not a test
-        # failure -- surface it with the captured stderr.
+        # No report -> pytest never wrote one (collection error / crash before
+        # any test ran). An execution failure -- surface the captured stderr.
         if artifacts.report_path is None:
             stderr_text = artifacts.stderr or "<empty>"
             if len(stderr_text) > MAX_STDERR_LEN:
@@ -495,14 +448,18 @@ class PytestOperator(BaseOperator):
         )
         if result.failed_node_ids:
             self.log.error("Failed tests:\n  %s", "\n  ".join(result.failed_node_ids))
-        return result
+
+        # Coverage is read by the controller from the captured stdout, only on
+        # the run that measured it.
+        coverage = (
+            self._coverage.extract(artifacts.stdout) if measure_coverage else None
+        )
+        return result, coverage
 
     def _emit_pytest_line(self, line: str, stream: str) -> None:
-        """Live sink for child output -- routes each line to the task log.
+        """Live sink (``on_output``) routing each child line to the task log.
 
-        Passed to the runner as ``on_output`` when ``stream_output`` is on.
-        stdout goes to info, stderr to warning (matching the old end-of-run
-        blob levels), so the output streams to the Airflow UI as it happens.
+        stdout -> info, stderr -> warning, so output streams to the UI live.
         """
         if stream == "stderr":
             self.log.warning("%s", line)
@@ -511,16 +468,11 @@ class PytestOperator(BaseOperator):
 
     # -- best-effort collaborator calls ---------------------------------
     #
-    # cleanup/read/delete/write are best-effort by contract. Since runner/store
-    # are injection points, a custom one could still raise; these wrappers keep a
+    # runner/store are injection points and could raise; these wrappers keep a
     # bookkeeping/teardown error from masking execute()'s real outcome.
 
     def _safe_cleanup(self, *, success: bool) -> None:
-        """Invoke the runner's cleanup; teardown must never mask the outcome.
-
-        Used both between in-process reruns (to free each round's report dir)
-        and in ``execute``'s ``finally``.
-        """
+        """Invoke the runner's cleanup; teardown must never mask the outcome."""
         try:
             self._runner.cleanup(success=success)
         except Exception:
@@ -542,24 +494,17 @@ class PytestOperator(BaseOperator):
             self.log.exception("Error while deleting failed_only Variable %r", key)
 
     def _safe_store_write(self, key: str, node_ids: list[str]) -> None:
-        """Hand the failed set forward; a store error must not mask the result.
-
-        This write sits right before the ``TestsFailedError`` raise, so an
-        exception here from a contract-violating store would otherwise replace
-        the genuine test-failure signal with a bookkeeping traceback.
-        """
+        """Hand the failed set forward; a store error must not mask the result."""
         try:
             self._store.write(key, node_ids)
         except Exception:
             self.log.exception("Error while writing failed_only Variable %r", key)
 
     def on_kill(self) -> None:
-        """Abort the test run when Airflow terminates the task.
+        """Abort the run when Airflow terminates the task (timeout / clear / SIGTERM).
 
-        Called on timeout, manual clear/mark-failed, or worker SIGTERM. We
-        delegate to the runner, which owns the spawned process/resources; the
-        operator knows nothing about subprocesses. Runners with nothing to
-        cancel inherit a safe no-op.
+        Delegates to the runner, which owns the process; a runner with nothing
+        to cancel inherits a safe no-op.
         """
         self.log.warning("Task killed -- cancelling pytest run on %s", self.test_path)
         try:
@@ -568,10 +513,8 @@ class PytestOperator(BaseOperator):
             # on_kill must never raise -- it runs during teardown.
             self.log.exception("Error while cancelling pytest run")
 
-        # cancel() stopped the process, but the "always" policy still removes
-        # the temp report dir -- kills/timeouts are exactly when dirs leak, so
-        # clean here too. cleanup() is idempotent, so racing execute()'s finally
-        # is harmless.
+        # Kills/timeouts are exactly when temp dirs leak, so clean here too.
+        # cleanup() is idempotent, so racing execute()'s finally is harmless.
         try:
             self._runner.cleanup(success=False)
         except Exception:  # pragma: no cover - best-effort teardown

--- a/src/airflow_pytest_operator/provider_info.py
+++ b/src/airflow_pytest_operator/provider_info.py
@@ -12,25 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Airflow provider-discovery metadata.
-
-This module is deliberately import-light: it pulls in *nothing* from the
-rest of the package (no operator, no compat shim, no Airflow imports) --
-only the stdlib.
-
-Airflow's provider manager imports the ``get_provider_info`` entry point
-very early during startup, while Airflow's own configuration is still
-initializing and before the Task SDK is ready. If that entry point lived
-in ``__init__.py`` -- which would otherwise import the operator and thus
-``airflow.sdk.bases.operator`` -- that early import crashes on Airflow
-3.2.x (``cannot import name 'conf' from 'airflow.sdk.configuration'``) and
-aborts worker startup. Keeping the entry point here, import-light, breaks
-that chain.
-
-It also owns the single source of truth for ``__version__`` (read from
-package metadata), which the package root re-exports.
-"""
-
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version

--- a/src/airflow_pytest_operator/reporters/base.py
+++ b/src/airflow_pytest_operator/reporters/base.py
@@ -1,11 +1,3 @@
-"""The result-parser interface.
-
-A parser turns a report file into a :class:`TestRunResult`. It knows
-nothing about how the report was produced. Keeping this separate from
-the runner means we can support other report formats (e.g. a JSON
-report plugin) by adding a parser, not by editing existing code (OCP).
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/airflow_pytest_operator/reporters/json_parser.py
+++ b/src/airflow_pytest_operator/reporters/json_parser.py
@@ -12,26 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""JSON result parser using pytest-json-report.
-
-Parses the JSON document emitted by the ``pytest-json-report`` plugin
-(``--json-report --json-report-file=...``). The plugin must be available
-on the worker that runs the tests; install via the ``json-report`` extra::
-
-    pip install airflow-pytest-operator[json-report]
-
-If the plugin is missing, pytest itself exits with a usage error
-("unrecognized arguments: --json-report"), the runner returns
-``report_path=None``, and the operator surfaces the captured stderr via
-``TestExecutionError`` -- the existing error path for "the run could not
-produce a report". We deliberately do not probe for the plugin at parser
-construction time: the parser lives in the operator's process while
-pytest-json-report is needed wherever the runner spawns pytest, which
-may be a different environment entirely (e.g. a Kubernetes pod started
-by a custom runner). Validating in the wrong place would produce false
-negatives.
-"""
-
 from __future__ import annotations
 
 import json

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -1,10 +1,3 @@
-"""JUnit XML result parser.
-
-Parses the JUnit XML that pytest emits via ``--junitxml``. We use the
-stdlib ``xml.etree`` with ``defusedxml`` when available to avoid XML
-attack vectors on untrusted reports.
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/airflow_pytest_operator/runners/base.py
+++ b/src/airflow_pytest_operator/runners/base.py
@@ -1,13 +1,3 @@
-"""The Runner interface.
-
-A Runner is responsible for *executing* a pytest run and producing
-:class:`RunArtifacts`. It is NOT responsible for interpreting results.
-That single responsibility is what makes runners interchangeable
-(Liskov): the operator depends only on this abstraction (DIP), so a
-``DockerPytestRunner`` or ``KubernetesPodPytestRunner`` could be dropped
-in later without changing the operator.
-"""
-
 # Copyright 2026 the airflow-pytest-operator contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/airflow_pytest_operator/stores/__init__.py
+++ b/src/airflow_pytest_operator/stores/__init__.py
@@ -12,18 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Cross-retry persistence for the ``failed_only`` retry strategy.
-
-A single Airflow task cannot read its OWN XCom from a previous attempt --
-Airflow clears a task instance's XCom at the start of every (re)run -- and
-writing a *different* task's XCom from inside a task is not portable to
-Airflow 3 (workers have no direct metadata-DB access). An Airflow Variable,
-in contrast, is readable AND writable from within a task on both 2.x and 3.x,
-survives the task's own retries, and can be deleted once no further retry will
-read it. That is exactly the lifecycle ``failed_only`` needs, so the failed
-node-id set is carried between native Airflow retries via a Variable.
-"""
-
 from .base import LastFailedStore
 from .variable_store import (
     VariableLastFailedStore,

--- a/src/airflow_pytest_operator/stores/base.py
+++ b/src/airflow_pytest_operator/stores/base.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The store interface for the ``failed_only`` cross-retry set."""
-
 from __future__ import annotations
 
 from typing import Protocol, runtime_checkable

--- a/src/airflow_pytest_operator/stores/variable_store.py
+++ b/src/airflow_pytest_operator/stores/variable_store.py
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Airflow-Variable backed store for the failed node-ids of a task instance.
-
-The ``Variable`` class is resolved through the compat shim
-(:func:`~airflow_pytest_operator.compat.import_variable`), so this module
-imports no Airflow directly. It degrades gracefully: if Airflow (or the
-Variable backend) is unavailable, reads return ``[]`` and writes/deletes are
-no-ops, so ``failed_only`` falls back to running the full suite -- it never
-crashes the task over a bookkeeping store.
-"""
-
 from __future__ import annotations
 
 import hashlib

--- a/src/airflow_pytest_operator/utils/__init__.py
+++ b/src/airflow_pytest_operator/utils/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from .node_id import node_id_to_pytest_args
 from .shard import parse_collect_only_output, partition_node_ids
 

--- a/src/airflow_pytest_operator/utils/node_id.py
+++ b/src/airflow_pytest_operator/utils/node_id.py
@@ -12,21 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Convert dotted-form node IDs back into pytest CLI selectors.
-
-The package's parsers (:class:`JUnitResultParser`,
-:class:`JSONResultParser`) emit ``failed_node_ids`` in a *dotted*
-JUnit-style form: ``"tests.test_x::test_y"`` regardless of which parser
-produced the result. That cross-parser parity is convenient -- downstream
-Airflow tasks reading XCom never have to care about the parser -- but
-it's not the form pytest accepts as a positional CLI selector. For that
-pytest needs the slash form ``"tests/test_x.py::test_y"``.
-
-This module provides the conversion one direction (dotted -> slash) so a
-follow-up "retry only failed" workflow can pull the IDs from XCom and
-feed them back into a fresh pytest invocation.
-"""
-
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence

--- a/src/airflow_pytest_operator/utils/shard.py
+++ b/src/airflow_pytest_operator/utils/shard.py
@@ -12,19 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Helpers for sharding a suite across mapped tasks (cross-worker parallelism).
-
-The pattern (see ``examples/sharded_mapped.py``): a *collect* task runs
-``pytest --collect-only -q`` and feeds its stdout to
-:func:`parse_collect_only_output`; the node-ids are split with
-:func:`partition_node_ids`; then ``PytestOperator.partial(...).expand(
-test_path=<chunks>)`` runs one mapped task per shard. Each shard can still set
-``parallel=`` for xdist *within* its worker -- the two axes are orthogonal.
-
-Both functions are pure (no I/O), so the distribution logic is unit-testable on
-its own; the operator and runner are untouched.
-"""
-
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/tests/operator/test_coverage_controller.py
+++ b/tests/operator/test_coverage_controller.py
@@ -1,0 +1,181 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Direct unit tests for CoverageController (operators/_coverage.py).
+
+The operator's integration tests (test_op_coverage.py) drive the controller
+through execute(); these pin its pieces in isolation: the splice/active/defer
+decision, the gate, the TOTAL-row parser, and the request/gate properties.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from airflow_pytest_operator.exceptions import (
+    AirflowPytestError,
+    CoverageThresholdError,
+)
+from airflow_pytest_operator.operators._coverage import CoverageController
+
+
+def _ctl(coverage=False, cov_fail_under=None):
+    return CoverageController(coverage=coverage, cov_fail_under=cov_fail_under)
+
+
+# -- properties --------------------------------------------------------------
+
+
+def test_requested_and_gate_enabled():
+    off = _ctl()
+    assert off.requested is False and off.gate_enabled is False
+    flag = _ctl(coverage=True)
+    assert flag.requested is True and flag.gate_enabled is False
+    gate = _ctl(cov_fail_under=0.5)
+    assert gate.requested is True and gate.gate_enabled is True
+
+
+# -- augment_args ------------------------------------------------------------
+
+
+def test_augment_splices_when_coverage_requested():
+    args = ["-k", "smoke"]
+    active, deferred = _ctl(coverage=True).augment_args(args, dry_run=False)
+    assert args == ["-k", "smoke", "--cov", "--cov-report=term-missing"]
+    assert active is True and deferred is False
+
+
+def test_augment_auto_enables_for_gate_only():
+    args = []
+    active, deferred = _ctl(cov_fail_under=0.8).augment_args(args, dry_run=False)
+    assert args == ["--cov", "--cov-report=term-missing"]
+    assert active is True and deferred is False
+
+
+def test_augment_noop_when_not_requested():
+    args = ["-q"]
+    active, deferred = _ctl().augment_args(args, dry_run=False)
+    assert args == ["-q"]
+    assert active is False and deferred is False
+
+
+def test_augment_skips_dry_run():
+    args = []
+    active, deferred = _ctl(coverage=True).augment_args(args, dry_run=True)
+    assert args == []
+    assert active is False and deferred is False
+
+
+def test_augment_defers_to_user_cov():
+    args = ["--cov=pkg"]
+    active, deferred = _ctl(coverage=True).augment_args(args, dry_run=False)
+    assert args == ["--cov=pkg"]  # nothing spliced
+    assert active is True and deferred is True
+
+
+def test_augment_defers_to_no_cov_opt_out():
+    args = ["--no-cov"]
+    active, deferred = _ctl(coverage=True).augment_args(args, dry_run=False)
+    assert args == ["--no-cov"]
+    assert active is False and deferred is True
+
+
+# -- evaluate_gate -----------------------------------------------------------
+
+
+def test_gate_passes_above_and_at_boundary():
+    _ctl(cov_fail_under=0.80).evaluate_gate(0.85)  # above -> no raise
+    _ctl(cov_fail_under=0.80).evaluate_gate(0.80)  # equal -> no raise
+
+
+def test_gate_fails_below():
+    with pytest.raises(CoverageThresholdError) as exc:
+        _ctl(cov_fail_under=0.80).evaluate_gate(0.79)
+    assert exc.value.coverage == 0.79
+    assert exc.value.threshold == 0.80
+
+
+def test_gate_fail_closed_on_unmeasurable():
+    with pytest.raises(CoverageThresholdError) as exc:
+        _ctl(cov_fail_under=0.80).evaluate_gate(None)
+    assert exc.value.coverage is None
+    assert exc.value.threshold == 0.80
+
+
+def test_coverage_threshold_error_message_and_base():
+    # The error is catchable as the package base, and its message is actionable
+    # (it reaches the Airflow task log, so the wording is part of the contract).
+    below = CoverageThresholdError(0.5, 0.8)
+    assert isinstance(below, AirflowPytestError)
+    assert below.coverage == 0.5 and below.threshold == 0.8
+    assert "50.00%" in str(below) and "80.00%" in str(below) and "below" in str(below)
+
+    unmeasured = CoverageThresholdError(None, 0.8)
+    assert unmeasured.coverage is None
+    assert "could not be" in str(unmeasured)
+
+
+# -- extract (the TOTAL-row parser) ------------------------------------------
+
+
+def test_extract_handles_formats():
+    extract = CoverageController.extract
+    # plain row, --cov-branch columns, configured precision, 0/100 bounds, none.
+    assert extract("TOTAL          20      3    85%\n") == 0.85
+    assert extract("TOTAL          20      3     8      2    88%\n") == 0.88
+    assert extract("TOTAL          20      3    85.25%\n") == 0.8525
+    assert extract("TOTAL          20     20     0%\n") == 0.0  # 0.0, not None
+    assert extract("TOTAL          20      0   100%\n") == 1.0
+    assert extract("nothing to see\n") is None
+    assert extract("") is None
+
+
+def test_extract_edge_cases():
+    extract = CoverageController.extract
+    assert extract("TOTALS booked 100% done\n") is None  # word boundary
+    assert extract("TOTAL  20  19  5%\n") == 0.05  # single digit
+    assert extract("TOTAL\t20\t3\t85%\n") == 0.85  # tabs
+    assert extract("TOTAL  20  3  85%\r\n") == 0.85  # CRLF
+    assert extract("Name  Stmts\nTOTAL  20  3  85%") == 0.85  # no trailing newline
+
+
+def test_extract_takes_last_total_row():
+    # A test that prints its own "TOTAL ... NN%" earlier must not shadow the real
+    # coverage table, which pytest-cov prints last in the run summary.
+    stdout = (
+        "test_report.py::test_summary PASSED\n"
+        "TOTAL revenue 42%  <- printed by the test itself\n"
+        "==================== tests coverage ====================\n"
+        "TOTAL          20      3    85%\n"
+    )
+    assert CoverageController.extract(stdout) == 0.85
+
+
+def test_extract_no_catastrophic_backtracking():
+    # Security/load guard: a ~1.8 MiB "TOTAL"-prefixed line with NO trailing '%'
+    # is the worst case for the lazy ``.*?``. A vulnerable (ReDoS-prone) pattern
+    # would hang here; the anchored lazy match is linear, so it returns fast.
+    adversarial = "TOTAL " + "1.2" * 300_000  # ~1.8 MiB, no '%'
+    start = time.perf_counter()
+    assert CoverageController.extract(adversarial) is None
+    assert time.perf_counter() - start < 5.0  # generous; real time is ~0.1s
+
+
+def test_extract_huge_percent_does_not_crash():
+    # A malformed >100% row (only possible from hostile/buggy output) must yield a
+    # number, never raise -- ``float(...) / 100`` cannot fail on the regex capture.
+    assert CoverageController.extract("TOTAL 1 1 999999%\n") == 9999.99

--- a/tests/operator/test_coverage_controller.py
+++ b/tests/operator/test_coverage_controller.py
@@ -116,6 +116,27 @@ def test_gate_fail_closed_on_unmeasurable():
     assert exc.value.threshold == 0.80
 
 
+def test_looks_like_missing_plugin():
+    # True only when pytest actually rejected --cov (pytest-cov absent).
+    detect = CoverageController.looks_like_missing_plugin
+    assert detect("error: unrecognized arguments: --cov --cov-report=term-missing")
+    assert detect("... unrecognized arguments: --cov=pkg ...")
+    # Not a missing-plugin signal:
+    assert not detect(None)
+    assert not detect("")
+    assert not detect("ModuleNotFoundError: No module named 'app'")  # collection err
+    assert not detect("unrecognized arguments: --json-report")  # different flag
+    assert not detect("--cov mentioned but no 'unrecognized' phrase")
+
+
+def test_evaluate_gate_noop_without_gate():
+    # No gate configured -> evaluate_gate is a safe no-op: no raise, and no
+    # reliance on ``assert`` (which python -O would strip). Guards a direct/misuse
+    # call from turning into an obscure ``x < None`` TypeError.
+    _ctl(coverage=True, cov_fail_under=None).evaluate_gate(0.1)  # no raise
+    _ctl().evaluate_gate(None)  # no raise even with coverage None
+
+
 def test_coverage_threshold_error_message_and_base():
     # The error is catchable as the package base, and its message is actionable
     # (it reaches the Airflow task log, so the wording is part of the contract).

--- a/tests/operator/test_op_coverage.py
+++ b/tests/operator/test_op_coverage.py
@@ -1,0 +1,913 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""coverage: splice pytest-cov flags into the first full run, defer to explicit
+user --cov / --no-cov, and stay out of dry_run and in-process reruns. Shared
+fakes in _op_helpers."""
+
+from __future__ import annotations
+
+import pytest
+from _op_helpers import (
+    FakeParser,
+    FakeRunner,
+    FakeStore,
+    SequenceParser,
+    _ctx,
+    _key,
+    _res,
+    _result,
+)
+
+from airflow_pytest_operator.exceptions import CoverageThresholdError, TestsFailedError
+from airflow_pytest_operator.models import RunArtifacts
+from airflow_pytest_operator.operators import PytestOperator
+
+
+def test_coverage_default_false():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[coverage:default] coverage={op.coverage!r}")
+    assert op.coverage is False
+
+
+def test_coverage_false_adds_nothing():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:off] forwarded = {forwarded!r}")
+    assert forwarded == ["-k", "smoke"]
+    assert "--cov" not in forwarded
+    assert not any(a.startswith("--cov") for a in forwarded)
+
+
+def test_coverage_true_splices_cov_and_term_missing():
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["-k", "smoke"],
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:on] forwarded = {forwarded!r}")
+    assert forwarded == ["-k", "smoke", "--cov", "--cov-report=term-missing"]
+
+
+def test_coverage_skipped_in_dry_run():
+    # dry-run runs no test bodies, so coverage measurement is meaningless;
+    # --collect-only is still appended, --cov is not.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        dry_run=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=0)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:dry_run] forwarded = {forwarded!r}")
+    assert "--collect-only" in forwarded
+    assert "--cov" not in forwarded
+    assert not any(a.startswith("--cov") for a in forwarded)
+
+
+def test_coverage_defers_to_explicit_cov_in_pytest_args():
+    # User already drives --cov with their own source -> operator must not add
+    # a second --cov / --cov-report so their explicit measurement is preserved.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--cov=mypkg", "--cov-report=html"],
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:defer_cov_equals] forwarded = {forwarded!r}")
+    assert forwarded == ["--cov=mypkg", "--cov-report=html"]
+    assert forwarded.count("--cov") == 0  # the bare --cov was not appended
+
+
+def test_coverage_defers_to_bare_cov_in_pytest_args():
+    # The bare ``--cov`` spelling is detected too, not only the equals form.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--cov"],
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:defer_cov_bare] forwarded = {forwarded!r}")
+    assert forwarded == ["--cov"]
+    assert "--cov-report=term-missing" not in forwarded
+
+
+def test_coverage_defers_to_no_cov_opt_out():
+    # --no-cov is the explicit pytest-cov opt-out (overrides any earlier --cov,
+    # e.g. one set by addopts). If the user has it, coverage=True must defer:
+    # forcing --cov on top would silently undo their opt-out.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--no-cov"],
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:defer_no_cov] forwarded = {forwarded!r}")
+    assert forwarded == ["--no-cov"]
+    assert "--cov" not in forwarded[1:]
+
+
+def test_coverage_not_applied_to_in_process_reruns():
+    # The full run is measured; the in-process rerun_failed round re-runs a
+    # narrow subset and would distort the measurement -- it uses
+    # list(self.pytest_args), not effective_args, so --cov is never re-added.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),  # first full run: 1 failure
+            _res([], passed=1),  # rerun: recovered
+        ]
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        rerun_failed=1,
+        runner=runner,
+        parser=parser,
+    )
+    op.execute(_ctx())
+    first = runner.calls[0]["pytest_args"]
+    rerun = runner.calls[1]["pytest_args"]
+    print(f"[coverage:reruns] first={first!r} rerun={rerun!r}")
+    assert len(runner.calls) == 2
+    assert first == ["--cov", "--cov-report=term-missing"]
+    assert "--cov" not in rerun  # rerun stays uncovered
+    assert not any(a.startswith("--cov") for a in rerun)
+
+
+def test_coverage_does_not_mutate_user_pytest_args():
+    # Like dry-run's --collect-only injection: the user's list is never mutated,
+    # and a retry (second execute) appends exactly one --cov, not two.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    user_args = ["-k", "smoke"]
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=user_args,
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    op.execute(_ctx())  # retry simulation
+    print(f"[coverage:no_mutation] op.pytest_args = {op.pytest_args!r}")
+    assert op.pytest_args == ["-k", "smoke"]
+    for call in runner.calls:
+        assert call["pytest_args"].count("--cov") == 1
+        assert call["pytest_args"].count("--cov-report=term-missing") == 1
+
+
+def test_coverage_is_applied_to_failed_only_retry():
+    # Unlike the in-process rerun_failed rounds (which run uncovered), a
+    # failed_only Airflow retry runs the narrowed set through effective_args,
+    # so --cov DOES apply -- the narrowed set may still be a large slice users
+    # want measured.
+    key = _key()
+    store = FakeStore({key: ["tests.test_x::test_a"]})
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        test_retry_strategy="failed_only",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_res([], passed=1)),
+        store=store,
+    )
+    op.execute(_ctx(try_number=2, dag_id="d", task_id="t", run_id="r"))
+    forwarded = runner.calls[0]["pytest_args"]
+    target = runner.calls[0]["test_path"]
+    print(f"[coverage:failed_only] target={target!r} forwarded={forwarded!r}")
+    assert target == ["tests/test_x.py::test_a"]  # narrowed to the prior failure
+    assert forwarded == ["--cov", "--cov-report=term-missing"]
+
+
+def test_coverage_combines_with_parallel():
+    # coverage / parallel are independent: --cov is spliced before -n, and both
+    # apply to the first full run.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        parallel=2,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:with_parallel] forwarded = {forwarded!r}")
+    assert "--cov" in forwarded
+    assert "--cov-report=term-missing" in forwarded
+    assert "-n" in forwarded
+    assert forwarded[forwarded.index("--cov") + 1] == "--cov-report=term-missing"
+
+
+def test_coverage_logs_warning_when_user_owns_cov():
+    # The deferral path emits a one-line warning so users can see why their
+    # coverage=True did not take effect (mirrors the parallel/dist warnings).
+    from unittest import mock
+
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--cov=mypkg"],
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with mock.patch.object(op.log, "warning") as warning:
+        op.execute(_ctx())
+
+    logged = " ".join(str(c) for c in warning.call_args_list)
+    print(f"[coverage:defer_warn] warnings = {logged!r}")
+    assert "coverage measurement" in logged
+    assert "--cov" in logged
+    assert "deferring" in logged
+
+
+# -- coverage value pushed to XCom ------------------------------------------
+#
+# The operator reads the overall % back from the run's stdout (the TOTAL row of
+# pytest-cov's terminal table) and puts the fraction under summary["coverage"].
+
+# A representative --cov-report=term-missing tail; TOTAL row at 85%.
+_COV_STDOUT = (
+    "Name        Stmts   Miss  Cover   Missing\n"
+    "-----------------------------------------\n"
+    "pkg/a.py       20      3    85%   10-12\n"
+    "-----------------------------------------\n"
+    "TOTAL          20      3    85%\n"
+)
+
+
+def test_coverage_fraction_pushed_to_xcom():
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:xcom] coverage = {out['coverage']!r}")
+    assert out["coverage"] == 0.85  # 85% TOTAL row -> 0.85 fraction
+
+
+def test_coverage_key_absent_when_disabled():
+    # coverage=False -> the XCom shape is unchanged (no 'coverage' key), even if
+    # the stdout happens to contain a coverage-looking table.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:xcom_absent] keys = {sorted(out)}")
+    assert "coverage" not in out
+
+
+def test_coverage_none_when_no_total_row():
+    # coverage=True but no TOTAL row in the output (e.g. --cov-report without a
+    # terminal report): the key is present and None, signalling "requested but
+    # unavailable" rather than a misleading 0.0.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout="no table here\n")
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:xcom_none] coverage = {out['coverage']!r}")
+    assert "coverage" in out
+    assert out["coverage"] is None
+
+
+def test_coverage_fraction_present_after_reruns():
+    # Coverage is measured on the first full run only; the rerun rounds run
+    # uncovered. The first run's fraction must survive into the final summary.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),  # first run: 1 failure
+            _res([], passed=1),  # rerun: recovered
+        ]
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        rerun_failed=1,
+        runner=runner,
+        parser=parser,
+    )
+    out = op.execute(_ctx())
+    print(
+        f"[coverage:xcom_reruns] coverage={out['coverage']!r} rounds={out.get('rerun_rounds')}"
+    )
+    assert out["coverage"] == 0.85
+    assert out["rerun_rounds"] == 1  # reruns happened, coverage still from run 1
+
+
+def test_coverage_fraction_pushed_on_failed_only_retry():
+    # The failed_only Airflow retry runs the narrowed set through effective_args
+    # (with --cov), so its coverage is surfaced too.
+    key = _key()
+    store = FakeStore({key: ["tests.test_x::test_a"]})
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        test_retry_strategy="failed_only",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_res([], passed=1)),
+        store=store,
+    )
+    out = op.execute(_ctx(try_number=2, dag_id="d", task_id="t", run_id="r"))
+    print(f"[coverage:xcom_failed_only] coverage = {out['coverage']!r}")
+    assert out["coverage"] == 0.85
+
+
+def test_coverage_key_absent_in_dry_run():
+    # dry-run never measures coverage (no --cov), so the key must be absent even
+    # with coverage=True and a coverage-looking stdout.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        dry_run=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=0)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:xcom_dry_run] keys = {sorted(out)}")
+    assert "coverage" not in out
+
+
+def test_coverage_surfaced_for_user_supplied_cov():
+    # The operator defers the splice to a user's explicit --cov, but still reads
+    # the fraction back from the terminal TOTAL row -- so a hand-driven --cov gets
+    # the XCom value for free (coverage param left at its default False).
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--cov=mypkg"],
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:xcom_user_cov] coverage = {out['coverage']!r}")
+    assert out["coverage"] == 0.85
+
+
+def test_coverage_key_absent_on_no_cov_opt_out():
+    # --no-cov is the explicit opt-out: no measurement, so no XCom key even though
+    # coverage=True (the operator defers to the opt-out).
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--no-cov"],
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:xcom_no_cov] keys = {sorted(out)}")
+    assert "coverage" not in out
+
+
+def test_coverage_surfaced_when_tests_fail_without_raising():
+    # The meaningful red-suite path: with fail_on_test_failure=False the task does
+    # NOT raise, so its summary (coverage included) is the XCom return value. A
+    # failing suite must still surface its coverage number.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=1, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        fail_on_test_failure=False,
+        runner=runner,
+        parser=FakeParser(_res(["tests.test_x::test_a"], passed=3)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:red_suite] success={out['success']} coverage={out['coverage']!r}")
+    assert out["success"] is False  # the suite was red ...
+    assert out["coverage"] == 0.85  # ... but coverage is still reported
+
+
+def test_coverage_combines_with_markers():
+    # coverage / markers are independent sugar: -m is spliced first, then --cov,
+    # and both reach the first full run in a stable order.
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        markers="smoke",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[coverage:with_markers] forwarded = {forwarded!r}")
+    assert forwarded == ["-m", "smoke", "--cov", "--cov-report=term-missing"]
+
+
+def test_coverage_non_bool_raises_type_error():
+    # A bare ``1`` would silently enable coverage if we accepted truthy ints;
+    # reject any non-bool so the contract is unambiguous.
+    with pytest.raises(TypeError, match="coverage"):
+        PytestOperator(task_id="t", test_path="tests/", coverage=1)  # type: ignore[arg-type]
+
+
+def test_coverage_none_raises_type_error():
+    with pytest.raises(TypeError, match="coverage"):
+        PytestOperator(task_id="t", test_path="tests/", coverage=None)  # type: ignore[arg-type]
+
+
+def test_coverage_string_raises_type_error():
+    with pytest.raises(TypeError, match="coverage"):
+        PytestOperator(task_id="t", test_path="tests/", coverage="yes")  # type: ignore[arg-type]
+
+
+# -- cov_fail_under: the native coverage gate (fraction in [0, 1]) -----------
+
+
+def test_cov_fail_under_default_none():
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[gate:default] cov_fail_under={op.cov_fail_under!r}")
+    assert op.cov_fail_under is None
+
+
+def test_cov_fail_under_auto_enables_coverage():
+    # Setting only cov_fail_under (coverage left False) still measures coverage
+    # AND surfaces the value -- the gate implies measurement.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.80,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[gate:auto_enable] forwarded={forwarded!r} out_cov={out.get('coverage')!r}")
+    assert "--cov" in forwarded and "--cov-report=term-missing" in forwarded
+    assert out["coverage"] == 0.85
+    assert out["coverage_passed"] is True
+
+
+def test_cov_fail_under_passes_at_threshold_boundary():
+    # Boundary: coverage exactly equal to the threshold passes (>=, not >).
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.85,  # == measured 0.85
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[gate:boundary] coverage_passed={out.get('coverage_passed')}")
+    assert out["coverage_passed"] is True
+
+
+def test_cov_fail_under_fails_below_threshold():
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.90,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with pytest.raises(CoverageThresholdError) as exc:
+        op.execute(_ctx())
+    print(
+        f"[gate:below] {exc.value} cov={exc.value.coverage} thr={exc.value.threshold}"
+    )
+    assert exc.value.coverage == 0.85
+    assert exc.value.threshold == 0.90
+
+
+def test_cov_fail_under_fail_closed_when_unmeasurable():
+    # Gate set, coverage active, but no TOTAL row -> fail-closed (coverage=None).
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout="no table here\n")
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.80,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with pytest.raises(CoverageThresholdError) as exc:
+        op.execute(_ctx())
+    print(f"[gate:fail_closed] {exc.value}")
+    assert exc.value.coverage is None
+    assert exc.value.threshold == 0.80
+
+
+def test_cov_fail_under_skipped_in_dry_run():
+    # dry-run measures nothing -> the gate is inert: no raise, no coverage keys.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.99,
+        dry_run=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=0)),
+    )
+    out = op.execute(_ctx())  # must NOT raise
+    print(f"[gate:dry_run] keys={sorted(out)}")
+    assert "coverage" not in out
+    assert "coverage_passed" not in out
+
+
+def test_cov_fail_under_deferred_to_no_cov_opt_out():
+    # An explicit --no-cov wins; the gate is inert (no raise) -- consistent with
+    # the operator's "defer to your explicit flag" rule.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--no-cov"],
+        cov_fail_under=0.99,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())  # must NOT raise
+    print(f"[gate:no_cov] keys={sorted(out)}")
+    assert "coverage_passed" not in out
+
+
+def test_cov_fail_under_test_failure_takes_precedence():
+    # A red suite raises TestsFailedError first, even when coverage is also below
+    # the gate -- the more fundamental failure is reported.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=1, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.99,
+        runner=runner,
+        parser=FakeParser(_res(["tests.test_x::test_a"], passed=1)),
+    )
+    with pytest.raises(TestsFailedError):
+        op.execute(_ctx())
+
+
+def test_cov_fail_under_gates_red_suite_when_failures_not_fatal():
+    # With fail_on_test_failure=False the suite does not raise on red, so the
+    # coverage gate becomes the active gate and can still fail the task.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=1, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.90,
+        fail_on_test_failure=False,
+        runner=runner,
+        parser=FakeParser(_res(["tests.test_x::test_a"], passed=1)),
+    )
+    with pytest.raises(CoverageThresholdError):
+        op.execute(_ctx())
+
+
+def test_coverage_passed_key_absent_without_gate():
+    # coverage=True without cov_fail_under measures but does NOT add coverage_passed.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    print(f"[gate:no_gate] keys={sorted(out)}")
+    assert "coverage_passed" not in out
+
+
+def test_cov_fail_under_bool_raises_type_error():
+    with pytest.raises(TypeError, match="cov_fail_under"):
+        PytestOperator(task_id="t", test_path="tests/", cov_fail_under=True)  # type: ignore[arg-type]
+
+
+def test_cov_fail_under_string_raises_type_error():
+    with pytest.raises(TypeError, match="cov_fail_under"):
+        PytestOperator(task_id="t", test_path="tests/", cov_fail_under="0.8")  # type: ignore[arg-type]
+
+
+def test_cov_fail_under_above_one_raises_value_error():
+    # The "I meant 80%" footgun: 80 is rejected with a pointed hint.
+    with pytest.raises(ValueError, match="0.8 for 80"):
+        PytestOperator(task_id="t", test_path="tests/", cov_fail_under=80)
+
+
+def test_cov_fail_under_negative_raises_value_error():
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        PytestOperator(task_id="t", test_path="tests/", cov_fail_under=-0.1)
+
+
+# -- extra edge coverage requested in review --------------------------------
+
+
+def test_coverage_real_pytest_cov_end_to_end(tmp_path):
+    # The unit tests above feed synthetic TOTAL rows; this one drives the WHOLE
+    # path through real pytest-cov so a future change to its terminal format
+    # (which would silently break the regex) is caught here. Skipped where
+    # pytest-cov is not installed (the bare-pytest CI job).
+    pytest.importorskip("pytest_cov")
+    from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+    (tmp_path / "mod.py").write_text(
+        "def add(a, b):\n    return a + b\n\n"
+        "def unused(x):\n    if x > 0:\n        return 'p'\n    return 'n'\n"
+    )
+    (tmp_path / "test_mod.py").write_text(
+        "from mod import add\ndef test_add():\n    assert add(1, 2) == 3\n"
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path=str(tmp_path / "test_mod.py"),
+        coverage=True,
+        pytest_args=["--cov=mod"],
+        runner=SubprocessPytestRunner(cwd=str(tmp_path)),
+    )
+    out = op.execute(_ctx())
+    print(f"[coverage:real_e2e] coverage = {out.get('coverage')!r}")
+    # mod.py: 6 statements, 3 covered -> 50% -> 0.5, parsed from REAL output.
+    assert out["coverage"] == 0.5
+
+
+def test_cov_fail_under_boundary_requires_full_coverage():
+    # Threshold extreme 1.0 (require 100%): 85% fails, exactly 100% passes.
+    below = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)  # 85%
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=1.0,
+        runner=below,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with pytest.raises(CoverageThresholdError) as exc:
+        op.execute(_ctx())
+    print(f"[gate:require_100] below -> {exc.value}")
+    assert exc.value.threshold == 1.0
+    assert exc.value.coverage == 0.85
+
+    full = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout="TOTAL  20  0  100%\n")
+    )
+    op2 = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=1.0,
+        runner=full,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op2.execute(_ctx())
+    print(f"[gate:require_100] full -> coverage_passed={out.get('coverage_passed')}")
+    assert out["coverage"] == 1.0
+    assert out["coverage_passed"] is True
+
+
+def test_cov_fail_under_with_user_supplied_cov():
+    # The gate evaluates the fraction surfaced from the user's OWN --cov (the
+    # defer path), and the operator does not add a second --cov.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)  # 85%
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        pytest_args=["--cov=mypkg"],
+        cov_fail_under=0.90,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with pytest.raises(CoverageThresholdError) as exc:
+        op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[gate:user_cov] forwarded={forwarded!r} cov={exc.value.coverage}")
+    assert exc.value.coverage == 0.85
+    assert forwarded == ["--cov=mypkg"]  # deferred -- no second --cov spliced
+
+
+def test_cov_fail_under_int_normalized_to_float():
+    # An int threshold (e.g. 1 == 100%) is stored as a float so the gate compares
+    # and formats uniformly -- this is why the controller is built from self.*.
+    op = PytestOperator(task_id="t", test_path="tests/", cov_fail_under=1)
+    print(f"[gate:normalize] cov_fail_under={op.cov_fail_under!r}")
+    assert op.cov_fail_under == 1.0
+    assert isinstance(op.cov_fail_under, float)
+
+
+def test_cov_fail_under_passes_with_reruns_using_first_run_coverage():
+    # Gate evaluates the FIRST run's coverage even after in-process reruns; here
+    # reruns recover the suite (green) and 0.85 >= 0.80 -> the gate passes.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=1, report_path="/x.xml", stdout=_COV_STDOUT)  # 85%
+    )
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),  # first run: 1 failure
+            _res([], passed=1),  # rerun: recovered
+        ]
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.80,
+        rerun_failed=1,
+        runner=runner,
+        parser=parser,
+    )
+    out = op.execute(_ctx())
+    print(
+        f"[gate:reruns_pass] {out.get('coverage')} passed={out.get('coverage_passed')} rounds={out.get('rerun_rounds')}"
+    )
+    assert out["coverage"] == 0.85
+    assert out["coverage_passed"] is True
+    assert out["rerun_rounds"] == 1  # reruns happened, gate still passed
+    assert out["success"] is True
+
+
+def test_cov_fail_under_fails_after_reruns_recover():
+    # Same shape, but the threshold is above the first-run coverage: even though
+    # reruns made the suite green, the gate fires on the first run's fraction.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=1, report_path="/x.xml", stdout=_COV_STDOUT)  # 85%
+    )
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),
+            _res([], passed=1),  # recovered
+        ]
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.90,
+        rerun_failed=1,
+        runner=runner,
+        parser=parser,
+    )
+    with pytest.raises(CoverageThresholdError) as exc:
+        op.execute(_ctx())
+    print(f"[gate:reruns_fail] {exc.value}")
+    assert exc.value.coverage == 0.85
+
+
+def test_coverage_gate_combines_with_parallel():
+    # The gate and xdist are independent: --cov and -n both reach the run, and
+    # the gate evaluates normally.
+    runner = FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml", stdout=_COV_STDOUT)
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.80,
+        parallel=2,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    out = op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[gate:with_parallel] forwarded={forwarded!r}")
+    assert "--cov" in forwarded and "-n" in forwarded
+    assert out["coverage_passed"] is True
+
+
+def test_cov_fail_under_real_runner_gate(tmp_path):
+    # End-to-end gate through real pytest-cov: a 50%-covered module fails an 80%
+    # gate and passes a 40% gate. Skipped where pytest-cov is not installed.
+    pytest.importorskip("pytest_cov")
+    from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+    (tmp_path / "mod.py").write_text(
+        "def add(a, b):\n    return a + b\n\n"
+        "def unused(x):\n    if x > 0:\n        return 'p'\n    return 'n'\n"
+    )
+    (tmp_path / "test_mod.py").write_text(
+        "from mod import add\ndef test_add():\n    assert add(1, 2) == 3\n"
+    )
+
+    fail = PytestOperator(
+        task_id="t",
+        test_path=str(tmp_path / "test_mod.py"),
+        cov_fail_under=0.80,
+        pytest_args=["--cov=mod"],
+        runner=SubprocessPytestRunner(cwd=str(tmp_path)),
+    )
+    with pytest.raises(CoverageThresholdError) as exc:
+        fail.execute(_ctx())
+    print(f"[gate:real_e2e] FAIL -> {exc.value}")
+    assert exc.value.coverage == 0.5
+
+    ok = PytestOperator(
+        task_id="t",
+        test_path=str(tmp_path / "test_mod.py"),
+        cov_fail_under=0.40,
+        pytest_args=["--cov=mod"],
+        runner=SubprocessPytestRunner(cwd=str(tmp_path)),
+    )
+    out = ok.execute(_ctx())
+    print(f"[gate:real_e2e] PASS -> {out.get('coverage')} {out.get('coverage_passed')}")
+    assert out["coverage"] == 0.5
+    assert out["coverage_passed"] is True

--- a/tests/operator/test_op_coverage.py
+++ b/tests/operator/test_op_coverage.py
@@ -31,7 +31,11 @@ from _op_helpers import (
     _result,
 )
 
-from airflow_pytest_operator.exceptions import CoverageThresholdError, TestsFailedError
+from airflow_pytest_operator.exceptions import (
+    CoverageThresholdError,
+    TestExecutionError,
+    TestsFailedError,
+)
 from airflow_pytest_operator.models import RunArtifacts
 from airflow_pytest_operator.operators import PytestOperator
 
@@ -788,6 +792,43 @@ def test_cov_fail_under_with_user_supplied_cov():
     assert forwarded == ["--cov=mypkg"]  # deferred -- no second --cov spliced
 
 
+def test_summary_keys_are_all_declared_in_run_summary():
+    # Contract guard: a run that populates the MOST keys (coverage + gate pass +
+    # reruns) must emit only keys declared in RunSummary. Catches a new summary
+    # key added to the operator but not to the RunSummary TypedDict.
+    from airflow_pytest_operator import RunSummary
+
+    declared = set(RunSummary.__required_keys__) | set(RunSummary.__optional_keys__)
+    runner = FakeRunner(
+        RunArtifacts(exit_code=1, report_path="/x.xml", stdout=_COV_STDOUT)  # 85%
+    )
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),  # first run: 1 failure
+            _res([], passed=1),  # rerun: recovered
+        ]
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        cov_fail_under=0.80,  # gate passes (0.85 >= 0.80) -> coverage_passed
+        rerun_failed=1,  # -> rerun_rounds / recovered / still_failing
+        runner=runner,
+        parser=parser,
+    )
+    out = op.execute(_ctx())
+    print(f"[contract] emitted keys = {sorted(out)}")
+    assert set(out) <= declared, set(out) - declared
+    # this scenario should populate every optional key:
+    assert {
+        "coverage",
+        "coverage_passed",
+        "rerun_rounds",
+        "recovered_node_ids",
+        "still_failing_node_ids",
+    } <= set(out)
+
+
 def test_cov_fail_under_int_normalized_to_float():
     # An int threshold (e.g. 1 == 100%) is stored as a float so the gate compares
     # and formats uniformly -- this is why the controller is built from self.*.
@@ -911,3 +952,52 @@ def test_cov_fail_under_real_runner_gate(tmp_path):
     print(f"[gate:real_e2e] PASS -> {out.get('coverage')} {out.get('coverage_passed')}")
     assert out["coverage"] == 0.5
     assert out["coverage_passed"] is True
+
+
+def test_coverage_missing_pytest_cov_gives_actionable_error():
+    # coverage active + pytest rejected --cov (pytest-cov absent) -> an actionable
+    # error naming the [coverage] extra, not the generic "no report" message.
+    runner = FakeRunner(
+        RunArtifacts(
+            exit_code=4,
+            report_path=None,
+            stderr="error: unrecognized arguments: --cov --cov-report=term-missing",
+        )
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        coverage=True,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with pytest.raises(TestExecutionError) as exc:
+        op.execute(_ctx())
+    msg = str(exc.value)
+    print(f"[coverage:missing_plugin] {msg[:90]!r}")
+    assert "pytest-cov is not installed" in msg
+    assert "airflow-pytest-operator[coverage]" in msg
+
+
+def test_no_report_without_coverage_keeps_generic_error():
+    # Without coverage active, a no-report run keeps the generic message even if
+    # stderr happens to mention --cov -- the hint is gated on measure_coverage.
+    runner = FakeRunner(
+        RunArtifacts(
+            exit_code=2,
+            report_path=None,
+            stderr="unrecognized arguments: --cov (coverage is off here)",
+        )
+    )
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",  # coverage defaults to False
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+    )
+    with pytest.raises(TestExecutionError) as exc:
+        op.execute(_ctx())
+    msg = str(exc.value)
+    print(f"[coverage:generic_no_report] {msg[:90]!r}")
+    assert "produced no report" in msg
+    assert "airflow-pytest-operator[coverage]" not in msg

--- a/tests/operator/test_validation.py
+++ b/tests/operator/test_validation.py
@@ -1,0 +1,205 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Direct unit tests for the extracted constructor validators (_validation.py).
+
+These pin each function's contract in isolation; the operator's feature suites
+(test_op_*.py) also exercise them through PytestOperator.__init__. Convention:
+wrong type -> TypeError, valid type / wrong value -> ValueError.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _op_helpers import FakeStore
+
+from airflow_pytest_operator.operators._validation import (
+    validate_cov_fail_under,
+    validate_coverage,
+    validate_env,
+    validate_markers_keyword,
+    validate_parallel_dist,
+    validate_rerun_failed,
+    validate_store,
+    validate_test_retry_strategy,
+)
+
+# -- test_retry_strategy -----------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["all", "failed_only"])
+def test_retry_strategy_valid(value):
+    validate_test_retry_strategy(value)  # no raise
+
+
+def test_retry_strategy_invalid():
+    with pytest.raises(ValueError, match="test_retry_strategy"):
+        validate_test_retry_strategy("nope")
+
+
+# -- markers / keyword -------------------------------------------------------
+
+
+def test_markers_keyword_valid():
+    validate_markers_keyword(None, None)
+    validate_markers_keyword("smoke and not slow", "login or logout")
+
+
+@pytest.mark.parametrize("markers,keyword", [(123, None), (None, ["k"])])
+def test_markers_keyword_non_str(markers, keyword):
+    with pytest.raises(TypeError, match="markers|keyword"):
+        validate_markers_keyword(markers, keyword)
+
+
+# -- rerun_failed ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [0, 1, 5])
+def test_rerun_failed_valid(value):
+    validate_rerun_failed(value)
+
+
+def test_rerun_failed_bool_rejected():
+    with pytest.raises(TypeError, match="rerun_failed"):
+        validate_rerun_failed(True)
+
+
+def test_rerun_failed_non_int():
+    with pytest.raises(TypeError, match="rerun_failed"):
+        validate_rerun_failed(1.5)
+
+
+def test_rerun_failed_negative():
+    with pytest.raises(ValueError, match="non-negative"):
+        validate_rerun_failed(-1)
+
+
+# -- parallel / dist ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("parallel", [None, 1, 8, "auto", "logical"])
+def test_parallel_valid(parallel):
+    validate_parallel_dist(parallel, None)
+
+
+def test_parallel_bool_rejected():
+    with pytest.raises(TypeError, match="parallel"):
+        validate_parallel_dist(True, None)
+
+
+def test_parallel_int_below_one():
+    with pytest.raises(ValueError, match="parallel must be >= 1"):
+        validate_parallel_dist(0, None)
+
+
+def test_parallel_bad_keyword():
+    with pytest.raises(ValueError, match="'auto', 'logical'"):
+        validate_parallel_dist("many", None)
+
+
+def test_parallel_bad_type():
+    with pytest.raises(TypeError, match="parallel must be an int"):
+        validate_parallel_dist(1.5, None)
+
+
+def test_dist_valid_with_parallel():
+    validate_parallel_dist(2, "loadscope")
+
+
+def test_dist_bad_mode():
+    with pytest.raises(ValueError, match="dist must be one of"):
+        validate_parallel_dist(2, "nope")
+
+
+def test_dist_requires_parallel():
+    with pytest.raises(ValueError, match="dist requires parallel"):
+        validate_parallel_dist(None, "load")
+
+
+# -- coverage ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_coverage_valid(value):
+    validate_coverage(value)
+
+
+def test_coverage_non_bool():
+    with pytest.raises(TypeError, match="coverage must be a bool"):
+        validate_coverage(1)
+
+
+# -- cov_fail_under ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, 0.0, 0.5, 1.0, 1, 0])
+def test_cov_fail_under_valid(value):
+    validate_cov_fail_under(value)
+
+
+def test_cov_fail_under_bool_rejected():
+    with pytest.raises(TypeError, match="cov_fail_under"):
+        validate_cov_fail_under(True)
+
+
+def test_cov_fail_under_non_number():
+    with pytest.raises(TypeError, match="cov_fail_under"):
+        validate_cov_fail_under("0.8")
+
+
+def test_cov_fail_under_above_one():
+    with pytest.raises(ValueError, match="0.8 for 80"):
+        validate_cov_fail_under(80)
+
+
+def test_cov_fail_under_negative():
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        validate_cov_fail_under(-0.5)
+
+
+# -- store -------------------------------------------------------------------
+
+
+def test_store_valid():
+    validate_store(None)
+    validate_store(FakeStore())  # structurally implements read/write/delete
+
+
+def test_store_invalid():
+    with pytest.raises(TypeError, match="LastFailedStore"):
+        validate_store(object())
+
+
+# -- env ---------------------------------------------------------------------
+
+
+def test_env_valid():
+    validate_env(None)
+    validate_env({"A": "1", "B": "2"})
+
+
+def test_env_not_dict():
+    with pytest.raises(TypeError, match="env must be a dict"):
+        validate_env(["A=1"])
+
+
+def test_env_non_str_key():
+    with pytest.raises(TypeError, match="env keys must be str"):
+        validate_env({1: "x"})
+
+
+def test_env_non_str_value():
+    with pytest.raises(TypeError, match=r"env\["):
+        validate_env({"A": 1})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -410,3 +410,51 @@ def test_to_xcom_is_faster_than_asdict_on_large_suite(capsys):
         f"old asdict-based one ({old_total * 1000:.1f}ms) -- something "
         "regressed the optimisation."
     )
+
+
+def test_run_summary_typeddict_matches_to_xcom_contract():
+    # RunSummary documents the XCom contract. Its *required* keys must be exactly
+    # what to_xcom() always emits, and its *optional* keys must cover every key
+    # the operator adds later (coverage / rerun). This guards against a key being
+    # added in one place but not the type.
+    import airflow_pytest_operator as pkg
+    from airflow_pytest_operator import RunSummary
+
+    assert "RunSummary" in pkg.__all__  # exported from the package root
+
+    summary = TestRunResult(
+        total=2,
+        passed=1,
+        failed=1,
+        skipped=0,
+        errors=0,
+        duration=0.1,
+        exit_code=1,
+    ).to_xcom()
+    print(f"[run_summary] to_xcom keys = {sorted(summary)}")
+    assert set(summary) == set(RunSummary.__required_keys__)
+
+    operator_optional = {
+        "coverage",
+        "coverage_passed",
+        "rerun_rounds",
+        "recovered_node_ids",
+        "still_failing_node_ids",
+    }
+    assert operator_optional <= set(RunSummary.__optional_keys__)
+
+
+def test_to_xcom_returns_a_fresh_dict_each_call():
+    # execute() mutates the summary in place (adds coverage / rerun keys) without
+    # copying -- it relies on to_xcom() returning a NEW dict every call. Pin that:
+    # two calls are distinct objects and mutating one never leaks into the other.
+    r = TestRunResult(
+        total=1, passed=1, failed=0, skipped=0, errors=0, duration=0.1, exit_code=0
+    )
+    a = r.to_xcom()
+    b = r.to_xcom()
+    assert a is not b
+    a["coverage"] = 0.5
+    a["failed_node_ids"].append("x")
+    assert "coverage" not in b
+    assert b["failed_node_ids"] == []

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,30 @@
+"""Packaging invariants that keep the built distribution correct."""
+
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import airflow_pytest_operator
+
+
+def test_py_typed_marker_ships():
+    # PEP 561: without this marker downstream type-checkers (mypy/pyright) treat
+    # the whole package as untyped, so the public hints -- including the RunSummary
+    # TypedDict -- are invisible to users. It lives inside the package dir, so
+    # hatchling ships it in the wheel automatically.
+    marker = Path(airflow_pytest_operator.__file__).parent / "py.typed"
+    assert marker.is_file(), "py.typed marker is missing -- downstream typing breaks"


### PR DESCRIPTION
## [0.6.0] - 2026-07-01

### Added
- `PytestOperator(coverage=True)` -- measure coverage via ``pytest-cov`` on the
  first full run: splices ``--cov --cov-report=term-missing`` (table to the task
  log) and pushes the overall coverage **fraction** to XCom under the new
  ``coverage`` key -- a float in ``[0, 1]`` (e.g. ``0.85``), or ``None`` if no
  total was parsed; absent when coverage was not measured. First run only (not
  the ``rerun_failed`` rounds), skipped in ``dry_run``, and defers to an explicit
  ``--cov``/``--no-cov`` in ``pytest_args``. Configure source / formats /
  ``fail_under`` via ``[tool.coverage.*]``; needs the new ``[coverage]`` extra;
  defaults ``False``. See the README "Coverage" section.
- `PytestOperator(cov_fail_under=...)` -- a coverage **gate** (a fraction in
  ``[0, 1]``). Enables coverage measurement automatically and fails the task with
  the new ``CoverageThresholdError`` below the threshold; test failures take
  precedence, and it is fail-closed if coverage can't be measured. On pass the
  summary gains ``coverage_passed=True``. Exported from the package root.
- `RunSummary` -- a ``TypedDict`` for the XCom summary, exported from the package
  root, so ``xcom_pull`` results can be typed. ``execute`` / ``to_xcom`` now
  return it (a plain ``dict`` at runtime; type-only, no behaviour change).
- `py.typed` marker (PEP 561), so downstream type-checkers see the package's
  public hints -- including ``RunSummary``.
- `examples/coverage_gate.py` -- a DAG showing the native gate and the
  measure-then-read-``coverage``-from-XCom pattern.

### Changed
- A coverage run without ``pytest-cov`` installed now fails with an actionable
  error naming the ``[coverage]`` extra, instead of a generic "no report".
- Internal: extracted argument validation to ``operators/_validation.py`` and the
  pytest-cov concern to a ``CoverageController`` (``operators/_coverage.py``),
  keeping ``pytest_operator.py`` orchestration-only (~40% smaller). No API change.