### PR TITLE
harden pytest execution and add cache control for 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Change history
 
+- [0.6.1 — Disable the pytest cache (cache) + hardening of failed_only, runner targets, and XML parsing](#061---2026-07-20)
 - [0.6.0 — Coverage gate (cov_fail_under), typed XCom summary (RunSummary), and py.typed](#060---2026-07-01)
 - [0.5.3 — Live streaming of pytest output to the task log (stream_output)](#053---2026-06-24)
 - [0.5.2 — Sharding across workers (dynamic task mapping), parallel/dist execution, and test selection sugar (markers, keyword)](#052---2026-06-21)
@@ -22,6 +23,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [0.1.0 — Initial release: operator, runner, parser, core functionality](#010---2026-05-23)
 
 ## [Unreleased]
+
+## [0.6.1] - 2026-07-20
+
+### Added
+- `PytestOperator(cache=...)` -- when ``False``, splices ``-p no:cacheprovider``
+  so pytest never reads or writes ``.pytest_cache``. For ephemeral, read-only, or
+  containerised runs and for shards sharing one rootdir. Applied to **every**
+  invocation (first run, each ``rerun_failed`` round, ``dry_run``), unlike the
+  first-run-only splices; defers to an explicit ``-p no:cacheprovider``. Defaults
+  ``True`` -- pytest's behaviour, unchanged. See the README.
+- A warning when ``cache=False`` meets a flag the cacheprovider owns (``--lf``,
+  ``--ff``, ``--nf``, ``--sw``, ``--cache-clear``, ...): disabling the plugin
+  also **unregisters** those options, so pytest would abort with "unrecognized
+  arguments" and write no report.
+
+### Security
+- **`failed_only`: the stored set is now validated.** Anyone able to write the
+  Airflow Variable could store ``["-p", "evil_module"]``; those strings became
+  pytest *positional arguments*, and a leading ``-`` makes pytest read one as an
+  option -- loading an arbitrary plugin, i.e. code execution on the worker.
+  Entries are held to the shape the feature stores (must contain ``::``, must not
+  start with ``-``); rejected ones are logged and the run falls back to the full
+  suite.
+- **Runner: option-like positional targets are refused.** Defence in depth at the
+  last gate before the child process: any target with a leading ``-`` is dropped
+  and logged, whatever the caller. If none remain, the run fails closed.
+- **JUnit parser: no more silent XML-hardening downgrade.** The defusedxml import
+  guard caught ``Exception`` (a broken install silently fell back to the
+  unhardened stdlib parser) and never logged the fallback. It now catches
+  ``ImportError`` only and warns once that entity-expansion protection is off,
+  naming the ``[secure-xml]`` extra.
 
 ## [0.6.0] - 2026-07-01
 
@@ -693,7 +725,8 @@ Initial release.
 - Packaged as an Airflow provider (`get_provider_info` entry point), Apache-2.0
   licensed.
 
-[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/IKrysanov/airflow-pytest-operator/compare/v0.5.1...v0.5.2

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Works on **Airflow 2.x and 3.x** — all version-specific imports are isolated i
 - [Selecting tests (markers / keyword)](#selecting-tests-markers--keyword)
 - [Parallel execution (parallel / dist)](#parallel-execution-parallel--dist)
 - [Coverage (coverage)](#coverage-coverage)
+- [Disabling the pytest cache (cache)](#disabling-the-pytest-cache-cache)
 - [Sharding across workers (dynamic task mapping)](#sharding-across-workers-dynamic-task-mapping)
 - [Report location & cleanup](#report-location--cleanup)
 - [Cancellation and timeouts](#cancellation-and-timeouts)
@@ -341,6 +342,7 @@ The parameters specific to `PytestOperator` are:
 | `rerun_failed` | `0` | **In-process** re-runs of only the failed tests, within one task. `N>0` runs the full suite then re-runs the still-failing tests up to `N` more times — no cache, no Airflow retry, robust on any executor. See [Retry strategy](#retry-strategy-failed-only-reruns). |
 | `parallel` | `None` | Run the suite in parallel on the worker via `pytest-xdist` (`-n`). An int is the worker count; `"auto"`/`"logical"` map to xdist's CPU/logical-core counts. Applied to the first full run only (in-process `rerun_failed` rounds stay serial); ignored in `dry_run`; defers to an explicit `-n` in `pytest_args`. Needs the `[xdist]` extra on the worker. See [Parallel execution](#parallel-execution-parallel--dist). |
 | `dist` | `None` | `pytest-xdist` scheduler mode (`--dist`): `"load"` (default behaviour, spread individual tests), `"loadscope"`/`"loadfile"`/`"loadgroup"` (pin a module-or-class/file/`xdist_group` to one worker), `"worksteal"`, `"each"`, `"no"`. Requires `parallel` to be set. See [Parallel execution](#parallel-execution-parallel--dist). |
+| `cache` | `True` | When `False`, disable pytest's cacheprovider (`-p no:cacheprovider`) so pytest never reads or writes `.pytest_cache`. For ephemeral, read-only, or containerised runs and for shards sharing one rootdir. Applied to **every** invocation (first run, each `rerun_failed` round, `dry_run`); defers to an explicit `-p no:cacheprovider`. See [Disabling the pytest cache](#disabling-the-pytest-cache-cache). |
 | `coverage` | `False` | Measure coverage via `pytest-cov` on the first full run and push the overall fraction to XCom under the `coverage` key. Needs the `[coverage]` extra on the worker. See [Coverage](#coverage-coverage). |
 | `cov_fail_under` | `None` | Coverage **gate**: a fraction in `[0, 1]` (e.g. `0.80`). Enables coverage automatically and fails the task with `CoverageThresholdError` when below the threshold (test failures take precedence; fail-closed if unmeasurable). See [Coverage](#coverage-coverage). |
 | `do_xcom_push` | `True` | Airflow's standard flag. When on, the summary dict is pushed to XCom under the `return_value` key. Set `False` to disable all XCom output. Read it downstream with `xcom_pull(task_ids="<task>")`. |
@@ -498,6 +500,27 @@ This enables coverage measurement automatically (no need to also pass `coverage=
 
 > **What it measures.** `coverage.py` instruments the Python that runs **in the pytest worker process** — your code under `source`/`--cov`. For a **system/integration test that calls an external service** (REST, gRPC, a DB), it counts only the *local* client code, never the remote system's code (a different process/host). Such a test reports **low coverage of your package** by design — that is expected, not a regression. Point `[tool.coverage.run] source` at unit-testable packages, and don't hold a system-test task to the same threshold as a unit-test task. (To cover a remote Python service you must run coverage inside *that* process — see [subprocess measurement](https://coverage.readthedocs.io/en/latest/subprocess.html).)
 
+## Disabling the pytest cache (`cache`)
+
+pytest writes a `.pytest_cache/` directory in its rootdir, holding the `--lf`/`--ff`/`--nf` bookkeeping, `--stepwise` state, and whatever third-party plugins stash via `config.cache`. Set `cache=False` to turn that off entirely:
+
+```python
+PytestOperator(task_id="tests", test_path="tests/", cache=False)
+```
+
+The operator **never relies on that cache itself** — `rerun_failed` re-runs failures from in-process node-ids, and `test_retry_strategy="failed_only"` carries them in an Airflow Variable. So switching it off costs you nothing the operator provides, and buys you:
+
+- **Read-only or ephemeral filesystems.** In a container or K8s pod the code is often mounted read-only, or the working dir is thrown away. pytest attempting to write `.pytest_cache` there produces warnings, errors, or a file in an unexpected place. `cache=False` removes the write attempt altogether.
+- **Concurrent shards on one rootdir.** With [sharding](#sharding-across-workers-dynamic-task-mapping) (or several DAGs pointed at a shared checkout/NFS mount), multiple pytest processes run against the same rootdir and race on the same cache files. Nothing here needs that state, so removing it removes the race.
+- **Deterministic, stateless runs.** On a warm worker or reused container, a leftover `.pytest_cache` from a previous run can subtly change the behaviour of cache-reading plugins. Disabling it guarantees every task starts from the same clean state.
+- **No artifact pollution.** Nothing left behind in mounted volumes, checkouts, or image layers to clean up later.
+
+**Rules.** Unlike `markers`/`coverage`/`parallel` — which apply to the first full run only — `cache=False` is applied to **every** pytest invocation: the first run, each `rerun_failed` round, and `dry_run` collection. The reasons above hold equally for all of them. It defers to an explicit `-p no:cacheprovider` already in `pytest_args` (both the two-token and concatenated `-pno:cacheprovider` spellings).
+
+> ⚠️ **It also unregisters the cache-backed options.** Disabling the provider doesn't just stop the writes — pytest's `--lf`, `--last-failed`, `--ff`, `--nf`, `--sw`, `--stepwise`, `--cache-show`, and `--cache-clear` are *registered by* that plugin. With `cache=False` pytest rejects them outright (`error: unrecognized arguments: --lf`), exits with a usage error, and writes **no report** — which would otherwise surface as an opaque "pytest produced no report". The operator detects the combination and logs an explicit warning naming the offending flag. Drop the flag, or keep `cache=True`.
+
+**Why the default is `True`.** Precisely because of the above: silently disabling the cache would break every user who passes `--lf` or `--stepwise` in `pytest_args`. It stays opt-in.
+
 ## Sharding across workers (dynamic task mapping)
 
 The **second axis**: split one suite *across* workers/pods, not just within one. The pattern — a `collect` task lists node-ids, they're split into N balanced groups, and one mapped `PytestOperator` runs per group:
@@ -654,11 +677,108 @@ How it works:
 
 **Safe by construction.** If the Variable backend is unavailable, or the Airflow ids can't be derived from the context, the retry simply runs the **full suite** rather than failing — you never silently skip tests. Ignored in `dry_run` mode (there is no "last failed" to narrow to). The default `test_retry_strategy="all"` keeps the original behaviour (full suite on every retry).
 
+**The stored set is treated as untrusted input.** Its entries become pytest *positional arguments*, and anyone with permission to edit Airflow Variables can write to it — so a value like `["-p", "some_module"]` would otherwise reach pytest as a flag and load an arbitrary plugin. Entries are therefore held to the shape this feature actually stores: a node-id contains `::` and never starts with `-`. Anything else is dropped and logged, and if nothing usable remains the attempt runs the full suite. The runner enforces the same rule independently, for any target from any source.
+
 > **Keep `fail_on_test_failure=True` (the default).** A retry only happens when a failing run actually *fails the task*, which it does only under `fail_on_test_failure=True`. With `fail_on_test_failure=False` the task always succeeds, Airflow never retries, and `failed_only` has nothing to narrow on — so the operator writes nothing forward (no orphaned Variable). If you want to inspect failures without failing the task, use the two-task `run-all → run-failed` pattern below instead.
 
 > **Tip.** Want a different backing store (e.g. a custom KV store, or to scope the key differently)? Inject one: `PytestOperator(..., store=MyStore())`. Any object implementing the `LastFailedStore` protocol — `read(key) -> list[str]`, `write(key, ids)`, `delete(key)` — works (structural typing, so it type-checks under mypy without subclassing); the default is `VariableLastFailedStore`.
 
 For absorbing flaky failures **without** an Airflow retry at all, prefer `rerun_failed` above (in-process, no metadata writes). For splitting the work across two explicit tasks, see the pattern below.
+
+### Optional: housekeeping DAG for orphaned Variables
+
+You almost certainly don't need this. Consume-on-read means a crash *during* a run leaves nothing behind, and because the key includes `run_id`, a leftover Variable can never be read by a different DAG run — so an orphan **cannot cause wrong test selection**, it is only a dead row in the Variables table. A few edge cases can still strand one:
+
+- the DAG run is deleted, or the task is manually marked success, so the expected retry never happens (clearing the task does *not* strand one — it reuses the same `run_id`, so the re-run consumes it);
+- `max_tries` is lowered between attempts, or `try_number`/`max_tries` can't be read from the context — the operator then assumes "more retries may come", writes forward, and logs a warning.
+
+If you run at a scale where those add up, sweep them. The key derivation is deterministic and public, so the sweep **recomputes** the keys a live DAG run could still consume and deletes everything else:
+
+```python
+"""Sweep orphaned failed_only Variables. Airflow 2.x (needs metadata-DB access)."""
+from types import SimpleNamespace
+
+import pendulum
+from airflow.decorators import dag, task
+from airflow.models import DagRun, TaskInstance, Variable
+from airflow.utils.session import provide_session
+from airflow.utils.state import DagRunState
+from sqlalchemy import select
+
+from airflow_pytest_operator.stores import last_failed_var_key
+
+PREFIX = "apo_last_failed__"
+CANDIDATES = "apo_sweep_candidates"  # deliberately outside PREFIX
+
+
+def _key_for(dag_id, task_id, run_id, map_index):
+    # last_failed_var_key only reads attributes off context["ti"].
+    ti = SimpleNamespace(
+        dag_id=dag_id, task_id=task_id, run_id=run_id, map_index=map_index
+    )
+    return last_failed_var_key({"ti": ti})
+
+
+@dag(
+    schedule="@daily",
+    start_date=pendulum.datetime(2026, 1, 1),
+    catchup=False,
+    tags=["housekeeping"],
+)
+def apo_failed_only_housekeeping():
+    @task
+    @provide_session
+    def sweep(session=None):
+        # 1. Keys a still-live DAG run could legitimately consume.
+        live = {
+            _key_for(*row)
+            for row in session.execute(
+                select(
+                    TaskInstance.dag_id,
+                    TaskInstance.task_id,
+                    TaskInstance.run_id,
+                    TaskInstance.map_index,
+                )
+                .join(
+                    DagRun,
+                    (DagRun.dag_id == TaskInstance.dag_id)
+                    & (DagRun.run_id == TaskInstance.run_id),
+                )
+                .where(
+                    DagRun.state.notin_([DagRunState.SUCCESS, DagRunState.FAILED])
+                )
+            ).all()
+        }
+
+        # 2. Everything the operator has left behind. Filtered in Python, not
+        #    with LIKE: "_" is a single-char wildcard in SQL and would over-match.
+        existing = {
+            k
+            for (k,) in session.execute(select(Variable.key)).all()
+            if k.startswith(PREFIX)
+        }
+        orphans = existing - live
+
+        # 3. Two-pass grace. A Variable written seconds ago by a failed attempt
+        #    whose retry is not scheduled yet is not an orphan -- delete only
+        #    what was ALREADY orphaned on the previous sweep.
+        previous = set(Variable.get(CANDIDATES, default_var=[], deserialize_json=True))
+        doomed = orphans & previous
+        for key in doomed:
+            Variable.delete(key)
+        Variable.set(CANDIDATES, sorted(orphans - previous), serialize_json=True)
+
+        print(f"existing={len(existing)} live={len(live)} deleted={len(doomed)}")
+
+    sweep()
+
+
+apo_failed_only_housekeeping()
+```
+
+**Airflow 3.** Workers have no direct metadata-DB access, so the query above won't run in a task. Either list variables and task instances through the REST API (`GET /api/v2/variables`, `GET /api/v2/dags/~/dagRuns/~/taskInstances`) and apply the same set logic, or run the sweep as an operator-side job outside the worker.
+
+**Worst case if you get it wrong:** deleting a Variable that a retry would have used just makes that retry run the **full suite**. You never skip tests — which is why the two-pass grace is a comfort, not a correctness requirement.
 
 ### Robust: run-all → run-failed (any executor)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ the latest release to receive security fixes.
 
 | Version | Status |
 |---------|--------|
-| 0.3.x   | ✅ Supported |
-| < 0.3   | ❌ Not supported — please upgrade |
+| 0.6.x   | ✅ Supported |
+| < 0.6   | ❌ Not supported — please upgrade |
 
 Once 1.0 is released this policy will be reviewed and tightened. For now,
 treat any pre-1.0 release older than the latest minor as end-of-life from a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "airflow-pytest-operator"
-version = "0.6.0"
+version = "0.6.1"
 description = "Run pytest suites as Airflow tasks, with structured results in XCom."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/airflow_pytest_operator/operators/_constants.py
+++ b/src/airflow_pytest_operator/operators/_constants.py
@@ -53,6 +53,31 @@ KEYWORD_FLAGS: tuple[str, ...] = ("-k",)
 # splices nothing.
 COV_FLAGS: tuple[str, ...] = ("--cov", "--no-cov")
 
+# The plugin-disable token ``cache=False`` splices as ``-p no:cacheprovider``.
+NO_CACHEPROVIDER = "no:cacheprovider"
+
+# Options registered BY the cacheprovider plugin. Disabling the plugin does not
+# merely stop it writing ``.pytest_cache`` -- it unregisters these options, so
+# pytest rejects any of them with "unrecognized arguments" (a usage error, exit
+# 4) and writes NO report, which the operator would surface as an opaque
+# TestExecutionError. We detect the combination and warn with the real cause.
+CACHE_DEPENDENT_FLAGS: tuple[str, ...] = (
+    "--lf",
+    "--last-failed",
+    "--lfnf",
+    "--last-failed-no-failures",
+    "--ff",
+    "--failed-first",
+    "--nf",
+    "--new-first",
+    "--cache-show",
+    "--cache-clear",
+    "--sw",
+    "--stepwise",
+    "--sw-skip",
+    "--stepwise-skip",
+)
+
 
 def has_flag(args: Sequence[str], names: tuple[str, ...]) -> bool:
     """True if ``args`` already contains any of ``names`` in any spelling.
@@ -74,3 +99,37 @@ def has_flag(args: Sequence[str], names: tuple[str, ...]) -> bool:
             ):
                 return True
     return False
+
+
+def disables_cacheprovider(args: Sequence[str]) -> bool:
+    """True if ``args`` already disable pytest's cacheprovider plugin.
+
+    Recognises both spellings pytest accepts -- the two-token
+    ``-p no:cacheprovider`` and the single-token ``-pno:cacheprovider`` -- and
+    mirrors pytest's own handling, which strips the plugin name (see
+    ``_pytest/config``: ``parg = parg.strip()``). Padded variants such as
+    ``-p " no:cacheprovider"`` therefore count as disabling, because they
+    genuinely do disable the plugin.
+
+    ``-p=no:cacheprovider`` is deliberately NOT recognised: pytest reads
+    ``=no:cacheprovider`` as the plugin *name* and dies importing it, so that
+    form never disables anything. Treating it as "already disabled" would make
+    the operator skip its own (correct) splice and hand the user a broken run.
+    """
+    for i, arg in enumerate(args):
+        if arg == "-p":
+            if i + 1 < len(args) and args[i + 1].strip() == NO_CACHEPROVIDER:
+                return True
+        elif arg.startswith("-p") and arg[2:].strip() == NO_CACHEPROVIDER:
+            return True
+    return False
+
+
+def cache_dependent_flags(args: Sequence[str]) -> list[str]:
+    """Cache-provider-owned flags present in ``args``, in the order given.
+
+    Used to warn when ``cache=False`` would unregister an option the user is
+    relying on -- pytest would abort with "unrecognized arguments" and write no
+    report, which is a confusing way to learn about the interaction.
+    """
+    return [name for name in CACHE_DEPENDENT_FLAGS if has_flag(args, (name,))]

--- a/src/airflow_pytest_operator/operators/_validation.py
+++ b/src/airflow_pytest_operator/operators/_validation.py
@@ -100,6 +100,18 @@ def validate_coverage(coverage: bool) -> None:
         )
 
 
+def validate_cache(cache: bool) -> None:
+    # cache is a bool toggle for pytest's cacheprovider plugin. Reject a
+    # non-bool (no truthy ints) so a stray ``cache=0`` does not silently
+    # disable the cache, matching the ``coverage`` convention above.
+    if not isinstance(cache, bool):
+        raise TypeError(
+            "cache must be a bool (True to leave pytest's cacheprovider "
+            "enabled, False to disable it with -p no:cacheprovider); "
+            f"got {type(cache).__name__}"
+        )
+
+
 def validate_cov_fail_under(cov_fail_under: float | None) -> None:
     # cov_fail_under: optional coverage gate, a fraction in [0, 1] compared
     # against the same value pushed to XCom under ``coverage``. Reject bool (a

--- a/src/airflow_pytest_operator/operators/pytest_operator.py
+++ b/src/airflow_pytest_operator/operators/pytest_operator.py
@@ -35,11 +35,15 @@ from ._constants import (
     KEYWORD_FLAGS,
     MARKER_FLAGS,
     MAX_STDERR_LEN,
+    NO_CACHEPROVIDER,
     NUMPROCESSES_FLAGS,
+    cache_dependent_flags,
+    disables_cacheprovider,
     has_flag,
 )
 from ._coverage import CoverageController
 from ._validation import (
+    validate_cache,
     validate_cov_fail_under,
     validate_coverage,
     validate_env,
@@ -92,6 +96,16 @@ class PytestOperator(BaseOperator):
     :param stream_output: when True (default), child stdout/stderr is logged
         line-by-line as it runs (unbuffered ``-u``); False logs one blob at the
         end. The full output is captured either way.
+    :param cache: when False, disable pytest's cacheprovider plugin by splicing
+        ``-p no:cacheprovider``, so pytest never reads or writes
+        ``.pytest_cache``. Useful for ephemeral / read-only / containerised runs
+        and for shards sharing one rootdir. Applied to **every** invocation (the
+        first run, each ``rerun_failed`` round, and ``dry_run`` collection);
+        defers to an explicit ``-p no:cacheprovider`` in ``pytest_args``. The
+        operator never relies on the pytest cache itself. Note that disabling it
+        also unregisters pytest's ``--lf``/``--ff``/``--nf``/``--sw`` family --
+        the operator warns if ``pytest_args`` uses one. Default True (pytest's
+        own behaviour, unchanged). See the README.
     :param coverage: when True, measure coverage via pytest-cov on the first full
         run and push the overall fraction to XCom under ``coverage`` (a float in
         ``[0, 1]``, or ``None``). Defers to a user ``--cov``/``--no-cov``, skipped
@@ -137,6 +151,7 @@ class PytestOperator(BaseOperator):
         parallel: int | str | None = None,
         dist: str | None = None,
         stream_output: bool = True,
+        cache: bool = True,
         coverage: bool = False,
         cov_fail_under: float | None = None,
         runner: PytestRunner | None = None,
@@ -151,6 +166,7 @@ class PytestOperator(BaseOperator):
         validate_markers_keyword(markers, keyword)
         validate_rerun_failed(rerun_failed)
         validate_parallel_dist(parallel, dist)
+        validate_cache(cache)
         validate_coverage(coverage)
         validate_cov_fail_under(cov_fail_under)
         validate_store(store)
@@ -171,6 +187,7 @@ class PytestOperator(BaseOperator):
         self.parallel = parallel
         self.dist = dist
         self.stream_output = stream_output
+        self.cache = cache
         self.coverage = coverage
         # Store as float so the gate comparison and message formatting are
         # uniform (an int like 1 or 0 is a valid fraction).
@@ -204,6 +221,21 @@ class PytestOperator(BaseOperator):
             arg in COLLECT_ONLY_ALIASES for arg in effective_args
         ):
             effective_args.append("--collect-only")
+
+        # cache=False: warn once, up front, if the user drives a flag that the
+        # cacheprovider owns -- pytest would abort with "unrecognized arguments"
+        # and write no report, surfacing as an opaque "produced no report".
+        if not self.cache:
+            conflicting = cache_dependent_flags(effective_args)
+            if conflicting:
+                self.log.warning(
+                    "cache=False disables pytest's cacheprovider, which also "
+                    "unregisters %s found in pytest_args. pytest will abort with "
+                    "'unrecognized arguments' and write no report. Drop the flag, "
+                    "or set cache=True.",
+                    ", ".join(conflicting),
+                )
+        self._augment_cache_args(effective_args)
 
         # markers / keyword: sugar for -m / -k on the first full run. Skipped if
         # empty; defers to the same flag already in pytest_args.
@@ -273,15 +305,32 @@ class PytestOperator(BaseOperator):
             if var_key:
                 prior = self._safe_store_read(var_key)
                 if prior:
-                    targets = node_id_to_pytest_args(prior)
                     self._safe_delete_store(var_key)  # consume immediately
-                    self.log.info(
-                        "test_retry_strategy='failed_only' -- narrowing to the %d "
-                        "test(s) that failed on the previous attempt, carried via "
-                        "Airflow Variable %r (now consumed).",
-                        len(targets),
-                        var_key,
-                    )
+                    # The Variable is untrusted: anyone able to write it controls
+                    # strings that become pytest positionals. Hold them to the
+                    # shape this feature actually stores -- a node-id always
+                    # contains "::" and never leads with "-" -- so neither a flag
+                    # nor its orphaned value can reach the command line.
+                    safe = [
+                        nid for nid in prior if "::" in nid and not nid.startswith("-")
+                    ]
+                    if len(safe) != len(prior):
+                        self.log.warning(
+                            "failed_only: ignoring %d stored entry/entries that are "
+                            "not valid node-ids (Variable %r may have been tampered "
+                            "with); a node-id contains '::' and cannot start with '-'.",
+                            len(prior) - len(safe),
+                            var_key,
+                        )
+                    if safe:
+                        targets = node_id_to_pytest_args(safe)
+                        self.log.info(
+                            "test_retry_strategy='failed_only' -- narrowing to the %d "
+                            "test(s) that failed on the previous attempt, carried via "
+                            "Airflow Variable %r (now consumed).",
+                            len(targets),
+                            var_key,
+                        )
 
         run_ok = False
         try:
@@ -315,6 +364,11 @@ class PytestOperator(BaseOperator):
             # In-process reruns of only the failed tests -- no pytest cache, no
             # Airflow retry. Skipped in dry-run and when nothing failed.
             if not self.dry_run and self.rerun_failed > 0 and still_failing:
+                # Reruns deliberately drop the first-run-only splices (markers,
+                # coverage, xdist) but must keep the cache toggle: the reason to
+                # disable it (read-only / ephemeral fs) holds for every round.
+                rerun_args = list(self.pytest_args)
+                self._augment_cache_args(rerun_args)
                 for _ in range(self.rerun_failed):
                     if not still_failing:
                         break
@@ -328,7 +382,7 @@ class PytestOperator(BaseOperator):
                         self.rerun_failed,
                         len(selectors),
                     )
-                    result, _ = self._run_and_parse(selectors, list(self.pytest_args))
+                    result, _ = self._run_and_parse(selectors, rerun_args)
                     still_failing = list(result.failed_node_ids)
 
             # Add the post-rerun view to the snapshot when reruns happened.
@@ -470,6 +524,23 @@ class PytestOperator(BaseOperator):
             self._coverage.extract(artifacts.stdout) if measure_coverage else None
         )
         return result, coverage
+
+    def _augment_cache_args(self, args: list[str]) -> None:
+        """Splice ``-p no:cacheprovider`` when ``cache=False`` -- in place.
+
+        Unlike the first-run-only splices (markers, coverage, xdist), this is
+        applied to **every** pytest invocation -- the first run, each
+        ``rerun_failed`` round, and dry-run collection -- because the reasons to
+        disable the cache (a read-only or ephemeral filesystem, concurrent
+        shards sharing a rootdir) hold for all of them equally.
+
+        A no-op when ``cache`` is True, and when ``pytest_args`` already
+        disables the provider (we defer rather than pass ``-p`` twice, matching
+        how the other sugar defers to explicit user flags).
+        """
+        if self.cache or disables_cacheprovider(args):
+            return
+        args.extend(["-p", NO_CACHEPROVIDER])
 
     def _emit_pytest_line(self, line: str, stream: str) -> None:
         """Live sink (``on_output``) routing each child line to the task log.

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -14,17 +14,41 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import xml.etree.ElementTree as ET
 
 try:  # prefer the hardened parser when present
     from defusedxml.ElementTree import parse as _xml_parse
-except Exception:  # pragma: no cover - fallback path
+
+    _HARDENED_XML = True
+except ImportError:  # pragma: no cover - fallback path
+    # Narrow on purpose: a defusedxml that is installed but broken must fail
+    # loudly rather than silently downgrade us to the unhardened parser.
     from xml.etree.ElementTree import parse as _xml_parse
+
+    _HARDENED_XML = False
 
 from ..exceptions import ReportParseError
 from ..models import CaseResult, ReportRequest, TestRunResult
 from .base import ResultParser
+
+_log = logging.getLogger(__name__)
+_UNHARDENED_WARNED = False
+
+
+def _warn_if_unhardened() -> None:
+    """Warn once when parsing without defusedxml."""
+    global _UNHARDENED_WARNED
+    if _HARDENED_XML or _UNHARDENED_WARNED:
+        return
+    _UNHARDENED_WARNED = True
+    _log.warning(
+        "Parsing JUnit XML with the stdlib parser: defusedxml is not installed, "
+        "so a malicious or corrupt report can exhaust worker memory via entity "
+        "expansion. Install the extra: "
+        "pip install 'airflow-pytest-operator[secure-xml]'."
+    )
 
 
 class JUnitResultParser(ResultParser):
@@ -65,6 +89,7 @@ class JUnitResultParser(ResultParser):
         if not report_path or not os.path.exists(report_path):
             raise ReportParseError(f"JUnit report not found: {report_path!r}")
 
+        _warn_if_unhardened()
         try:
             tree = _xml_parse(report_path)
         except (ET.ParseError, ValueError, OSError) as exc:

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import os
 import xml.etree.ElementTree as ET
+from functools import lru_cache
 
 try:  # prefer the hardened parser when present
     from defusedxml.ElementTree import parse as _xml_parse
@@ -34,15 +35,18 @@ from ..models import CaseResult, ReportRequest, TestRunResult
 from .base import ResultParser
 
 _log = logging.getLogger(__name__)
-_UNHARDENED_WARNED = False
 
 
+@lru_cache(maxsize=1)
 def _warn_if_unhardened() -> None:
-    """Warn once when parsing without defusedxml."""
-    global _UNHARDENED_WARNED
-    if _HARDENED_XML or _UNHARDENED_WARNED:
+    """Warn on the first parse when defusedxml is absent.
+
+    ``lru_cache`` gives the once-only semantics without module-level mutable
+    state (a per-parse warning would spam the task log on a sharded DAG). Tests
+    reset it via the standard ``_warn_if_unhardened.cache_clear()``.
+    """
+    if _HARDENED_XML:
         return
-    _UNHARDENED_WARNED = True
     _log.warning(
         "Parsing JUnit XML with the stdlib parser: defusedxml is not installed, "
         "so a malicious or corrupt report can exhaust worker memory via entity "

--- a/src/airflow_pytest_operator/runners/subprocess_runner.py
+++ b/src/airflow_pytest_operator/runners/subprocess_runner.py
@@ -498,11 +498,22 @@ class SubprocessPytestRunner(PytestRunner):
         # if forwarded, would make pytest collect from the cwd or error out.
         # We keep non-blank entries verbatim (paths may legitimately contain
         # spaces) and only discard the blanks.
-        test_paths: list[str] = [p for p in raw_paths if p.strip()]
-        if len(test_paths) != len(raw_paths):
+        non_blank: list[str] = [p for p in raw_paths if p.strip()]
+        if len(non_blank) != len(raw_paths):
             _log.warning(
                 "Ignoring %d empty/blank test target(s) in test_path.",
-                len(raw_paths) - len(test_paths),
+                len(raw_paths) - len(non_blank),
+            )
+        # pytest parses a positional with a leading "-" as an OPTION, so a target
+        # arriving from an untrusted source (the failed_only Variable) could
+        # inject flags -- "-p evil_module" loads arbitrary code. This is the last
+        # gate before the child process, so it refuses them whatever the caller.
+        test_paths: list[str] = [p for p in non_blank if not p.startswith("-")]
+        if len(test_paths) != len(non_blank):
+            _log.warning(
+                "Ignoring %d test target(s) that look like a pytest option "
+                "(leading '-'); a positional target must be a path or node-id.",
+                len(non_blank) - len(test_paths),
             )
         if not test_paths:
             raise TestExecutionError(

--- a/tests/operator/test_op_cache.py
+++ b/tests/operator/test_op_cache.py
@@ -19,7 +19,7 @@ every invocation. Shared fakes in _op_helpers."""
 
 from __future__ import annotations
 
-import logging
+from unittest import mock
 
 import pytest
 from _op_helpers import (
@@ -208,38 +208,46 @@ def test_composes_with_parallel_and_selectors():
 
 
 # -- the cache-dependent-flag warning --------------------------------------
+#
+# Airflow operator loggers do NOT always propagate to root (Airflow 3.2 routes
+# them through structlog), so pytest's ``caplog`` fixture misses them and the
+# assertions would silently pass against an empty string. We capture at the
+# source instead -- the pattern used by test_op_dry_run.
+
+
+def _warnings_of(op, ctx=None):
+    """Run ``op`` and return every ``log.warning`` call flattened into a string."""
+    with mock.patch.object(op.log, "warning") as warn:
+        op.execute(ctx if ctx is not None else _ctx())
+    return " ".join(str(c) for c in warn.call_args_list)
 
 
 @pytest.mark.parametrize(
     "flag", ["--lf", "--last-failed", "--ff", "--nf", "--sw", "--cache-clear"]
 )
-def test_warns_when_user_flag_needs_the_cacheprovider(flag, caplog):
+def test_warns_when_user_flag_needs_the_cacheprovider(flag):
     # Disabling the provider unregisters these options, so pytest aborts with
     # "unrecognized arguments" and writes NO report -- which the operator would
     # otherwise surface as an opaque "produced no report". Warn with the cause.
     op, runner = _op(pytest_args=[flag], cache=False)
-    with caplog.at_level(logging.WARNING):
-        op.execute(_ctx())
-    text = caplog.text
-    print(f"[cache:warn {flag}] warned={flag in text}")
-    assert "cacheprovider" in text
-    assert flag in text
+    logged = _warnings_of(op)
+    print(f"[cache:warn {flag}] logged={logged!r}")
+    assert "cacheprovider" in logged
+    assert flag in logged
 
 
-def test_no_warning_when_cache_left_enabled(caplog):
+def test_no_warning_when_cache_left_enabled():
     op, runner = _op(pytest_args=["--lf"], cache=True)
-    with caplog.at_level(logging.WARNING):
-        op.execute(_ctx())
-    print(f"[cache:no-warn] log={caplog.text!r}")
-    assert "cacheprovider" not in caplog.text
+    logged = _warnings_of(op)
+    print(f"[cache:no-warn] logged={logged!r}")
+    assert "cacheprovider" not in logged
 
 
-def test_no_warning_for_unrelated_flags(caplog):
+def test_no_warning_for_unrelated_flags():
     op, runner = _op(pytest_args=["-q", "-x"], cache=False)
-    with caplog.at_level(logging.WARNING):
-        op.execute(_ctx())
-    print(f"[cache:no-warn-unrelated] log={caplog.text!r}")
-    assert "unregisters" not in caplog.text
+    logged = _warnings_of(op)
+    print(f"[cache:no-warn-unrelated] logged={logged!r}")
+    assert "unregisters" not in logged
 
 
 # -- validation -------------------------------------------------------------

--- a/tests/operator/test_op_cache.py
+++ b/tests/operator/test_op_cache.py
@@ -1,0 +1,297 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""cache: disable pytest's cacheprovider (-p no:cacheprovider) for ephemeral,
+read-only, or sharded runs. Unlike the first-run-only splices, it applies to
+every invocation. Shared fakes in _op_helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _op_helpers import (
+    FakeParser,
+    FakeRunner,
+    SequenceParser,
+    _ctx,
+    _res,
+    _result,
+)
+
+from airflow_pytest_operator.models import RunArtifacts
+from airflow_pytest_operator.operators import PytestOperator
+from airflow_pytest_operator.operators._constants import (
+    cache_dependent_flags,
+    disables_cacheprovider,
+)
+
+DISABLE = ["-p", "no:cacheprovider"]
+
+
+def _op(**kwargs):
+    """Operator wired to fakes, returning (op, runner)."""
+    runner = kwargs.pop("runner", None) or FakeRunner(
+        RunArtifacts(exit_code=0, report_path="/x.xml")
+    )
+    parser = kwargs.pop("parser", None) or FakeParser(_result(passed=1))
+    op = PytestOperator(
+        task_id="t", test_path="tests/", runner=runner, parser=parser, **kwargs
+    )
+    return op, runner
+
+
+# -- defaults & basic splice ------------------------------------------------
+
+
+def test_cache_defaults_to_true():
+    # 0.6.1 is a patch release: pytest's own cache behaviour must be unchanged
+    # unless the user opts out explicitly.
+    op = PytestOperator(task_id="t", test_path="tests/")
+    print(f"[cache:default] cache={op.cache!r}")
+    assert op.cache is True
+
+
+def test_cache_true_splices_nothing():
+    op, runner = _op(pytest_args=["-q"])
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:true] forwarded={forwarded!r}")
+    assert forwarded == ["-q"]
+    assert "no:cacheprovider" not in forwarded
+
+
+def test_cache_false_appends_no_cacheprovider():
+    op, runner = _op(pytest_args=["-q"], cache=False)
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:false] forwarded={forwarded!r}")
+    assert forwarded == ["-q", *DISABLE]
+
+
+def test_cache_false_with_no_user_args():
+    op, runner = _op(cache=False)
+    op.execute(_ctx())
+    print(f"[cache:bare] forwarded={runner.calls[0]['pytest_args']!r}")
+    assert runner.calls[0]["pytest_args"] == DISABLE
+
+
+# -- deferring to explicit user args ----------------------------------------
+
+
+def test_defers_to_explicit_two_token_form():
+    # Already disabled by the user -> we must not pass -p twice.
+    op, runner = _op(pytest_args=["-p", "no:cacheprovider", "-q"], cache=False)
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:defer-2token] forwarded={forwarded!r}")
+    assert forwarded == ["-p", "no:cacheprovider", "-q"]
+    assert forwarded.count("no:cacheprovider") == 1
+
+
+def test_defers_to_concatenated_form():
+    # "-pno:cacheprovider" is a spelling pytest genuinely accepts.
+    op, runner = _op(pytest_args=["-pno:cacheprovider"], cache=False)
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:defer-concat] forwarded={forwarded!r}")
+    assert forwarded == ["-pno:cacheprovider"]
+
+
+def test_equals_form_is_not_treated_as_disabling():
+    # "-p=no:cacheprovider" does NOT disable anything: pytest reads
+    # "=no:cacheprovider" as the plugin NAME and dies importing it. Treating it
+    # as "already disabled" would skip our correct splice and ship a broken run.
+    op, runner = _op(pytest_args=["-p=no:cacheprovider"], cache=False)
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:equals-form] forwarded={forwarded!r}")
+    assert forwarded == ["-p=no:cacheprovider", *DISABLE]
+
+
+def test_unrelated_p_plugin_arg_is_not_mistaken_for_disabling():
+    # A different -p value must not suppress our splice.
+    op, runner = _op(pytest_args=["-p", "no:randomly"], cache=False)
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:other-plugin] forwarded={forwarded!r}")
+    assert forwarded == ["-p", "no:randomly", *DISABLE]
+
+
+def test_trailing_p_without_value_does_not_crash():
+    # A dangling "-p" (templating artefact) must not IndexError on lookahead.
+    op, runner = _op(pytest_args=["-p"], cache=False)
+    op.execute(_ctx())
+    print(f"[cache:dangling-p] forwarded={runner.calls[0]['pytest_args']!r}")
+    assert runner.calls[0]["pytest_args"] == ["-p", *DISABLE]
+
+
+# -- applies to EVERY invocation -------------------------------------------
+
+
+def test_applied_in_dry_run_collection():
+    op, runner = _op(cache=False, dry_run=True)
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:dry-run] forwarded={forwarded!r}")
+    assert "--collect-only" in forwarded
+    assert forwarded[-2:] == DISABLE
+
+
+def test_applied_to_every_rerun_round():
+    # The rerun rounds drop markers/coverage/xdist but must KEEP the cache
+    # toggle -- a read-only fs is read-only on round 3 too.
+    runner = FakeRunner(RunArtifacts(exit_code=1, report_path="/x.xml"))
+    parser = SequenceParser(
+        [
+            _res(["tests.test_x::test_a"], passed=2),
+            _res(["tests.test_x::test_a"], passed=0),
+            _res([], passed=1),
+        ]
+    )
+    op, runner = _op(
+        pytest_args=["-q"],
+        cache=False,
+        rerun_failed=2,
+        fail_on_test_failure=False,
+        runner=runner,
+        parser=parser,
+    )
+    op.execute(_ctx())
+    per_call = [c["pytest_args"] for c in runner.calls]
+    print(f"[cache:reruns] calls={len(per_call)} args={per_call!r}")
+    assert len(per_call) == 3  # first run + 2 rerun rounds
+    for args in per_call:
+        assert args[-2:] == DISABLE, args
+
+
+def test_rerun_rounds_keep_cache_enabled_when_cache_true():
+    runner = FakeRunner(RunArtifacts(exit_code=1, report_path="/x.xml"))
+    parser = SequenceParser(
+        [_res(["tests.test_x::test_a"], passed=2), _res([], passed=1)]
+    )
+    op, runner = _op(
+        cache=True,
+        rerun_failed=1,
+        fail_on_test_failure=False,
+        runner=runner,
+        parser=parser,
+    )
+    op.execute(_ctx())
+    per_call = [c["pytest_args"] for c in runner.calls]
+    print(f"[cache:reruns-enabled] args={per_call!r}")
+    assert all("no:cacheprovider" not in a for a in per_call)
+
+
+# -- composition with the other splices ------------------------------------
+
+
+def test_composes_with_parallel_and_selectors():
+    op, runner = _op(pytest_args=["-q"], cache=False, parallel=2, markers="smoke")
+    op.execute(_ctx())
+    forwarded = runner.calls[0]["pytest_args"]
+    print(f"[cache:compose] forwarded={forwarded!r}")
+    # Every splice lands, in order, and the cache toggle displaces none of them.
+    assert forwarded == ["-q", *DISABLE, "-m", "smoke", "-n", "2"]
+
+
+# -- the cache-dependent-flag warning --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag", ["--lf", "--last-failed", "--ff", "--nf", "--sw", "--cache-clear"]
+)
+def test_warns_when_user_flag_needs_the_cacheprovider(flag, caplog):
+    # Disabling the provider unregisters these options, so pytest aborts with
+    # "unrecognized arguments" and writes NO report -- which the operator would
+    # otherwise surface as an opaque "produced no report". Warn with the cause.
+    op, runner = _op(pytest_args=[flag], cache=False)
+    with caplog.at_level(logging.WARNING):
+        op.execute(_ctx())
+    text = caplog.text
+    print(f"[cache:warn {flag}] warned={flag in text}")
+    assert "cacheprovider" in text
+    assert flag in text
+
+
+def test_no_warning_when_cache_left_enabled(caplog):
+    op, runner = _op(pytest_args=["--lf"], cache=True)
+    with caplog.at_level(logging.WARNING):
+        op.execute(_ctx())
+    print(f"[cache:no-warn] log={caplog.text!r}")
+    assert "cacheprovider" not in caplog.text
+
+
+def test_no_warning_for_unrelated_flags(caplog):
+    op, runner = _op(pytest_args=["-q", "-x"], cache=False)
+    with caplog.at_level(logging.WARNING):
+        op.execute(_ctx())
+    print(f"[cache:no-warn-unrelated] log={caplog.text!r}")
+    assert "unregisters" not in caplog.text
+
+
+# -- validation -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [1, 0, "yes", None])
+def test_non_bool_cache_raises_type_error(bad):
+    # Matches the ``coverage`` convention: no truthy ints, so a stray cache=0
+    # cannot silently disable the provider.
+    with pytest.raises(TypeError, match="cache"):
+        PytestOperator(task_id="t", test_path="tests/", cache=bad)
+
+
+# -- helper units -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        ([], False),
+        (["-q"], False),
+        (["-p", "no:cacheprovider"], True),
+        (["-pno:cacheprovider"], True),
+        (["-p", "no:randomly"], False),
+        (["-p=no:cacheprovider"], False),  # invalid spelling -> not disabling
+        ([" -p", "no:cacheprovider"], False),  # argparse sees no option here
+        # pytest strips the plugin name, so every padded form really does
+        # disable the provider -- verified against pytest, which runs
+        # ``parg = parg.strip()`` before loading.
+        (["-p", " no:cacheprovider"], True),
+        (["-p", "no:cacheprovider "], True),
+        (["-pno:cacheprovider "], True),
+        (["-p no:cacheprovider"], True),  # single argv token, inner space
+        (["-p"], False),  # dangling, no lookahead crash
+        (["-q", "-p", "no:cacheprovider", "-x"], True),
+    ],
+)
+def test_disables_cacheprovider_unit(args, expected):
+    got = disables_cacheprovider(args)
+    print(f"[unit:disables] {args!r} -> {got}")
+    assert got is expected
+
+
+def test_cache_dependent_flags_unit():
+    got = cache_dependent_flags(["-q", "--lf", "--cache-clear"])
+    print(f"[unit:dependent] {got!r}")
+    assert got == ["--lf", "--cache-clear"]
+    assert cache_dependent_flags(["-q", "-x"]) == []
+
+
+def test_cache_dependent_flags_matches_equals_form():
+    # --lfnf takes a value, so the "=" spelling must be detected too.
+    got = cache_dependent_flags(["--lfnf=all"])
+    print(f"[unit:dependent-equals] {got!r}")
+    assert got == ["--lfnf"]

--- a/tests/operator/test_op_store_injection.py
+++ b/tests/operator/test_op_store_injection.py
@@ -1,0 +1,139 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""failed_only hardening: the stored set is untrusted input.
+
+Whoever can write the Airflow Variable controls strings that become pytest
+positional arguments. Since pytest parses a leading "-" as an option, an entry
+like "-p evil_module" would load an arbitrary plugin -- code execution on the
+worker. Option-like entries must never reach pytest. Shared fakes in
+_op_helpers."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _op_helpers import FakeParser, FakeRunner, FakeStore, _ctx, _key, _result
+
+from airflow_pytest_operator.models import RunArtifacts
+from airflow_pytest_operator.operators import PytestOperator
+
+
+def _op(stored, **kwargs):
+    """Operator in failed_only mode with ``stored`` already in the Variable."""
+    key = _key()
+    store = FakeStore({key: list(stored)})
+    runner = FakeRunner(RunArtifacts(exit_code=0, report_path="/x.xml"))
+    op = PytestOperator(
+        task_id="t",
+        test_path="tests/",
+        test_retry_strategy="failed_only",
+        store=store,
+        runner=runner,
+        parser=FakeParser(_result(passed=1)),
+        **kwargs,
+    )
+    return op, runner, store, key
+
+
+def _targets(runner):
+    return runner.calls[0]["test_path"]
+
+
+@pytest.mark.parametrize(
+    "poison",
+    [
+        "-p",
+        "-pevil_module",
+        "--rootdir=/tmp/pwn",
+        "-c",
+        "--import-mode=importlib",
+        "-x",
+    ],
+)
+def test_option_like_entry_never_reaches_pytest(poison):
+    op, runner, _store, _key_ = _op([poison])
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    targets = _targets(runner)
+    print(f"[inject:{poison}] targets={targets!r}")
+    assert poison not in targets
+
+
+def test_plugin_load_payload_is_neutralised():
+    # The concrete escalation: -p <module> makes pytest import arbitrary code.
+    # Both tokens must go -- the flag AND its orphaned value, neither of which
+    # is a node-id -- leaving nothing usable, so the full suite runs instead.
+    op, runner, _store, _key_ = _op(["-p", "evil_module"])
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    targets = _targets(runner)
+    print(f"[inject:plugin] targets={targets!r}")
+    assert targets == "tests/"
+
+
+def test_all_poisoned_falls_back_to_the_full_suite():
+    # Nothing usable left -> run everything, never a narrowed poisoned set.
+    op, runner, _store, _key_ = _op(["-p", "--rootdir=/tmp/pwn"])
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    targets = _targets(runner)
+    print(f"[inject:all-poison] targets={targets!r}")
+    assert targets == "tests/"
+
+
+def test_legit_node_ids_still_narrow_the_run():
+    # The guard must not break the actual feature.
+    op, runner, _store, _key_ = _op(["tests.test_x::test_a"])
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    targets = _targets(runner)
+    print(f"[inject:legit] targets={targets!r}")
+    assert targets == ["tests/test_x.py::test_a"]
+
+
+def test_mixed_set_keeps_only_the_legit_ids():
+    op, runner, _store, _key_ = _op(
+        ["tests.test_x::test_a", "-p", "evil_module", "tests.test_y::test_b"]
+    )
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    targets = _targets(runner)
+    print(f"[inject:mixed] targets={targets!r}")
+    assert targets == ["tests/test_x.py::test_a", "tests/test_y.py::test_b"]
+    assert not any(t.startswith("-") for t in targets)
+
+
+def test_tampered_variable_is_still_consumed():
+    # Consume-on-read must still happen, or the poison survives every retry.
+    op, runner, store, key = _op(["-p", "evil_module"])
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    print(f"[inject:consumed] deletes={store.deletes!r}")
+    assert key in store.deletes
+
+
+def test_tampering_is_logged(caplog):
+    op, runner, _store, _key_ = _op(["tests.test_x::test_a", "-p"])
+    with caplog.at_level(logging.WARNING):
+        op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    print(f"[inject:log] {caplog.text!r}")
+    assert "failed_only" in caplog.text
+    assert "node-id" in caplog.text
+
+
+def test_bare_value_without_separator_is_rejected():
+    # An orphaned option value ("evil_module") is not a node-id either: without
+    # "::" it would otherwise reach pytest as an arbitrary path target.
+    op, runner, _store, _key_ = _op(["evil_module", "/etc"])
+    op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
+    targets = _targets(runner)
+    print(f"[inject:bare-value] targets={targets!r}")
+    assert targets == "tests/"

--- a/tests/operator/test_op_store_injection.py
+++ b/tests/operator/test_op_store_injection.py
@@ -23,7 +23,7 @@ _op_helpers."""
 
 from __future__ import annotations
 
-import logging
+from unittest import mock
 
 import pytest
 from _op_helpers import FakeParser, FakeRunner, FakeStore, _ctx, _key, _result
@@ -120,13 +120,17 @@ def test_tampered_variable_is_still_consumed():
     assert key in store.deletes
 
 
-def test_tampering_is_logged(caplog):
+def test_tampering_is_logged():
+    # Captured at the source, not via caplog: Airflow operator loggers do not
+    # always propagate to root (Airflow 3.2 routes them through structlog), so
+    # caplog would be empty and the assertion would pass for the wrong reason.
     op, runner, _store, _key_ = _op(["tests.test_x::test_a", "-p"])
-    with caplog.at_level(logging.WARNING):
+    with mock.patch.object(op.log, "warning") as warn:
         op.execute(_ctx(dag_id="d", task_id="t", run_id="r"))
-    print(f"[inject:log] {caplog.text!r}")
-    assert "failed_only" in caplog.text
-    assert "node-id" in caplog.text
+    logged = " ".join(str(c) for c in warn.call_args_list)
+    print(f"[inject:log] {logged!r}")
+    assert "failed_only" in logged
+    assert "node-id" in logged
 
 
 def test_bare_value_without_separator_is_rejected():

--- a/tests/runner/test_run_target_injection.py
+++ b/tests/runner/test_run_target_injection.py
@@ -1,0 +1,118 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Runner-level guard: positional targets are never allowed to be pytest options.
+
+The runner is the last gate before the child process, so it refuses option-like
+targets whatever the caller did. These are end-to-end: a leaked "-p evil" would
+make the real pytest abort on the plugin import. Shared fakes in _run_helpers."""
+
+from __future__ import annotations
+
+import pytest
+from _run_helpers import _run, _suite
+
+from airflow_pytest_operator.exceptions import TestExecutionError
+from airflow_pytest_operator.reporters import JUnitResultParser
+from airflow_pytest_operator.runners import SubprocessPytestRunner
+
+
+def test_option_like_target_is_dropped_and_the_run_still_works(tmp_path):
+    # If "-p nonexistent_plugin" leaked through, pytest would die importing it.
+    suite = _suite(tmp_path, "def test_one(): assert True\n")
+    runner = SubprocessPytestRunner()
+    parser = JUnitResultParser()
+    artifacts = _run(
+        runner,
+        ["-pdefinitely_not_a_real_plugin_xyz", suite],
+        pytest_args=[],
+        report_request=parser.report_request,
+    )
+    result = parser.parse(artifacts.report_path, exit_code=artifacts.exit_code)
+    print(f"[target:dropped] exit={artifacts.exit_code} total={result.total}")
+    assert artifacts.exit_code == 0
+    assert result.total == 1
+
+
+def test_long_option_target_is_dropped(tmp_path):
+    suite = _suite(tmp_path, "def test_one(): assert True\n")
+    runner = SubprocessPytestRunner()
+    parser = JUnitResultParser()
+    artifacts = _run(
+        runner,
+        [suite, "--rootdir=/nonexistent/pwn"],
+        pytest_args=[],
+        report_request=parser.report_request,
+    )
+    result = parser.parse(artifacts.report_path, exit_code=artifacts.exit_code)
+    print(f"[target:long-opt] exit={artifacts.exit_code} total={result.total}")
+    assert artifacts.exit_code == 0
+    assert result.total == 1
+
+
+def test_only_option_like_targets_is_rejected():
+    # Nothing usable left -> fail closed rather than let pytest collect the cwd.
+    runner = SubprocessPytestRunner()
+    parser = JUnitResultParser()
+    with pytest.raises(TestExecutionError, match="test_path"):
+        _run(runner, ["-p", "--rootdir=/x"], report_request=parser.report_request)
+
+
+def test_orphaned_option_value_degrades_to_a_plain_path(tmp_path):
+    # Dropping "-p" leaves its value behind as a positional. The runner cannot
+    # tell an option's value from a target, so this is deliberate: the result is
+    # a nonexistent *path* (pytest exits 4), never a loaded plugin.
+    runner = SubprocessPytestRunner()
+    parser = JUnitResultParser()
+    artifacts = _run(
+        runner,
+        ["-p", "definitely_not_a_real_plugin_xyz"],
+        pytest_args=[],
+        report_request=parser.report_request,
+    )
+    print(
+        f"[target:orphan] exit={artifacts.exit_code} stderr={artifacts.stderr[:120]!r}"
+    )
+    assert artifacts.exit_code == 4
+    assert "Error importing plugin" not in artifacts.stderr
+
+
+def test_option_like_target_is_logged(tmp_path, caplog):
+    suite = _suite(tmp_path, "def test_one(): assert True\n")
+    runner = SubprocessPytestRunner()
+    parser = JUnitResultParser()
+    with caplog.at_level("WARNING"):
+        _run(
+            runner, [suite, "-x"], pytest_args=[], report_request=parser.report_request
+        )
+    print(f"[target:log] {caplog.text!r}")
+    assert "option" in caplog.text.lower()
+
+
+def test_leading_dash_only_matters_at_position_zero(tmp_path):
+    # A path that merely CONTAINS a dash is perfectly legitimate.
+    d = tmp_path / "my-tests"
+    d.mkdir()
+    f = d / "test_dash.py"
+    f.write_text("def test_one(): assert True\n")
+    runner = SubprocessPytestRunner()
+    parser = JUnitResultParser()
+    artifacts = _run(
+        runner, [str(f)], pytest_args=[], report_request=parser.report_request
+    )
+    result = parser.parse(artifacts.report_path, exit_code=artifacts.exit_code)
+    print(f"[target:dash-in-name] exit={artifacts.exit_code} total={result.total}")
+    assert artifacts.exit_code == 0
+    assert result.total == 1

--- a/tests/test_junit_parser_hardening.py
+++ b/tests/test_junit_parser_hardening.py
@@ -1,0 +1,110 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""XML hardening for the JUnit parser.
+
+defusedxml is optional (the [secure-xml] extra). Without it the stdlib parser is
+used, which is vulnerable to entity-expansion (billion laughs) -- so the
+downgrade must be visible in the log rather than silent."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from airflow_pytest_operator.exceptions import ReportParseError
+from airflow_pytest_operator.reporters import JUnitResultParser
+from airflow_pytest_operator.reporters import junit_parser as jp
+
+_OK_REPORT = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites><testsuite name="pytest" time="0.1">
+<testcase classname="tests.test_x" name="test_a" time="0.1"/>
+</testsuite></testsuites>
+"""
+
+# Classic billion-laughs: each entity references the previous one ten times.
+_BOMB_REPORT = """<?xml version="1.0"?>
+<!DOCTYPE testsuites [
+  <!ENTITY a "aaaaaaaaaa">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+  <!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">
+]>
+<testsuites><testsuite name="pytest" time="0.1">
+<testcase classname="tests.test_x" name="&d;" time="0.1"/>
+</testsuite></testsuites>
+"""
+
+
+def _report(tmp_path, text, name="junit.xml"):
+    p = tmp_path / name
+    p.write_text(text)
+    return str(p)
+
+
+def test_hardened_parser_is_used_when_defusedxml_is_installed():
+    print(f"[xml:hardened] _HARDENED_XML={jp._HARDENED_XML}")
+    assert jp._HARDENED_XML is True
+
+
+def test_entity_expansion_is_refused(tmp_path):
+    # The actual protection: a bomb must raise, not expand into memory.
+    path = _report(tmp_path, _BOMB_REPORT)
+    with pytest.raises(ReportParseError):
+        JUnitResultParser().parse(path)
+
+
+def test_no_warning_when_hardened(tmp_path, caplog):
+    path = _report(tmp_path, _OK_REPORT)
+    with caplog.at_level(logging.WARNING):
+        JUnitResultParser().parse(path)
+    print(f"[xml:no-warn] {caplog.text!r}")
+    assert "secure-xml" not in caplog.text
+
+
+def test_unhardened_fallback_warns(tmp_path, caplog, monkeypatch):
+    monkeypatch.setattr(jp, "_HARDENED_XML", False)
+    monkeypatch.setattr(jp, "_UNHARDENED_WARNED", False)
+    path = _report(tmp_path, _OK_REPORT)
+    with caplog.at_level(logging.WARNING):
+        result = JUnitResultParser().parse(path)
+    print(f"[xml:warn] {caplog.text!r}")
+    assert "secure-xml" in caplog.text
+    assert result.total == 1  # still parses; only the warning is new
+
+
+def test_unhardened_warning_is_emitted_once(tmp_path, caplog, monkeypatch):
+    # A per-parse warning would spam the task log on a sharded DAG.
+    monkeypatch.setattr(jp, "_HARDENED_XML", False)
+    monkeypatch.setattr(jp, "_UNHARDENED_WARNED", False)
+    path = _report(tmp_path, _OK_REPORT)
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            JUnitResultParser().parse(path)
+    hits = caplog.text.count("secure-xml")
+    print(f"[xml:warn-once] hits={hits}")
+    assert hits == 1
+
+
+def test_import_guard_is_narrow():
+    # A broken defusedxml must fail loudly, not silently downgrade security,
+    # so the guard catches ImportError only.
+    import inspect
+
+    src = inspect.getsource(jp)
+    print(f"[xml:guard] broad_except={'except Exception' in src}")
+    assert "except Exception" not in src
+    assert "except ImportError" in src

--- a/tests/test_junit_parser_hardening.py
+++ b/tests/test_junit_parser_hardening.py
@@ -49,6 +49,16 @@ _BOMB_REPORT = """<?xml version="1.0"?>
 """
 
 
+@pytest.fixture(autouse=True)
+def _reset_warn_cache():
+    # The warning is once-per-process by design, so every test here starts from
+    # a cleared cache and leaves one behind -- otherwise results depend on the
+    # order tests happen to run in.
+    jp._warn_if_unhardened.cache_clear()
+    yield
+    jp._warn_if_unhardened.cache_clear()
+
+
 def _report(tmp_path, text, name="junit.xml"):
     p = tmp_path / name
     p.write_text(text)
@@ -77,7 +87,6 @@ def test_no_warning_when_hardened(tmp_path, caplog):
 
 def test_unhardened_fallback_warns(tmp_path, caplog, monkeypatch):
     monkeypatch.setattr(jp, "_HARDENED_XML", False)
-    monkeypatch.setattr(jp, "_UNHARDENED_WARNED", False)
     path = _report(tmp_path, _OK_REPORT)
     with caplog.at_level(logging.WARNING):
         result = JUnitResultParser().parse(path)
@@ -89,7 +98,6 @@ def test_unhardened_fallback_warns(tmp_path, caplog, monkeypatch):
 def test_unhardened_warning_is_emitted_once(tmp_path, caplog, monkeypatch):
     # A per-parse warning would spam the task log on a sharded DAG.
     monkeypatch.setattr(jp, "_HARDENED_XML", False)
-    monkeypatch.setattr(jp, "_UNHARDENED_WARNED", False)
     path = _report(tmp_path, _OK_REPORT)
     with caplog.at_level(logging.WARNING):
         for _ in range(3):


### PR DESCRIPTION
### Added
- `PytestOperator(cache=...)` -- when ``False``, splices ``-p no:cacheprovider``
  so pytest never reads or writes ``.pytest_cache``. For ephemeral, read-only, or
  containerised runs and for shards sharing one rootdir. Applied to **every**
  invocation (first run, each ``rerun_failed`` round, ``dry_run``), unlike the
  first-run-only splices; defers to an explicit ``-p no:cacheprovider``. Defaults
  ``True`` -- pytest's behaviour, unchanged. See the README.
- A warning when ``cache=False`` meets a flag the cacheprovider owns (``--lf``,
  ``--ff``, ``--nf``, ``--sw``, ``--cache-clear``, ...): disabling the plugin
  also **unregisters** those options, so pytest would abort with "unrecognized
  arguments" and write no report.

### Security
- **`failed_only`: the stored set is now validated.** Anyone able to write the
  Airflow Variable could store ``["-p", "evil_module"]``; those strings became
  pytest *positional arguments*, and a leading ``-`` makes pytest read one as an
  option -- loading an arbitrary plugin, i.e. code execution on the worker.
  Entries are held to the shape the feature stores (must contain ``::``, must not
  start with ``-``); rejected ones are logged and the run falls back to the full
  suite.
- **Runner: option-like positional targets are refused.** Defence in depth at the
  last gate before the child process: any target with a leading ``-`` is dropped
  and logged, whatever the caller. If none remain, the run fails closed.
- **JUnit parser: no more silent XML-hardening downgrade.** The defusedxml import
  guard caught ``Exception`` (a broken install silently fell back to the
  unhardened stdlib parser) and never logged the fallback. It now catches
  ``ImportError`` only and warns once that entity-expansion protection is off,
  naming the ``[secure-xml]`` extra.