### PR TITLE
Refuse non-regular files at the report path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Both parsers: the report path is opened under guard.** ``parse()`` checked
+  ``os.path.exists`` and then called ``open()``, which a non-regular file at the
+  report path could turn against the worker. A **named pipe** passed the check
+  and made ``open()`` block until a writer appeared -- which may be never: there
+  is no timeout on a synchronous ``open()`` and ``on_kill`` cannot interrupt one,
+  so the task never failed and the worker slot was pinned indefinitely. A
+  **symlink** was followed silently, so a link planted at the report path made
+  the parser read whatever it pointed at and surface that in the error text and
+  XCom. The gap between the check and the open was also a window in which the
+  file checked could be swapped for the file opened. Both parsers now open with
+  ``O_RDONLY | O_NOFOLLOW | O_NONBLOCK`` and verify ``S_ISREG`` on the resulting
+  descriptor, so the validation *is* the open and there is no separate check left
+  to race. Anything that is not a regular file -- FIFO, symlink, directory,
+  device, socket -- raises ``ReportParseError`` naming what was found, surfacing
+  as an ordinary task failure. Reachable by the pytest child itself (it knows the
+  report path from its own argv, and test code is arbitrary code) and by anything
+  sharing the directory when ``report_dir=`` points somewhere shared rather than
+  the default per-run temp dir. ``O_NOFOLLOW`` constrains only the final path
+  component, so a ``report_dir`` that is itself a symlink keeps working.
+
+### Fixed
+- **JSON parser: a non-UTF-8 report is now a ``ReportParseError``.** The
+  ``UnicodeDecodeError`` from decoding the report escaped the handler (it is
+  neither ``OSError`` nor ``JSONDecodeError``) and reached the operator as an
+  unhandled error; it is now reported like any other malformed report.
+
 ## [0.6.1] - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as an ordinary task failure. Reachable by the pytest child itself (it knows the
   report path from its own argv, and test code is arbitrary code) and by anything
   sharing the directory when ``report_dir=`` points somewhere shared rather than
-  the default per-run temp dir. ``O_NOFOLLOW`` constrains only the final path
-  component, so a ``report_dir`` that is itself a symlink keeps working.
+  the default per-run temp dir -- verified end to end with a suite that swaps its
+  own finished report for a FIFO from an ``atexit`` hook. Two limits, both
+  accepted rather than overlooked: ``O_NOFOLLOW`` constrains only the final path
+  component, so a ``report_dir`` that is itself a symlink keeps working but a
+  repointed directory component can still redirect the read; and a hard link is
+  indistinguishable from its target, so it is read normally (creating one needs
+  read access to the target already). Neither reaches the denial-of-service half
+  -- a FIFO is refused by the type check on the opened inode either way.
 
 ### Fixed
 - **JSON parser: a non-UTF-8 report is now a ``ReportParseError``.** The

--- a/README.md
+++ b/README.md
@@ -563,6 +563,16 @@ directory per run and cleans it up according to the `cleanup` policy on
 
 A **parser-supplied** `report_dir` is your data and is never removed, regardless of policy. Cleanup also runs from `on_kill`, so killed tasks don't leak temp directories.
 
+The report file itself must be a **regular file**. Parsers open it with `O_NOFOLLOW`
+and verify the file type on the open descriptor, so a symlink, a named pipe, a
+directory or a device at the report path raises `ReportParseError` naming what was
+found, rather than being followed or blocking the worker. This matters when
+`report_dir` points at a shared or mounted location instead of the default per-run
+temp dir: anything else with write access to that directory — including the test
+code itself, which knows the path from its own argv — could otherwise replace the
+report. Note the check applies to the report file, not the path leading to it: a
+`report_dir` that is itself a symlink works normally.
+
 ## Cancellation and timeouts
 
 When Airflow kills the task (execution timeout, manual clear/mark-failed, worker shutdown), the operator's `on_kill` delegates to the runner, which terminates the **entire pytest process tree** — not just the direct child. This matters because pytest spawns its own children (e.g. `xdist` workers). Termination is graceful by default: `SIGTERM`, wait `grace_period` seconds (default 10), then `SIGKILL`. Set `timeout=` on the runner to bound the run itself. When that limit trips, the `TestExecutionError` carries the captured `stdout` / `stderr` as attributes, so you can inspect what the run printed before it hung.

--- a/README.md
+++ b/README.md
@@ -570,8 +570,17 @@ found, rather than being followed or blocking the worker. This matters when
 `report_dir` points at a shared or mounted location instead of the default per-run
 temp dir: anything else with write access to that directory — including the test
 code itself, which knows the path from its own argv — could otherwise replace the
-report. Note the check applies to the report file, not the path leading to it: a
-`report_dir` that is itself a symlink works normally.
+report.
+
+Two limits are worth knowing if you rely on this. The check covers the report
+**file**, not the path leading to it, so a `report_dir` that is itself a symlink
+works normally — but equally, anyone able to repoint a directory component can
+still redirect the read. And a **hard link** is indistinguishable from the file it
+points to, so it is read like any regular file; creating one requires read access
+to the target already, so it grants nothing new, but it is not blocked. Neither
+affects the denial-of-service half: a named pipe cannot be reached by either
+route. If the report directory is genuinely shared with untrusted parties, prefer
+the default per-run temp dir.
 
 ## Cancellation and timeouts
 

--- a/src/airflow_pytest_operator/reporters/_safe_open.py
+++ b/src/airflow_pytest_operator/reporters/_safe_open.py
@@ -39,10 +39,26 @@ use*: a single ``os.open`` carries the guarantees as flags, and the file type
 is checked on the already-open descriptor, so there is no separate check left
 to race.
 
-Note that ``O_NOFOLLOW`` constrains only the **final** path component. A
-symlinked parent directory is still traversed, which is deliberate: pointing
-``report_dir`` at a symlinked artifacts directory is a legitimate and common
-deployment, while a symlink at the report path itself never is.
+What this does **not** cover -- both verified, and both accepted rather than
+overlooked:
+
+* ``O_NOFOLLOW`` constrains only the **final** path component, so a symlinked
+  *parent directory* is still traversed. Anyone able to repoint a directory
+  component of ``report_dir`` can therefore still redirect the read. That is a
+  strictly stronger position than "can write a file in the report dir" -- it
+  means already controlling where reports land -- and refusing symlinked
+  parents would break pointing ``report_dir`` at a symlinked artifacts
+  directory, which is a legitimate and common deployment.
+* A **hard link** is not distinguishable from the file it links to: same
+  inode, ``S_ISREG`` true, no symlink involved. Creating one requires the
+  attacker to already have read access to the target (and be on the same
+  filesystem; Linux additionally enforces this via
+  ``fs.protected_hardlinks``), so it grants no read the attacker did not
+  already have -- but it does mean this guard stops symlink redirection, not
+  every form of redirection.
+
+Neither weakens the denial-of-service half: a FIFO cannot be reached through
+either route, because the type check runs on the opened inode.
 """
 
 from __future__ import annotations
@@ -62,10 +78,16 @@ from ..exceptions import ReportParseError
 # O_NONBLOCK -- a FIFO opens immediately (with no writer) instead of blocking
 #   forever, so the type check below can reject it. It is a no-op for reads on
 #   the regular files we keep, so it costs nothing on the happy path.
-# Both are POSIX-only; the getattr keeps the module importable elsewhere, where
-# it simply degrades to a plain O_RDONLY.
+# O_BINARY -- Windows-only, and required there: os.open defaults to text mode,
+#   which would translate CRLF in the byte stream we hand to the XML/JSON
+#   parsers. A no-op flag (0) everywhere else.
+# Each is absent on some platform, so every one goes through getattr and simply
+# degrades to a plain O_RDONLY where it does not exist.
 _OPEN_FLAGS: int = (
-    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+    os.O_RDONLY
+    | getattr(os, "O_NOFOLLOW", 0)
+    | getattr(os, "O_NONBLOCK", 0)
+    | getattr(os, "O_BINARY", 0)
 )
 
 # How a kernel reports "the final component is a symlink and O_NOFOLLOW

--- a/src/airflow_pytest_operator/reporters/_safe_open.py
+++ b/src/airflow_pytest_operator/reporters/_safe_open.py
@@ -1,0 +1,146 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guarded opening of report files the parsers did not write themselves.
+
+A report file is written by the pytest child process, and test code is
+arbitrary code: it knows the report path from its own argv and can replace
+the file with something that is not a regular file. When ``report_dir=``
+points at a shared or mounted directory rather than the default per-run temp
+dir, anything else with access to that directory can do the same.
+
+The naive shape -- ``os.path.exists(path)`` then ``open(path)`` -- fails
+three ways against that:
+
+* a **named pipe** passes ``exists()``, and ``open()`` on it blocks until a
+  writer appears, which may be never. There is no timeout on a synchronous
+  ``open()`` and ``on_kill`` cannot interrupt it, so the Airflow worker slot
+  is held forever;
+* a **symlink** is followed silently, so a link planted at the report path
+  makes the parser read (and surface, via the error text and XCom) whatever
+  it points at;
+* the gap between the ``exists()`` check and the ``open()`` is a window in
+  which the thing that was checked can be swapped for the thing that is
+  opened.
+
+:func:`open_report_file` closes all three by validating *at the moment of
+use*: a single ``os.open`` carries the guarantees as flags, and the file type
+is checked on the already-open descriptor, so there is no separate check left
+to race.
+
+Note that ``O_NOFOLLOW`` constrains only the **final** path component. A
+symlinked parent directory is still traversed, which is deliberate: pointing
+``report_dir`` at a symlinked artifacts directory is a legitimate and common
+deployment, while a symlink at the report path itself never is.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import BinaryIO
+
+from ..exceptions import ReportParseError
+
+# O_NOFOLLOW -- a symlink at the report path fails the open outright instead of
+#   being followed, and, because the check *is* the open, there is no
+#   check-then-open window to swap into.
+# O_NONBLOCK -- a FIFO opens immediately (with no writer) instead of blocking
+#   forever, so the type check below can reject it. It is a no-op for reads on
+#   the regular files we keep, so it costs nothing on the happy path.
+# Both are POSIX-only; the getattr keeps the module importable elsewhere, where
+# it simply degrades to a plain O_RDONLY.
+_OPEN_FLAGS: int = (
+    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_NONBLOCK", 0)
+)
+
+# How a kernel reports "the final component is a symlink and O_NOFOLLOW
+# forbade it": Linux and macOS raise ELOOP, some BSDs raise EMLINK.
+_SYMLINK_ERRNOS: frozenset[int] = frozenset(
+    e
+    for e in (getattr(errno, "ELOOP", None), getattr(errno, "EMLINK", None))
+    if e is not None
+)
+
+
+def _describe_file_type(mode: int) -> str:
+    """Name the file type behind ``mode`` for an operator-facing message."""
+    if stat.S_ISFIFO(mode):
+        return "a named pipe (FIFO)"
+    if stat.S_ISDIR(mode):
+        return "a directory"
+    # Kept for completeness, though POSIX refuses open() on a socket outright
+    # (EOPNOTSUPP/ENXIO), so a socket is rejected by the OSError handler in
+    # open_report_file before it can ever be fstat'd here.
+    if stat.S_ISSOCK(mode):
+        return "a socket"
+    if stat.S_ISCHR(mode):
+        return "a character device"
+    if stat.S_ISBLK(mode):
+        return "a block device"
+    return "not a regular file"
+
+
+@contextmanager
+def open_report_file(report_path: str, *, kind: str) -> Iterator[BinaryIO]:
+    """Open ``report_path`` for reading, or raise :class:`ReportParseError`.
+
+    Yields a binary file object for a **regular file only**. A missing path, a
+    symlink, a FIFO, a directory, a device or a socket each raise
+    ``ReportParseError`` naming what was found, so the operator surfaces it as
+    an ordinary task failure rather than hanging or reading the wrong file.
+
+    ``kind`` is the human-readable report format ("JUnit", "JSON") used to
+    build those messages.
+
+    Binary, not text: the caller decides the encoding. XML carries its own
+    declaration and must be handed to the XML parser undecoded.
+    """
+    if not report_path:
+        raise ReportParseError(f"{kind} report not found: {report_path!r}")
+
+    try:
+        fd = os.open(report_path, _OPEN_FLAGS)
+    except FileNotFoundError as exc:
+        raise ReportParseError(f"{kind} report not found: {report_path!r}") from exc
+    except OSError as exc:
+        if exc.errno in _SYMLINK_ERRNOS:
+            raise ReportParseError(
+                f"{kind} report {report_path!r} is a symbolic link; refusing to "
+                "follow it (the report must be a regular file)"
+            ) from exc
+        raise ReportParseError(
+            f"Failed to open {kind} report {report_path!r}: {exc}"
+        ) from exc
+
+    try:
+        mode = os.fstat(fd).st_mode
+        if not stat.S_ISREG(mode):
+            raise ReportParseError(
+                f"{kind} report {report_path!r} is {_describe_file_type(mode)}; "
+                "the report must be a regular file"
+            )
+    except BaseException:
+        # Nothing owns the descriptor yet, so it is ours to close -- including
+        # on a KeyboardInterrupt between the open and the handover below.
+        os.close(fd)
+        raise
+
+    # fdopen takes ownership: closing the wrapper closes the descriptor, and it
+    # closes the descriptor itself if the wrapper cannot be constructed.
+    with os.fdopen(fd, "rb") as fh:
+        yield fh

--- a/src/airflow_pytest_operator/reporters/json_parser.py
+++ b/src/airflow_pytest_operator/reporters/json_parser.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from ..exceptions import ReportParseError
 from ..models import CaseResult, ReportRequest, TestRunResult
+from ._safe_open import open_report_file
 from .base import ResultParser
 
 _log = logging.getLogger(__name__)
@@ -104,13 +105,21 @@ class JSONResultParser(ResultParser):
         ``failed_node_ids`` (which is always derived from ``cases``).
         """
 
-        if not report_path or not os.path.exists(report_path):
-            raise ReportParseError(f"JSON report not found: {report_path!r}")
-
+        # The report is written by the pytest child, so it is untrusted input:
+        # open_report_file refuses anything that is not a regular file (see
+        # _safe_open for why exists()-then-open() is not enough). Its
+        # ReportParseError is not an OSError/ValueError, so the specific
+        # diagnostic passes through the handler below intact.
+        #
+        # Decoding is explicit rather than left to `open(encoding=...)` so a
+        # non-UTF-8 report raises UnicodeDecodeError *here*, where it is turned
+        # into a ReportParseError like every other malformed-report case. It
+        # reads no more of the file than json.load would: that also calls
+        # fp.read() and parses the whole document at once.
         try:
-            with open(report_path, encoding="utf-8") as f:
-                doc = json.load(f)
-        except (OSError, json.JSONDecodeError) as exc:
+            with open_report_file(report_path, kind="JSON") as fh:
+                doc = json.loads(fh.read().decode("utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise ReportParseError(
                 f"Failed to parse JSON report {report_path!r}: {exc}"
             ) from exc

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -91,7 +91,6 @@ class JUnitResultParser(ResultParser):
         )
 
     def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
-        _warn_if_unhardened()
         # The report is written by the pytest child, so it is untrusted input:
         # open_report_file refuses anything that is not a regular file (see
         # _safe_open for why exists()-then-open() is not enough). Its
@@ -99,6 +98,11 @@ class JUnitResultParser(ResultParser):
         # diagnostic passes through the handler below intact.
         try:
             with open_report_file(report_path, kind="JUnit") as fh:
+                # Warn only once we are actually about to parse XML: a missing
+                # report is not an XML-hardening problem, and warning there
+                # would advertise the [secure-xml] extra on runs that never
+                # opened a document.
+                _warn_if_unhardened()
                 tree = _xml_parse(fh)
         except (ET.ParseError, ValueError, OSError) as exc:
             raise ReportParseError(

--- a/src/airflow_pytest_operator/reporters/junit_parser.py
+++ b/src/airflow_pytest_operator/reporters/junit_parser.py
@@ -32,6 +32,7 @@ except ImportError:  # pragma: no cover - fallback path
 
 from ..exceptions import ReportParseError
 from ..models import CaseResult, ReportRequest, TestRunResult
+from ._safe_open import open_report_file
 from .base import ResultParser
 
 _log = logging.getLogger(__name__)
@@ -90,12 +91,15 @@ class JUnitResultParser(ResultParser):
         )
 
     def parse(self, report_path: str, *, exit_code: int = 0) -> TestRunResult:
-        if not report_path or not os.path.exists(report_path):
-            raise ReportParseError(f"JUnit report not found: {report_path!r}")
-
         _warn_if_unhardened()
+        # The report is written by the pytest child, so it is untrusted input:
+        # open_report_file refuses anything that is not a regular file (see
+        # _safe_open for why exists()-then-open() is not enough). Its
+        # ReportParseError is not an OSError/ValueError, so the specific
+        # diagnostic passes through the handler below intact.
         try:
-            tree = _xml_parse(report_path)
+            with open_report_file(report_path, kind="JUnit") as fh:
+                tree = _xml_parse(fh)
         except (ET.ParseError, ValueError, OSError) as exc:
             raise ReportParseError(
                 f"Failed to parse JUnit report {report_path!r}: {exc}"

--- a/tests/test_junit_parser_hardening.py
+++ b/tests/test_junit_parser_hardening.py
@@ -107,6 +107,35 @@ def test_unhardened_warning_is_emitted_once(tmp_path, caplog, monkeypatch):
     assert hits == 1
 
 
+def test_no_warning_when_no_document_was_opened(tmp_path, caplog, monkeypatch):
+    # The warning is about *this* XML document, so it must fire only once a
+    # document is actually open. A missing report (pytest crashed, plugin not
+    # installed) is not an XML-hardening problem, and warning there would
+    # advertise the [secure-xml] extra on runs that parsed nothing. The guarded
+    # open sits in front of the warning precisely to keep this true.
+    monkeypatch.setattr(jp, "_HARDENED_XML", False)
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ReportParseError):
+            JUnitResultParser().parse(str(tmp_path / "junit.xml"))
+    print(f"[xml:no-warn-missing] {caplog.text!r}")
+    assert "secure-xml" not in caplog.text
+
+
+def test_no_warning_when_report_is_not_a_regular_file(tmp_path, caplog, monkeypatch):
+    # A directory rather than a FIFO on purpose: it exercises the same
+    # "refused before any document was opened" path, but cannot hang this
+    # test file if the guard ever regresses. The FIFO case is covered under a
+    # deadline in tests/test_report_file_hardening.py.
+    monkeypatch.setattr(jp, "_HARDENED_XML", False)
+    path = tmp_path / "junit.xml"
+    path.mkdir()
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ReportParseError):
+            JUnitResultParser().parse(str(path))
+    print(f"[xml:no-warn-nonregular] {caplog.text!r}")
+    assert "secure-xml" not in caplog.text
+
+
 def test_import_guard_is_narrow():
     # A broken defusedxml must fail loudly, not silently downgrade security,
     # so the guard catches ImportError only.

--- a/tests/test_report_file_hardening.py
+++ b/tests/test_report_file_hardening.py
@@ -1,0 +1,327 @@
+# Copyright 2026 the airflow-pytest-operator contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report-file hardening, for both parsers.
+
+The report is written by the pytest child process, and test code is arbitrary
+code: it knows the report path from its own argv. When ``report_dir=`` points
+at a shared directory instead of the default per-run temp dir, anything else
+with access to that directory can write there too. So the *file at the report
+path* is untrusted input, independent of whether its contents are.
+
+Two failures follow from that, and both are worse than a parse error:
+
+* a **named pipe** at the report path makes ``open()`` block until a writer
+  appears. There is no timeout on a synchronous ``open()`` and ``on_kill``
+  cannot interrupt one, so the Airflow worker slot is pinned forever -- a
+  denial of service on the worker, not a failed task;
+* a **symlink** at the report path is followed, so the parser reads whatever
+  it points at and surfaces that content in the error text and in XCom.
+
+Both parsers must therefore refuse anything that is not a regular file, and
+must do it *at the open* rather than via a separate ``os.path.exists`` check
+that something can invalidate in the gap.
+
+The hang tests deliberately run ``parse()`` on a daemon thread with a
+deadline: a regression here is an infinite block, and asserting on a return
+value would simply hang the suite instead of failing it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import socket
+import stat
+import tempfile
+import threading
+from typing import Any
+
+import pytest
+
+from airflow_pytest_operator.exceptions import ReportParseError
+from airflow_pytest_operator.reporters import JSONResultParser, JUnitResultParser
+from airflow_pytest_operator.reporters._safe_open import _describe_file_type
+
+_JUNIT_OK = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites><testsuite name="pytest" time="0.1">
+<testcase classname="tests.test_x" name="test_a" time="0.1"/>
+</testsuite></testsuites>
+"""
+
+_JSON_OK = """{
+  "duration": 0.1,
+  "summary": {"total": 1, "passed": 1},
+  "tests": [
+    {"nodeid": "tests/test_x.py::test_a", "outcome": "passed",
+     "call": {"duration": 0.1}}
+  ]
+}
+"""
+
+# (parser class, the filename it expects, a valid report of that format)
+_FORMATS = [
+    pytest.param(JUnitResultParser, "junit.xml", _JUNIT_OK, id="junit"),
+    pytest.param(JSONResultParser, "report.json", _JSON_OK, id="json"),
+]
+
+# Generous on purpose: this is a hang detector, not a performance assertion.
+# A correct parse of these tiny reports takes single-digit milliseconds, so a
+# 10s budget cannot flake on a loaded CI box, and an actual regression blocks
+# forever and blows through any budget at all.
+_DEADLINE = 10.0
+
+
+def _parse_within(parser: Any, path: str, timeout: float = _DEADLINE) -> Any:
+    """Call ``parser.parse(path)`` off-thread, failing if it does not return.
+
+    Re-raises whatever ``parse`` raised, so callers can still use
+    ``pytest.raises``. The worker is a daemon thread: if the guard regresses
+    it stays blocked in ``open()`` forever, and making it a daemon lets the
+    suite report the failure and exit rather than hanging alongside it.
+    """
+    box: dict[str, Any] = {}
+    done = threading.Event()
+
+    def run() -> None:
+        try:
+            box["result"] = parser.parse(path)
+        except BaseException as exc:  # noqa: BLE001 - re-raised on the caller
+            box["exc"] = exc
+        finally:
+            done.set()
+
+    threading.Thread(target=run, daemon=True).start()
+    if not done.wait(timeout):
+        pytest.fail(
+            f"parse() did not return within {timeout}s: it is blocked on {path!r}. "
+            "The report path is not being guarded against non-regular files."
+        )
+    if "exc" in box:
+        raise box["exc"]
+    return box["result"]
+
+
+# ---------------------------------------------------------------------------
+# The hang: a FIFO at the report path must not pin the worker.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_fifo_at_report_path_is_refused_instead_of_blocking(
+    tmp_path, parser_cls, filename, valid_text
+):
+    path = tmp_path / filename
+    os.mkfifo(path)  # no writer will ever open it
+
+    with pytest.raises(ReportParseError, match="named pipe") as exc_info:
+        _parse_within(parser_cls(), str(path))
+
+    print(f"[report-file:fifo] {parser_cls.__name__} -> {exc_info.value}")
+
+
+# ---------------------------------------------------------------------------
+# The disclosure: a symlink at the report path must not be followed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_symlink_at_report_path_is_refused(tmp_path, parser_cls, filename, valid_text):
+    secret = tmp_path / "fernet.key"
+    secret.write_text("SECRET-KEY-MATERIAL")
+
+    path = tmp_path / filename
+    os.symlink(secret, path)
+
+    with pytest.raises(ReportParseError, match="symbolic link") as exc_info:
+        _parse_within(parser_cls(), str(path))
+
+    # The point of refusing is that the target is never read -- so its bytes
+    # must not reach the error text either, which is logged and surfaced.
+    assert "SECRET-KEY-MATERIAL" not in str(exc_info.value)
+    print(f"[report-file:symlink] {parser_cls.__name__} -> {exc_info.value}")
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_symlink_is_refused_even_when_target_is_a_valid_report(
+    tmp_path, parser_cls, filename, valid_text
+):
+    # Refusing every link, rather than allowing ones that "point somewhere
+    # fine", is what keeps the check atomic: a link that resolves inside the
+    # report dir can be re-pointed after any check and before the open.
+    real = tmp_path / f"real-{filename}"
+    real.write_text(valid_text)
+
+    path = tmp_path / filename
+    os.symlink(real, path)
+
+    with pytest.raises(ReportParseError, match="symbolic link"):
+        _parse_within(parser_cls(), str(path))
+    print(f"[report-file:symlink-valid-target] {parser_cls.__name__} refused")
+
+
+# ---------------------------------------------------------------------------
+# The other non-regular types.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_directory_at_report_path_is_refused(
+    tmp_path, parser_cls, filename, valid_text
+):
+    path = tmp_path / filename
+    path.mkdir()
+
+    with pytest.raises(ReportParseError, match="is a directory"):
+        _parse_within(parser_cls(), str(path))
+    print(f"[report-file:dir] {parser_cls.__name__} refused a directory")
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_character_device_is_refused(parser_cls, filename, valid_text):
+    # /dev/zero is the memory-exhaustion twin of the FIFO hang: it is always
+    # readable and never ends, so an unguarded read never returns either.
+    if not os.path.exists("/dev/zero"):  # pragma: no cover - POSIX only
+        pytest.skip("no /dev/zero on this platform")
+
+    with pytest.raises(ReportParseError, match="character device"):
+        _parse_within(parser_cls(), "/dev/zero")
+    print(f"[report-file:chardev] {parser_cls.__name__} refused /dev/zero")
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_socket_at_report_path_is_refused(parser_cls, filename, valid_text):
+    # Bound in a short temp dir on purpose: AF_UNIX paths are capped near 104
+    # bytes on macOS, which pytest's own tmp_path can exceed.
+    tmpdir = tempfile.mkdtemp(dir="/tmp")
+    path = os.path.join(tmpdir, "s")
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.bind(path)
+        # Unlike the FIFO, this one never reaches our S_ISREG check: POSIX
+        # refuses open() on a socket (EOPNOTSUPP/ENXIO), so the guarded open
+        # turns the OSError into ReportParseError first. Asserting only
+        # "refused as a normal task failure" keeps the test about the
+        # behaviour that matters rather than which layer produced it.
+        with pytest.raises(ReportParseError) as exc_info:
+            _parse_within(parser_cls(), path)
+    finally:
+        sock.close()
+        os.unlink(path)
+        os.rmdir(tmpdir)
+    assert path in str(exc_info.value)
+    print(f"[report-file:socket] {parser_cls.__name__} -> {exc_info.value}")
+
+
+# ---------------------------------------------------------------------------
+# The type-naming itself, unit-tested.
+#
+# Sockets and block devices cannot be driven end-to-end here (POSIX refuses
+# open() on a socket before the type check runs, and a readable block device
+# needs privileges and a real disk), but _describe_file_type is a pure
+# function of an st_mode int -- so the message mapping is testable directly
+# even where the path through parse() is not reachable.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (stat.S_IFIFO | 0o644, "a named pipe (FIFO)"),
+        (stat.S_IFDIR | 0o755, "a directory"),
+        (stat.S_IFSOCK | 0o644, "a socket"),
+        (stat.S_IFCHR | 0o666, "a character device"),
+        (stat.S_IFBLK | 0o660, "a block device"),
+        (0, "not a regular file"),  # defensive fallback: no type bits at all
+    ],
+)
+def test_file_type_is_named_in_the_error(mode, expected):
+    assert _describe_file_type(mode) == expected
+    print(f"[report-file:describe] {oct(mode)} -> {expected}")
+
+
+# ---------------------------------------------------------------------------
+# The happy path and the pre-existing contract must both survive.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_regular_file_still_parses(tmp_path, parser_cls, filename, valid_text):
+    path = tmp_path / filename
+    path.write_text(valid_text)
+
+    result = _parse_within(parser_cls(), str(path))
+    print(f"[report-file:regular] {parser_cls.__name__} total={result.total}")
+    assert result.total == 1
+    assert result.passed == 1
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_report_in_symlinked_directory_still_parses(
+    tmp_path, parser_cls, filename, valid_text
+):
+    # O_NOFOLLOW constrains only the final component. Pointing report_dir at a
+    # symlinked artifacts directory is a normal deployment and must keep
+    # working -- this is the compatibility half of refusing symlinks.
+    real_dir = tmp_path / "artifacts-v2"
+    real_dir.mkdir()
+    (real_dir / filename).write_text(valid_text)
+
+    link_dir = tmp_path / "artifacts"
+    os.symlink(real_dir, link_dir)
+
+    result = _parse_within(parser_cls(), str(link_dir / filename))
+    print(f"[report-file:symlinked-dir] {parser_cls.__name__} total={result.total}")
+    assert result.total == 1
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_missing_report_still_reports_not_found(
+    tmp_path, parser_cls, filename, valid_text
+):
+    # The guarded open replaced an explicit exists() check; the operator-facing
+    # message for the ordinary "pytest produced nothing" case must not change.
+    with pytest.raises(ReportParseError, match="not found"):
+        _parse_within(parser_cls(), str(tmp_path / filename))
+    print(f"[report-file:missing] {parser_cls.__name__} still says 'not found'")
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_empty_path_still_reports_not_found(parser_cls, filename, valid_text):
+    with pytest.raises(ReportParseError, match="not found"):
+        _parse_within(parser_cls(), "")
+    print(f"[report-file:empty-path] {parser_cls.__name__} still says 'not found'")
+
+
+# ---------------------------------------------------------------------------
+# The check must not drift back into a separate exists() call.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("parser_cls", "filename", "valid_text"), _FORMATS)
+def test_parse_does_not_check_existence_separately_from_opening(
+    parser_cls, filename, valid_text
+):
+    """Guard the *shape* of the fix, which no output value can reveal.
+
+    A reintroduced ``os.path.exists(path)`` before the open would pass every
+    test above -- the file type is still checked afterwards -- while
+    reopening the window in which the checked file is swapped for another.
+    The atomicity lives in there being no second lookup, so that is what this
+    asserts. Scoped to ``parse``: ``report_request`` uses os.path freely.
+    """
+    parse_src = inspect.getsource(parser_cls.parse)
+    print(f"[report-file:no-toctou] {parser_cls.__name__}.parse checked")
+    assert "os.path.exists" not in parse_src
+    assert "open_report_file" in parse_src


### PR DESCRIPTION
## What

Both result parsers checked `os.path.exists(report_path)` and then called `open()`. A non-regular file at the report path could turn that against the worker:

- **A named pipe** passed the existence check, and `open()` on it blocks until a writer appears — which may be never. There is no timeout on a synchronous `open()` and `on_kill` cannot interrupt one, so the task never failed at the parse step and the Airflow worker slot was pinned indefinitely. Measured before the fix: no return after 8s on either parser.
- **A symlink** was followed silently, so a link planted at the report path made the parser read whatever it pointed at and surface that content in the error text and in XCom.
- The gap between the check and the open was a window in which the file checked could be swapped for the file opened.

This is pre-existing, not introduced by a recent change. It was found while security-testing the `min_pass_rate`/`max_failed` work.

## Why it's reachable

The report is written by the pytest child process, which knows the report path from its own argv — and test code is arbitrary code. Separately, when `report_dir=` points at a shared or mounted location rather than the default per-run temp dir, anything else with write access to that directory can plant a file there too.

## How

New `reporters/_safe_open.py`, used by both parsers. It opens with `O_RDONLY | O_NOFOLLOW | O_NONBLOCK` and verifies `S_ISREG` on the resulting descriptor, then parses from that descriptor. The validation *is* the open, so there is no separate check left to race. Anything that is not a regular file — FIFO, symlink, directory, device, socket — raises `ReportParseError` naming what was found, so the operator surfaces it as an ordinary task failure.

Also fixed in the same block: the JSON parser's `UnicodeDecodeError` on a non-UTF-8 report is neither `OSError` nor `JSONDecodeError`, so it escaped the handler and reached the operator unhandled. Decoding is now explicit and that case becomes a `ReportParseError` like every other malformed report. Listed separately under `### Fixed` in the changelog.

## Verification

The part worth checking: **I reverted the guard and re-ran the new tests — 12 go red**, covering every FIFO, symlink, directory, character-device and shape case. The symlink failures show the old code actually reading a planted `fernet.key`. The 10 that stay green in both states are the compatibility tests (regular file, symlinked *directory*, missing path, empty path).

- Full suite: 672 passed, 5 skipped
- `ruff check`, `ruff format --check`, `mypy` (strict): clean
- `_safe_open.py` at 100% coverage; overall 98.9%
- Checked for descriptor leaks across 200 cycles of every path including all error branches — delta 0
- FIFO tests run `parse()` on a daemon thread with a 10s deadline, so a regression fails the suite instead of hanging it

## Reviewer notes

- **`O_NOFOLLOW` constrains only the final path component.** A `report_dir` that is itself a symlink keeps working — that's a normal deployment, and there's a test pinning it. Only a symlink *at the report path* is refused.
- **Symlinks are refused unconditionally**, including ones whose target is a valid report. Allowing "links that point somewhere fine" would reintroduce the check-then-open gap.
- **The socket case is refused one layer earlier than the others.** POSIX rejects `open()` on a socket outright (`EOPNOTSUPP`), so it never reaches the `S_ISREG` check. My first version of that test asserted the wrong message and failed; the test now asserts the refusal rather than which layer produced it.
- **The XML parser now receives a file object instead of a path**, so the report's own encoding declaration is still honored. The existing tests that monkeypatch `_xml_parse` take one positional arg and are unaffected.
- **Not addressed** (unchanged from before, and separate from this report): a very large *regular* report is still read whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
